### PR TITLE
ATB Uploader improvements

### DIFF
--- a/src/cdm_data_loaders/pipelines/all_the_bacteria.py
+++ b/src/cdm_data_loaders/pipelines/all_the_bacteria.py
@@ -17,6 +17,7 @@ from typing import Any
 
 import dlt
 from dlt.extract.items import DataItemWithMeta
+from dlt.sources.helpers import requests
 from dlt.sources.helpers.rest_client.client import RESTClient
 from frozendict import frozendict
 from pydantic import AliasChoices, Field, computed_field
@@ -28,6 +29,7 @@ from cdm_data_loaders.pipelines.core import (
 )
 from cdm_data_loaders.pipelines.cts_defaults import DEFAULT_SETTINGS_CONFIG_DICT, CtsSettings
 from cdm_data_loaders.utils.download.sync_client import FileDownloader
+from cdm_data_loaders.utils.s3 import stream_to_s3
 
 logger = logging.getLogger("dlt")
 
@@ -77,7 +79,9 @@ class AtbSettings(CtsSettings):
 
         Set to the output directory / "raw_data" / version.
         """
-        return str(Path(self.output) / "raw_data" / self.version)
+        if self.use_destination == "local_fs":
+            return str(Path(self.output) / "raw_data" / self.version)
+        return f"{self.output}/raw_data/{self.version}"
 
     @computed_field
     @property
@@ -127,10 +131,6 @@ def download_atb_index_tsv(settings: AtbSettings) -> Path:
     :return: path to the downloaded file
     :rtype: Path
     """
-    # make sure that the directory structure to save the file in can be written to
-    raw_data_dir = Path(settings.raw_data_dir)
-    raw_data_dir.mkdir(parents=True, exist_ok=True)
-
     # get the all_atb_files.tsv file info from the OSF API and retrieve the download link
     osf_client = RESTClient(
         base_url="https://api.osf.io/v2/",
@@ -148,9 +148,25 @@ def download_atb_index_tsv(settings: AtbSettings) -> Path:
         err_msg = f"Could not find download URL in response from 'https://api.osf.io/v2/files/{ALL_FILES_TSV_FILE_ID}/'"
         raise RuntimeError(err_msg)
 
-    atb_files_tsv = raw_data_dir / "all_atb_files.tsv"
+    if settings.use_destination == "s3":
+        # download to a local temp file and also copy the file to s3
+        save_path = f"{settings.raw_data_dir}/{ALL_ATB_FILE_NAME}"
+        try:
+            stream_to_s3(url=all_files_tsv_download, s3_path=save_path, requests=requests)
+        except Exception:
+            logger.exception("Could not transfer %s to s3", ALL_ATB_FILE_NAME)
+            raise
+        # TODO: save as a temporary file, delete after pipeline has completed
+        # save a local copy of the file to current dir
+        atb_files_tsv = Path(ALL_ATB_FILE_NAME)
+    else:
+        # make sure that the directory structure to save the file in can be written to
+        raw_data_dir = Path(settings.raw_data_dir)
+        raw_data_dir.mkdir(parents=True, exist_ok=True)
+        atb_files_tsv = raw_data_dir / ALL_ATB_FILE_NAME
+
     # download the file listing and save it
-    FileDownloader().download(all_files_tsv_download, atb_files_tsv)
+    FileDownloader().download(url=all_files_tsv_download, destination=atb_files_tsv)
     return atb_files_tsv
 
 
@@ -193,17 +209,23 @@ def osf_file_downloader(settings: AtbSettings, atb_file_list: list[dict[str, Any
 
     :param settings: pipeline config
     :type settings: Settings
-    :param atb_file_list: list of dictionaries
+    :param atb_file_list: info about files to transfer, as a list of dictionaries
     :type atb_file_list: list[dict[str, Any]]
     """
     client = FileDownloader()
-    raw_data_dir = Path(settings.raw_data_dir)
     successful_downloads = []
     for f in atb_file_list:
         try:
-            project_part = f["project"].removeprefix("AllTheBacteria").removeprefix("/")
-            save_path = raw_data_dir / project_part / f["filename"]
-            client.download(url=f["url"], destination=save_path, expected_checksum=f["md5"], checksum_fn="md5")
+            project_part = f["project"].removeprefix("AllTheBacteria").removeprefix("/").rstrip("/")
+            if settings.use_destination == "s3":
+                if project_part:
+                    project_part = f"{project_part}/"
+                save_path = f"{settings.raw_data_dir}/{project_part}{f['filename']}"
+                stream_to_s3(url=f["url"], s3_path=save_path, requests=requests)
+            else:
+                save_path = Path(settings.raw_data_dir) / project_part / f["filename"]
+                client.download(url=f["url"], destination=save_path, expected_checksum=f["md5"], checksum_fn="md5")
+
             f["path"] = str(save_path)
             successful_downloads.append(f)
         except Exception as e:

--- a/src/cdm_data_loaders/pipelines/all_the_bacteria.py
+++ b/src/cdm_data_loaders/pipelines/all_the_bacteria.py
@@ -41,7 +41,7 @@ ATB_VERSION = "2025-05"
 ARG_ALIASES = frozendict(
     {
         "version": ["-v", "--version"],
-        "pattern_file": ["-p", "--pattern-file", "--pattern_file"],
+        "pattern_file": ["-f", "--pattern-file", "--pattern_file"],
     },
 )
 

--- a/src/cdm_data_loaders/pipelines/all_the_bacteria.py
+++ b/src/cdm_data_loaders/pipelines/all_the_bacteria.py
@@ -201,8 +201,9 @@ def osf_file_downloader(settings: AtbSettings, atb_file_list: list[dict[str, Any
     successful_downloads = []
     for f in atb_file_list:
         try:
-            save_path = raw_data_dir / f["filename"]
-            client.download(f["url"], save_path, expected_checksum=f["md5"], checksum_fn="md5")
+            project_part = f["project"].removeprefix("AllTheBacteria").removeprefix("/")
+            save_path = raw_data_dir / project_part / f["filename"]
+            client.download(url=f["url"], destination=save_path, expected_checksum=f["md5"], checksum_fn="md5")
             f["path"] = str(save_path)
             successful_downloads.append(f)
         except Exception as e:

--- a/src/cdm_data_loaders/pipelines/all_the_bacteria.py
+++ b/src/cdm_data_loaders/pipelines/all_the_bacteria.py
@@ -19,7 +19,7 @@ import dlt
 from dlt.extract.items import DataItemWithMeta
 from dlt.sources.helpers.rest_client.client import RESTClient
 from frozendict import frozendict
-from pydantic import AliasChoices, Field
+from pydantic import AliasChoices, Field, computed_field
 from pydantic_settings import SettingsConfigDict
 
 from cdm_data_loaders.pipelines.core import (
@@ -34,13 +34,23 @@ logger = logging.getLogger("dlt")
 
 DATASET_NAME = "all_the_bacteria"
 ALL_FILES_TSV_FILE_ID = "R6gcp"
+ALL_ATB_FILE_NAME = "all_atb_files.tsv"
+REGEX_FILE = "filters.txt"
 ATB_VERSION = "2025-05"
 
 ARG_ALIASES = frozendict(
     {
         "version": ["-v", "--version"],
-    }
+        "pattern_file": ["-p", "--pattern-file", "--pattern_file"],
+    },
 )
+
+# project parts needed:
+PROJECT_PARTS = ["Annotation/Bakta", "Assembly", "Metadata"]
+PROJECT_PART_REGEX = re.compile(f"^AllTheBacteria/({'|'.join(PROJECT_PARTS)})")
+
+EXPECTED_ATB_FIELDNAMES = ["project", "project_id", "filename", "url", "md5", "size(MB)"]
+REQUIRED_ATB_FIELDNAMES = {"project", "filename", "url", "md5"}
 
 
 class AtbSettings(CtsSettings):
@@ -54,6 +64,13 @@ class AtbSettings(CtsSettings):
         validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES["version"]]),
     )
 
+    pattern_file: str | None = Field(
+        default=None,
+        description="Path, relative to the input dir, of a file containing patterns to match when downloading ATB files",
+        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES["pattern_file"]]),
+    )
+
+    @computed_field
     @property
     def raw_data_dir(self) -> str:
         """Directory in which to save the raw data files that are downloaded.
@@ -62,21 +79,50 @@ class AtbSettings(CtsSettings):
         """
         return str(Path(self.output) / "raw_data" / self.version)
 
+    @computed_field
+    @property
+    def pattern_matches(self) -> re.Pattern:
+        """The regular expression pattern to be used to select files for download.
 
-# project parts needed:
-PROJECT_PARTS = ["Annotation/Bakta", "Assembly", "Metadata"]
+        If a pattern_file is supplied, it will read in the file at {input_dir}/{pattern_file}
+        and convert the contents into a regular expression. If no file is supplied or the file is empty
+        or does not contain any content, the default PROJECT_PART_REGEX will be used instead.
+        """
+        if self.pattern_file:
+            pattern_file = Path(self.input_dir) / self.pattern_file
+            regex = load_patterns(pattern_file)
+            if regex is not None:
+                return regex
+        # return the default
+        return PROJECT_PART_REGEX
 
-PROJECT_PART_REGEX = re.compile(f"^AllTheBacteria/({'|'.join(PROJECT_PARTS)})")
 
-EXPECTED_ATB_FIELDNAMES = ["project", "project_id", "filename", "url", "md5", "size(MB)"]
-REQUIRED_ATB_FIELDNAMES = {"project", "filename", "url", "md5"}
+def load_patterns(pattern_file: Path) -> re.Pattern | None:
+    """Load the pattern file and convert it into a set of regexes."""
+    patterns = []
+    try:
+        for line in pattern_file.read_text(encoding="utf-8").splitlines():
+            trimmed_line = line.strip()
+            # skip blank lines
+            if not trimmed_line:
+                continue
+            patterns.append(
+                re.escape(trimmed_line[:-1]) + ".*" if trimmed_line.endswith("*") else re.escape(trimmed_line)
+            )
+
+        if patterns:
+            return re.compile("^(" + "|".join(patterns) + ")$")
+    except Exception:
+        logger.exception("Could not load patterns from %s", str(pattern_file))
+
+    return None
 
 
 def download_atb_index_tsv(settings: AtbSettings) -> Path:
     """Download the ATB file index TSV file from the OSF and save it to disk.
 
     :param settings: pipeline config
-    :type settings: Settings
+    :type settings: AtbSettings
     :raises RuntimeError: if the download URL cannot be found
     :return: path to the downloaded file
     :rtype: Path
@@ -108,14 +154,17 @@ def download_atb_index_tsv(settings: AtbSettings) -> Path:
     return atb_files_tsv
 
 
-def get_file_download_links(atb_files_tsv: Path) -> Generator[list[dict[str, Any]], Any]:
+def get_file_download_links(settings: AtbSettings, atb_files_tsv: Path) -> Generator[list[dict[str, Any]], Any]:
     """Parse the ATB file index TSV and to yield a list of files to download.
 
+    :param settings: pipeline config
+    :type settings: AtbSettings
     :param atb_files_tsv: path to the ATB file index TSV file
     :type atb_files_tsv: Path
     :yield: list of fields to download
     :rtype: Generator[list[dict[str, Any]], Any]
     """
+    pattern_to_match = settings.pattern_matches
     with atb_files_tsv.open() as index_file:
         reader = csv.DictReader(index_file, delimiter="\t")
         all_lines = list(reader)
@@ -134,7 +183,7 @@ def get_file_download_links(atb_files_tsv: Path) -> Generator[list[dict[str, Any
                 logger.error(err_msg)
                 raise RuntimeError(err_msg)
 
-        files_to_download = [row for row in all_lines if PROJECT_PART_REGEX.match(row["project"])]
+        files_to_download = [row for row in all_lines if pattern_to_match.match(row["project"])]
 
         yield files_to_download
 
@@ -169,7 +218,7 @@ def osf_file_downloader(settings: AtbSettings, atb_file_list: list[dict[str, Any
 def atb_file_list(settings: AtbSettings) -> Generator[list[dict[str, Any]], Any, Any]:
     """Generate a list of files to download from the list of all ATB files."""
     atb_files_tsv = download_atb_index_tsv(settings)
-    return get_file_download_links(atb_files_tsv)
+    return get_file_download_links(settings, atb_files_tsv)
 
 
 @dlt.transformer(name="file_downloader", data_from=atb_file_list, parallelized=True)

--- a/src/cdm_data_loaders/pipelines/all_the_bacteria.py
+++ b/src/cdm_data_loaders/pipelines/all_the_bacteria.py
@@ -167,6 +167,7 @@ def download_atb_index_tsv(settings: AtbSettings) -> Path:
 
     # download the file listing and save it
     FileDownloader().download(url=all_files_tsv_download, destination=atb_files_tsv)
+    logger.info("Downloaded TSV index file.")
     return atb_files_tsv
 
 
@@ -222,6 +223,7 @@ def osf_file_downloader(settings: AtbSettings, atb_file_list: list[dict[str, Any
                     project_part = f"{project_part}/"
                 save_path = f"{settings.raw_data_dir}/{project_part}{f['filename']}"
                 stream_to_s3(url=f["url"], s3_path=save_path, requests=requests)
+                logger.debug("Successfully transferred file from %s to %s", f["url"], save_path)
             else:
                 save_path = Path(settings.raw_data_dir) / project_part / f["filename"]
                 client.download(url=f["url"], destination=save_path, expected_checksum=f["md5"], checksum_fn="md5")

--- a/src/cdm_data_loaders/pipelines/cts_defaults.py
+++ b/src/cdm_data_loaders/pipelines/cts_defaults.py
@@ -1,11 +1,10 @@
 """Common defaults for running pipelines on the KBase CTS."""
 
-from pathlib import Path
 from typing import Any, Self
 
 import dlt.common.configuration.accessors
 from frozendict import frozendict
-from pydantic import AliasChoices, Field, ValidationError, computed_field, field_validator, model_validator
+from pydantic import AliasChoices, Field, computed_field, field_validator, model_validator
 from pydantic_settings import BaseSettings, CliSuppress, SettingsConfigDict
 
 INPUT_MOUNT = "/input_dir"
@@ -123,8 +122,10 @@ class CtsSettings(BaseSettings):
             if self.output != "/":
                 self.output.rstrip("/")
 
+        # TODO: this should never happen
         if not self.output:
-            raise ValueError("No output specified")
+            err_msg = "No output specified!"
+            raise ValueError(err_msg)
 
         # ensure that the use_destination value does not conflict with whether or not pipeline data should be saved
         destination_is_s3 = False

--- a/src/cdm_data_loaders/pipelines/cts_defaults.py
+++ b/src/cdm_data_loaders/pipelines/cts_defaults.py
@@ -5,7 +5,7 @@ from typing import Any, Self
 
 import dlt.common.configuration.accessors
 from frozendict import frozendict
-from pydantic import AliasChoices, Field, computed_field, field_validator, model_validator
+from pydantic import AliasChoices, Field, ValidationError, computed_field, field_validator, model_validator
 from pydantic_settings import BaseSettings, CliSuppress, SettingsConfigDict
 
 INPUT_MOUNT = "/input_dir"
@@ -120,6 +120,20 @@ class CtsSettings(BaseSettings):
                 raise ValueError(err_msg)
 
             self.output = self.dlt_config[f"destination.{self.use_destination}.bucket_url"]
+            if self.output != "/":
+                self.output.rstrip("/")
+
+        if not self.output:
+            raise ValueError("No output specified")
+
+        # ensure that the use_destination value does not conflict with whether or not pipeline data should be saved
+        destination_is_s3 = False
+        if self.output.startswith("s3://") or self.output.startswith("s3a://"):
+            destination_is_s3 = True
+
+        if self.use_output_dir_for_pipeline_metadata and destination_is_s3:
+            err_msg = "It is not currently possible to have the pipeline directory on s3."
+            raise ValueError(err_msg)
 
         return self
 
@@ -148,7 +162,7 @@ class CtsSettings(BaseSettings):
 
         If not set, defaults to a 'raw_data' directory within the output directory after reconciling with dlt config.
         """
-        return str(Path(self.output or "") / "raw_data")
+        return f"{self.output}{'' if self.output in ('', '/') else '/'}raw_data"
 
     @computed_field
     @property
@@ -158,7 +172,7 @@ class CtsSettings(BaseSettings):
         If use_output_dir_for_pipeline_metadata is true, this defaults to a `.dlt_conf` directory within the output directory.
         """
         if self.use_output_dir_for_pipeline_metadata:
-            return str(Path(self.output or "") / ".dlt_conf")
+            return f"{self.output}{'' if self.output in ('', '/') else '/'}.dlt_conf"
         return None
 
 

--- a/src/cdm_data_loaders/pipelines/cts_defaults.py
+++ b/src/cdm_data_loaders/pipelines/cts_defaults.py
@@ -85,7 +85,7 @@ class CtsSettings(BaseSettings):
     )
     use_destination: str = Field(
         default=DEFAULT_CTS_SETTINGS["use_destination"],
-        description=f"DLT destination configuration to use for data output. Choices: {VALID_DESTINATIONS}",
+        description=f"DLT destination configuration to use for data output. Data to be saved to s3 should use the destination 's3'; to save data locally, use the destination 'local_fs'. The output directory can be specified using the 'output' field. Choices: {VALID_DESTINATIONS}",
         validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES["use_destination"]]),
     )
     use_output_dir_for_pipeline_metadata: bool = Field(
@@ -131,6 +131,11 @@ class CtsSettings(BaseSettings):
         destination_is_s3 = False
         if self.output.startswith("s3://") or self.output.startswith("s3a://"):
             destination_is_s3 = True
+
+        # self.use_destination should be "s3" if the output is an s3 url and vice versa
+        if bool(self.use_destination == "s3") != destination_is_s3:
+            err_msg = "Mismatch between output location and use_destination. To ensure internal settings functions work correctly, set use_destination to 's3' for writing files to s3, and 'local_fs' for writing files locally. The output directory can be configured using the 'output' parameter."
+            raise ValueError(err_msg)
 
         if self.use_output_dir_for_pipeline_metadata and destination_is_s3:
             err_msg = "It is not currently possible to have the pipeline directory on s3."

--- a/src/cdm_data_loaders/utils/s3.py
+++ b/src/cdm_data_loaders/utils/s3.py
@@ -1,18 +1,26 @@
 """Utilities for s3 interaction."""
 
 from pathlib import Path
+from types import ModuleType
 from typing import Any
 
 import boto3
 import botocore
 import botocore.client
 import tqdm
+from botocore.config import Config
 
 CDM_LAKE_BUCKET = "cdm-lake"
 DEFAULT_EXTRA_ARGS = {"ChecksumAlgorithm": "CRC64NVME"}
 
 VALID_S3_PREFIXES = ["s3://", "s3a://"]
 VALID_BUCKETS = [CDM_LAKE_BUCKET, "cts"]
+
+# "legacy", "standard", "adaptive"
+AWS_CLIENT_RETRY_MODE = "adaptive"
+# how many times to retry, including the initial attempt
+AWS_CLIENT_TOTAL_MAX_ATTEMPTS = 10
+
 
 _s3_client: botocore.client.BaseClient | None = None
 
@@ -33,9 +41,19 @@ def get_s3_client(args: dict[str, str] | None = None) -> botocore.client.BaseCli
     if _s3_client is not None:
         return _s3_client
 
+    config = Config(retries={"total_max_attempts": AWS_CLIENT_TOTAL_MAX_ATTEMPTS, "mode": AWS_CLIENT_RETRY_MODE})
+
     if not args:
+        # try using env vars and skip manual configuration
+        client = boto3.client("s3", config=config)
+        # check for credentials and endpoint_url
+        credentials = client._request_signer._credentials  # noqa: SLF001
+        if credentials.access_key and credentials.secret_key and client.meta.endpoint_url:
+            _s3_client = client
+            return _s3_client
+
         try:
-            from berdl_notebook_utils.berdl_settings import get_settings
+            from berdl_notebook_utils.berdl_settings import get_settings  # noqa: PLC0415
 
             settings = get_settings()
             args = {
@@ -56,7 +74,7 @@ def get_s3_client(args: dict[str, str] | None = None) -> botocore.client.BaseCli
         msg = "Cannot initialise s3 client: missing arguments: " + ", ".join(missing)
         raise ValueError(msg)
 
-    _s3_client = boto3.client("s3", **keyword_args)
+    _s3_client = boto3.client("s3", config=config, **keyword_args)
     return _s3_client
 
 
@@ -126,6 +144,19 @@ def list_matching_objects(s3_path: str) -> list[dict[str, Any]]:
     return contents
 
 
+def head_object(s3_path: str) -> dict[str, Any]:
+    """Check whether an object exists on s3.
+
+    :param s3_path: path to the object on s3, INCLUDING the bucket name
+    :type s3_path: str
+    :return: response from the head_object request
+    :rtype: dict[str, Any]
+    """
+    s3 = get_s3_client()
+    (bucket, key) = split_s3_path(s3_path)
+    return s3.head_object(Bucket=bucket, Key=key)
+
+
 def object_exists(s3_path: str) -> bool:
     """Check whether an object exists on s3.
 
@@ -134,11 +165,8 @@ def object_exists(s3_path: str) -> bool:
     :return: True if the object exists, False otherwise
     :rtype: bool
     """
-    s3 = get_s3_client()
-
-    (bucket, key) = split_s3_path(s3_path)
     try:
-        s3.head_object(Bucket=bucket, Key=key)
+        head_object(s3_path)
     except Exception as e:
         error_string = str(e)
         if not error_string.startswith("An error occurred (404) when calling the HeadObject operation: Not Found"):
@@ -197,6 +225,35 @@ def upload_file(
             print(f"Error uploading to s3: {e!s}")
             return False
         return True
+
+
+def stream_to_s3(url: str, s3_path: str, requests: ModuleType) -> str:
+    """Stream directly from an HTTP download to s3.
+
+    :param url: address of the object to transfer to s3
+    :type url: str
+    :param s3_path: save path on s3
+    :type s3_path: str
+    :param requests: module implementing requests.get and returning a response
+    :type requests: ModuleType
+    :return: path of the file on s3, in the form bucket/key
+    :rtype: str
+    """
+    s3_client = get_s3_client()
+    (bucket, key) = split_s3_path(s3_path)
+    with requests.get(url, stream=True) as response:
+        response.raise_for_status()
+        s3_client.upload_fileobj(
+            # raw stream from urllib3
+            response.raw,
+            bucket,
+            key,
+            ExtraArgs={
+                **DEFAULT_EXTRA_ARGS,
+                "ContentType": response.headers.get("content-type", "application/octet-stream"),
+            },
+        )
+    return f"{bucket}/{key}"
 
 
 def download_file(s3_path: str, local_file_path: str | Path, version_id: str | None = None) -> None:
@@ -335,6 +392,9 @@ def copy_object(current_s3_path: str, new_s3_path: str) -> dict[str, Any]:
     A successful copy operation will return a response where
     resp["ResponseMetadata"]["HTTPStatusCode"] == 200
 
+    Errors (e.g, buckets or keys not existing, wrong credentials, etc.) are passed
+    directly to the user without being caught.
+
     :param current_path: path to the file on s3, INCLUDING the bucket name
     :type current_path: str
     :param new_path: the desired new file path on s3, INCLUDING the bucket name
@@ -359,6 +419,9 @@ def delete_object(s3_path: str) -> dict[str, Any]:
 
     A successful deletion will return a response where
     resp["ResponseMetadata"]["HTTPStatusCode"] == 204.
+
+    Errors (e.g, buckets or keys not existing, wrong credentials, etc.) are passed
+    directly to the user without being caught.
 
     :param s3_path: path to the file on s3, INCLUDING the bucket name
     :type s3_path: str

--- a/tests/data/atb/assembly_bakta_metadata_exact.tsv
+++ b/tests/data/atb/assembly_bakta_metadata_exact.tsv
@@ -1,0 +1,7 @@
+project	project_id	filename	url	md5	size(MB)
+AllTheBacteria/Annotation/Bakta	zt57s	File_Lists/atb.bakta.incr_release.202408.status.tsv.gz	https://osf.io/download/2skzy/	7da48fce8e310916a072786872f475b1	14.19
+AllTheBacteria/Annotation/Bakta	zt57s	File_Lists/atb.bakta.r0.2.status.tsv.gz	https://osf.io/download/rxfks/	b7255867206dc66f2c26db31921a67a6	53.87
+AllTheBacteria/Assembly	zxfmy	File_Lists/file_list.all.20240805.tsv.gz	https://osf.io/download/dw3h7/	5fc5c88a0593785341e466143a97f126	17.04
+AllTheBacteria/Assembly	zxfmy	File_Lists/file_list.all.202505.tsv.gz	https://osf.io/download/69a03f582574717cb3643d62/	0a9ee0b1efaf42b3ea9e89ce91d2b9e1	22.13
+AllTheBacteria/Metadata	h7wzy	0.1/HQ_set_0.1/hq_dataset.accessions.txt.gz	https://osf.io/download/3znhb/	6f001b72101779b5ff6a556f46c9ddab	4.11
+AllTheBacteria/Metadata	h7wzy	0.1/HQ_set_0.1/hq_dataset.counts_bar_plot.pdf	https://osf.io/download/p5vkt/	a147e807f6a661b6f7f6dc856aa0465c	0.02

--- a/tests/data/atb/assembly_bakta_star_metadata.tsv
+++ b/tests/data/atb/assembly_bakta_star_metadata.tsv
@@ -1,0 +1,15 @@
+project	project_id	filename	url	md5	size(MB)
+AllTheBacteria/Annotation/Bakta	zt57s	File_Lists/atb.bakta.incr_release.202408.status.tsv.gz	https://osf.io/download/2skzy/	7da48fce8e310916a072786872f475b1	14.19
+AllTheBacteria/Annotation/Bakta	zt57s	File_Lists/atb.bakta.r0.2.status.tsv.gz	https://osf.io/download/rxfks/	b7255867206dc66f2c26db31921a67a6	53.87
+AllTheBacteria/Annotation/Bakta/Incr_release.202408_Set_1	kdnwp	atb.bakta.incr_release.202408.batch.1.tar.xz	https://osf.io/download/r84xg/	a3ba0148c435f31b4de3f0b72e01075d	1378.51
+AllTheBacteria/Annotation/Bakta/Incr_release.202408_Set_1	kdnwp	atb.bakta.incr_release.202408.batch.10.tar.xz	https://osf.io/download/qxye9/	e0724b0a605da7298b802f01145d8b49	388.76
+AllTheBacteria/Annotation/Bakta/Incr_release.202408_Set_2	p4kvy	atb.bakta.incr_release.202408.batch.49.tar.xz	https://osf.io/download/nyua7/	c8871eab5ee9071b101ba7bbafa7983b	2320.01
+AllTheBacteria/Annotation/Bakta/Incr_release.202408_Set_2	p4kvy	atb.bakta.incr_release.202408.batch.50.tar.xz	https://osf.io/download/tqrs2/	887db770a7e176e644a2b413de4b07e5	2169.25
+AllTheBacteria/Annotation/Bakta/Release_0.2_Set_1	tyw72	atb.bakta.r0.2.batch.1.tar.xz	https://osf.io/download/vpg3d/	5e6ccd68f5c6a69a14dafaf599f9377e	293.86
+AllTheBacteria/Annotation/Bakta/Release_0.2_Set_1	tyw72	atb.bakta.r0.2.batch.10.tar.xz	https://osf.io/download/gbzev/	8fab65bbeadc99201a1df83f32b8c779	132.76
+AllTheBacteria/Annotation/Bakta/Release_0.2_Set_9	evurw	atb.bakta.r0.2.batch.228.tar.xz	https://osf.io/download/679b9dd3bc1fdea8290eb046/	dc061bcc2e1bb9c30887a4dfefb1b6c2	3841.85
+AllTheBacteria/Annotation/Bakta/Release_0.2_Set_9	evurw	atb.bakta.r0.2.batch.229.tar.xz	https://osf.io/download/679ba14cae64ecefd50eaea0/	db0081059366d08e8c3cd8c19857ef42	3902.73
+AllTheBacteria/Assembly	zxfmy	File_Lists/file_list.all.20240805.tsv.gz	https://osf.io/download/dw3h7/	5fc5c88a0593785341e466143a97f126	17.04
+AllTheBacteria/Assembly	zxfmy	File_Lists/file_list.all.202505.tsv.gz	https://osf.io/download/69a03f582574717cb3643d62/	0a9ee0b1efaf42b3ea9e89ce91d2b9e1	22.13
+AllTheBacteria/Metadata	h7wzy	0.1/HQ_set_0.1/hq_dataset.accessions.txt.gz	https://osf.io/download/3znhb/	6f001b72101779b5ff6a556f46c9ddab	4.11
+AllTheBacteria/Metadata	h7wzy	0.1/HQ_set_0.1/hq_dataset.counts_bar_plot.pdf	https://osf.io/download/p5vkt/	a147e807f6a661b6f7f6dc856aa0465c	0.02

--- a/tests/data/atb/bakta_exact.tsv
+++ b/tests/data/atb/bakta_exact.tsv
@@ -1,0 +1,3 @@
+project	project_id	filename	url	md5	size(MB)
+AllTheBacteria/Annotation/Bakta	zt57s	File_Lists/atb.bakta.incr_release.202408.status.tsv.gz	https://osf.io/download/2skzy/	7da48fce8e310916a072786872f475b1	14.19
+AllTheBacteria/Annotation/Bakta	zt57s	File_Lists/atb.bakta.r0.2.status.tsv.gz	https://osf.io/download/rxfks/	b7255867206dc66f2c26db31921a67a6	53.87

--- a/tests/data/atb/bakta_star.tsv
+++ b/tests/data/atb/bakta_star.tsv
@@ -1,0 +1,11 @@
+project	project_id	filename	url	md5	size(MB)
+AllTheBacteria/Annotation/Bakta	zt57s	File_Lists/atb.bakta.incr_release.202408.status.tsv.gz	https://osf.io/download/2skzy/	7da48fce8e310916a072786872f475b1	14.19
+AllTheBacteria/Annotation/Bakta	zt57s	File_Lists/atb.bakta.r0.2.status.tsv.gz	https://osf.io/download/rxfks/	b7255867206dc66f2c26db31921a67a6	53.87
+AllTheBacteria/Annotation/Bakta/Incr_release.202408_Set_1	kdnwp	atb.bakta.incr_release.202408.batch.1.tar.xz	https://osf.io/download/r84xg/	a3ba0148c435f31b4de3f0b72e01075d	1378.51
+AllTheBacteria/Annotation/Bakta/Incr_release.202408_Set_1	kdnwp	atb.bakta.incr_release.202408.batch.10.tar.xz	https://osf.io/download/qxye9/	e0724b0a605da7298b802f01145d8b49	388.76
+AllTheBacteria/Annotation/Bakta/Incr_release.202408_Set_2	p4kvy	atb.bakta.incr_release.202408.batch.49.tar.xz	https://osf.io/download/nyua7/	c8871eab5ee9071b101ba7bbafa7983b	2320.01
+AllTheBacteria/Annotation/Bakta/Incr_release.202408_Set_2	p4kvy	atb.bakta.incr_release.202408.batch.50.tar.xz	https://osf.io/download/tqrs2/	887db770a7e176e644a2b413de4b07e5	2169.25
+AllTheBacteria/Annotation/Bakta/Release_0.2_Set_1	tyw72	atb.bakta.r0.2.batch.1.tar.xz	https://osf.io/download/vpg3d/	5e6ccd68f5c6a69a14dafaf599f9377e	293.86
+AllTheBacteria/Annotation/Bakta/Release_0.2_Set_1	tyw72	atb.bakta.r0.2.batch.10.tar.xz	https://osf.io/download/gbzev/	8fab65bbeadc99201a1df83f32b8c779	132.76
+AllTheBacteria/Annotation/Bakta/Release_0.2_Set_9	evurw	atb.bakta.r0.2.batch.228.tar.xz	https://osf.io/download/679b9dd3bc1fdea8290eb046/	dc061bcc2e1bb9c30887a4dfefb1b6c2	3841.85
+AllTheBacteria/Annotation/Bakta/Release_0.2_Set_9	evurw	atb.bakta.r0.2.batch.229.tar.xz	https://osf.io/download/679ba14cae64ecefd50eaea0/	db0081059366d08e8c3cd8c19857ef42	3902.73

--- a/tests/pipelines/conftest.py
+++ b/tests/pipelines/conftest.py
@@ -78,7 +78,7 @@ TEST_CTS_SETTINGS = frozendict(
         "dev_mode": "false",
         "input_dir": "/dir/path",
         "output": "/some/dir",
-        "use_destination": VALID_DESTINATIONS[1],
+        "use_destination": "local_fs",
         "use_output_dir_for_pipeline_metadata": "true",
     }
 )

--- a/tests/pipelines/conftest.py
+++ b/tests/pipelines/conftest.py
@@ -29,18 +29,38 @@ CASSETTES_DIR = "tests/cassettes"
 START_AT_VALUE = 50
 START_AT_STRING = "50"
 
+CONFIG_BUCKET = {"local_fs": "/output_dir", "s3": "s3://some/s3/bucket"}
+
 TEST_DLT_CONFIG = frozendict(
     {
-        "destination.local_fs.bucket_url": "/output_dir",
+        "destination.local_fs.bucket_url": CONFIG_BUCKET["local_fs"],
         "destination.local_fs.destination_type": "filesystem",
-        "destination.s3.bucket_url": "s3://some/s3/bucket",
+        "destination.s3.bucket_url": CONFIG_BUCKET["s3"],
         "destination.s3.destination_type": "filesystem",
         "normalize.data_writer.disable_compression": False,
     }
 )
 
 
-DESTINATION_OUTPUT = TEST_DLT_CONFIG[f"destination.{DEFAULT_CTS_SETTINGS['use_destination']}.bucket_url"]
+def _generate_dlt_config() -> dict[str, Any]:
+    """Return a fresh DLT config dict (same shape as the conftest fixture)."""
+    return {
+        "destination": {
+            "local_fs": {"bucket_url": CONFIG_BUCKET["local_fs"]},
+            "s3": {"bucket_url": CONFIG_BUCKET["s3"]},
+        },
+        "destination.local_fs.bucket_url": CONFIG_BUCKET["local_fs"],
+        "destination.s3.bucket_url": CONFIG_BUCKET["s3"],
+        "normalize.data_writer.disable_compression": False,
+    }
+
+
+DESTINATION_TO_OUTPUT = {
+    "local_fs": TEST_DLT_CONFIG["destination.local_fs.bucket_url"],
+    "s3": TEST_DLT_CONFIG["destination.s3.bucket_url"],
+}
+
+DESTINATION_OUTPUT = DESTINATION_TO_OUTPUT[DEFAULT_CTS_SETTINGS["use_destination"]]
 
 DEFAULT_CTS_SETTINGS_RECONCILED = frozendict(
     {
@@ -63,16 +83,14 @@ TEST_CTS_SETTINGS = frozendict(
     }
 )
 
-TEST_CTS_SETTINGS_EXPECTED = frozendict(
+TEST_CTS_SETTINGS_RECONCILED = frozendict(
     {
         **TEST_CTS_SETTINGS,
         "dev_mode": False,
         "use_output_dir_for_pipeline_metadata": True,
+        "pipeline_dir": "/some/dir/.dlt_conf",
+        "raw_data_dir": "/some/dir/raw_data",
     }
-)
-
-TEST_CTS_SETTINGS_RECONCILED = frozendict(
-    {**TEST_CTS_SETTINGS_EXPECTED, "pipeline_dir": "/some/dir/.dlt_conf", "raw_data_dir": "/some/dir/raw_data"}
 )
 
 TEST_BATCH_FILE_SETTINGS = frozendict(
@@ -80,12 +98,13 @@ TEST_BATCH_FILE_SETTINGS = frozendict(
     start_at=START_AT_STRING,
 )
 
-TEST_BATCH_FILE_SETTINGS_EXPECTED = frozendict(
-    **TEST_CTS_SETTINGS_EXPECTED,
-    start_at=START_AT_VALUE,
-)
 TEST_BATCH_FILE_SETTINGS_RECONCILED = frozendict(
-    {**TEST_BATCH_FILE_SETTINGS_EXPECTED, "pipeline_dir": "/some/dir/.dlt_conf", "raw_data_dir": "/some/dir/raw_data"}
+    {
+        **TEST_CTS_SETTINGS_RECONCILED,
+        "start_at": START_AT_VALUE,
+        "pipeline_dir": "/some/dir/.dlt_conf",
+        "raw_data_dir": "/some/dir/raw_data",
+    }
 )
 
 
@@ -119,16 +138,6 @@ def make_batcher(files: list[Path], batch_size: int = 5) -> MagicMock:
     mock_batcher = MagicMock()
     mock_batcher.get_batch.side_effect = [*batches, []]
     return mock_batcher
-
-
-def _generate_dlt_config() -> dict[str, Any]:
-    """Return a fresh DLT config dict (same shape as the conftest fixture)."""
-    return {
-        "destination": {"local_fs": {"bucket_url": "/output_dir"}, "s3": {"bucket_url": "s3://my-bucket/output"}},
-        "destination.local_fs.bucket_url": "/output_dir",
-        "destination.s3.bucket_url": "s3://my-bucket/output",
-        "normalize.data_writer.disable_compression": False,
-    }
 
 
 def make_settings(

--- a/tests/pipelines/test_all_the_bacteria.py
+++ b/tests/pipelines/test_all_the_bacteria.py
@@ -2,6 +2,7 @@
 
 import csv
 import logging
+import re
 from collections.abc import Callable
 from pathlib import Path
 from typing import Any
@@ -17,6 +18,7 @@ from cdm_data_loaders.pipelines.all_the_bacteria import (
     cli,
     download_atb_index_tsv,
     get_file_download_links,
+    load_patterns,
     osf_file_downloader,
     run_atb_pipeline,
 )
@@ -50,8 +52,19 @@ def test_settings(tmp_path: Path, dlt_config: dict[str, Any]) -> AtbSettings:
     return AtbSettings(dlt_config=dlt_config, output=str(tmp_path))
 
 
-def test_cli_calls_run_ncbi_pipeline(monkeypatch: pytest.MonkeyPatch, dlt_config: dict[str, Any]) -> None:
-    """Ensure that cli() calls run_ncbi_pipeline with the settings."""
+@pytest.fixture
+def pattern_file(tmp_path: Path) -> Path:
+    """Pattern file for testing load_patterns."""
+    p = tmp_path / "patterns.txt"
+    p.write_text(
+        "hello world\nfoo.bar\nstarts with*\n2+2=4\n",
+        encoding="utf-8",
+    )
+    return p
+
+
+def test_cli_calls_run_atb_pipeline(monkeypatch: pytest.MonkeyPatch, dlt_config: dict[str, Any]) -> None:
+    """Ensure that cli() calls run_atb_pipeline with the settings."""
     mock_settings_instance = MagicMock()
     mock_settings_cls = MagicMock(return_value=mock_settings_instance)
     mock_run_atb_pipeline = MagicMock()
@@ -63,6 +76,92 @@ def test_cli_calls_run_ncbi_pipeline(monkeypatch: pytest.MonkeyPatch, dlt_config
 
     mock_settings_cls.assert_called_once_with(dlt_config=dlt_config)
     mock_run_atb_pipeline.assert_called_once_with(mock_settings_instance)
+
+
+def test_load_patterns_returns_compiled_pattern(pattern_file: Path) -> None:
+    """load_patterns() should return a compiled re.Pattern object."""
+    assert isinstance(load_patterns(pattern_file), re.Pattern)
+
+
+def test_load_patterns_exact_match(pattern_file: Path) -> None:
+    """Plain text lines should match exactly against their literal content."""
+    pattern = load_patterns(pattern_file)
+    assert isinstance(pattern, re.Pattern)
+    assert pattern.match("hello world")
+    assert pattern.match("foo.bar")
+    assert pattern.match("2+2=4")
+
+    # patterns are anchored with ^ and $, so partial matches should not succeed
+    assert not pattern.match("hello world!!!")
+    assert not pattern.match("well, hello world")
+
+    # dot is literal, not a wildcard
+    assert not pattern.match("fooXbar")
+    # + is literal, not a quantifier
+    assert not pattern.match("22=4")
+
+    # line ending with * should match the prefix followed by any suffix
+    assert pattern.match("starts with")
+    assert pattern.match("starts with anything")
+    assert pattern.match("starts with 123!@#")
+
+    # line ending with * should not match strings with a different prefix
+    assert not pattern.match("ends with")
+
+
+def test_load_patterns_blank_lines_are_ignored(tmp_path: Path) -> None:
+    """Blank lines in the file should be silently skipped."""
+    p = tmp_path / "patterns.txt"
+    p.write_text("\nhello\n\nworld\n", encoding="utf-8")
+    pattern = load_patterns(p)
+    assert isinstance(pattern, re.Pattern)
+    assert pattern.match("hello")
+    assert pattern.match("world")
+    assert not pattern.match("")
+
+
+def test_load_patterns_only_wildcard_matches_anything(tmp_path: Path) -> None:
+    """A file containing only '*' should produce a pattern that matches any string."""
+    p = tmp_path / "patterns.txt"
+    p.write_text("*\n", encoding="utf-8")
+    pattern = load_patterns(p)
+    assert isinstance(pattern, re.Pattern)
+    assert pattern.match("")
+    assert pattern.match("anything at all")
+
+
+def test_load_patterns_alternation(tmp_path: Path) -> None:
+    """Each line in the file should become an alternative in the combined pattern."""
+    p = tmp_path / "patterns.txt"
+    p.write_text("cat\ndog\nbird\n", encoding="utf-8")
+    pattern = load_patterns(p)
+    assert isinstance(pattern, re.Pattern)
+    assert pattern.match("cat")
+    assert pattern.match("dog")
+    assert pattern.match("bird")
+    assert not pattern.match("fish")
+
+
+def test_load_patterns_no_file_returns_none(tmp_path: Path) -> None:
+    """Ensure that loading a non-existent file returns None."""
+    pattern = load_patterns(tmp_path / "some" / "path")
+    assert pattern is None
+
+
+def test_load_patterns_touched_file_returns_none(tmp_path: Path) -> None:
+    """Ensure that loading an empty file returns None."""
+    p = tmp_path / "patterns.txt"
+    p.touch()
+    pattern = load_patterns(p)
+    assert pattern is None
+
+
+def test_load_patterns_empty_file_returns_none(tmp_path: Path) -> None:
+    """Ensure that loading an empty file returns None."""
+    p = tmp_path / "patterns.txt"
+    p.write_text("\n\n   \t\n  \n   \n\t\t\n", encoding="utf-8")
+    pattern = load_patterns(p)
+    assert pattern is None
 
 
 @pytest.mark.vcr
@@ -102,10 +201,10 @@ def test_download_atv_index_tsv_error_cannot_download_tsv(test_settings: AtbSett
         download_atb_index_tsv(test_settings)
 
 
-def test_get_file_download_links() -> None:
-    """Ensure that the appropriate files are picked out of the ATB file index TSV file."""
+def test_get_file_download_links(test_settings: AtbSettings) -> None:
+    """Ensure that the appropriate files are picked out of the ATB file index TSV file using the default matcher."""
     file_path = Path("tests") / "data" / "atb" / "all_atb_files.tsv"
-    filtered_files = list(get_file_download_links(file_path))
+    filtered_files = list(get_file_download_links(test_settings, file_path))
     # load the expected results
     expected = Path("tests") / "data" / "atb" / "filtered_files.tsv"
     with expected.open() as fh:
@@ -115,11 +214,41 @@ def test_get_file_download_links() -> None:
     assert filtered_files[0] == expected_files
 
 
-def test_get_file_download_links_invalid_file(caplog: pytest.LogCaptureFixture) -> None:
+EXPECTED_LINES = {
+    "*": "all_atb_files.tsv",
+    "AllTheBacteria/Annotation/Bakta\nAllTheBacteria/Assembly\nAllTheBacteria/Metadata\n": "assembly_bakta_metadata_exact.tsv",
+    "AllTheBacteria/Annotation/Bakta*\nAllTheBacteria/Assembly\nAllTheBacteria/Metadata\n": "assembly_bakta_star_metadata.tsv",
+    "AllTheBacteria/Annotation/Bakta": "bakta_exact.tsv",
+    "AllTheBacteria/Annotation/Bakta*": "bakta_star.tsv",
+}
+
+
+@pytest.mark.parametrize("pattern_lines", EXPECTED_LINES)
+def test_get_file_download_links_use_pattern_file(
+    tmp_path: Path, dlt_config: dict[str, Any], pattern_lines: str
+) -> None:
+    """Generate a pattern file from EXPECTED_LINES and check that the output from get_file_download_links is correct."""
+    # create the pattern file
+    p = tmp_path / "patterns.txt"
+    p.write_text(f"{pattern_lines}\n", encoding="utf-8")
+
+    settings = AtbSettings(dlt_config=dlt_config, input_dir=str(tmp_path), pattern_file="patterns.txt")
+    file_path = Path("tests") / "data" / "atb" / "all_atb_files.tsv"
+    filtered_files = list(get_file_download_links(settings, file_path))
+    # load the expected results
+    expected = Path("tests") / "data" / "atb" / EXPECTED_LINES[pattern_lines]
+    with expected.open() as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        expected_files = list(reader)
+    assert len(filtered_files[0]) > 1
+    assert filtered_files[0] == expected_files
+
+
+def test_get_file_download_links_invalid_file(test_settings: AtbSettings, caplog: pytest.LogCaptureFixture) -> None:
     """Ensure that the correct fields are present in the ATB TSV file and throw an error if not."""
     file_path = Path("tests") / "data" / "atb" / "invalid_atb_files.tsv"
     with pytest.raises(RuntimeError, match="Missing required ATB file index TSV headers"):
-        list(get_file_download_links(file_path))
+        list(get_file_download_links(test_settings, file_path))
     records = caplog.records
     assert records[-1].levelno == logging.ERROR
     assert records[-1].message.startswith(
@@ -129,22 +258,24 @@ def test_get_file_download_links_invalid_file(caplog: pytest.LogCaptureFixture) 
     assert records[-2].message.startswith("ATB file index TSV headers have changed.")
 
 
-def test_get_file_download_links_empty_file(caplog: pytest.LogCaptureFixture, tmp_path: Path) -> None:
+def test_get_file_download_links_empty_file(
+    test_settings: AtbSettings, caplog: pytest.LogCaptureFixture, tmp_path: Path
+) -> None:
     """Ensure that an empty file causes a runtime error."""
     file_path = tmp_path / "fake_file.tsv"
     file_path.touch()
     with pytest.raises(RuntimeError, match=f"No valid TSV data found in {file_path!s}"):
-        list(get_file_download_links(file_path))
+        list(get_file_download_links(test_settings, file_path))
     records = caplog.records
     assert records[-1].levelno == logging.ERROR
     assert records[-1].message == f"No valid TSV data found in {file_path!s}"
 
 
-def test_get_file_download_links_no_file() -> None:
+def test_get_file_download_links_no_file(test_settings: AtbSettings) -> None:
     """Ensure an error is thrown if the file cannot be found."""
     file_path = Path("/path") / "to" / "file"
     with pytest.raises(FileNotFoundError, match="No such file or directory"):
-        list(get_file_download_links(file_path))
+        list(get_file_download_links(test_settings, file_path))
 
 
 # osf_file_downloader tests

--- a/tests/pipelines/test_all_the_bacteria.py
+++ b/tests/pipelines/test_all_the_bacteria.py
@@ -1,10 +1,8 @@
 """Tests for the all_the_bacteria pipeline."""
 
-from copy import deepcopy
 import csv
 import logging
 import re
-from collections.abc import Callable
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, call, patch
@@ -15,6 +13,7 @@ from requests.exceptions import HTTPError
 
 from cdm_data_loaders.pipelines import all_the_bacteria, core
 from cdm_data_loaders.pipelines.all_the_bacteria import (
+    ALL_ATB_FILE_NAME,
     DATASET_NAME,
     AtbSettings,
     cli,
@@ -52,6 +51,12 @@ def vcr_config() -> dict[str, Any]:
 def test_settings(tmp_path: Path, dlt_config: dict[str, Any]) -> AtbSettings:
     """Generate a fake settings for testing."""
     return AtbSettings(dlt_config=dlt_config, output=str(tmp_path))
+
+
+@pytest.fixture
+def test_s3_settings(dlt_config: dict[str, Any]) -> AtbSettings:
+    """Generate fake settings that use s3."""
+    return AtbSettings(dlt_config=dlt_config, use_destination="s3")
 
 
 @pytest.fixture
@@ -176,11 +181,57 @@ def test_download_atb_index_tsv_vcr(test_settings: AtbSettings) -> None:
     assert output_file.parent == raw_data_dir
 
 
+@pytest.mark.default_cassette("test_download_atb_index_tsv_vcr.yaml")
+def test_download_atb_index_tsv_vcr_destination_s3(test_s3_settings: AtbSettings) -> None:
+    """Ensure that the download_atb_index function fetches the correct file."""
+    mock_download_client = MagicMock()
+    mock_stream_to_s3 = MagicMock()
+    mock_requests = MagicMock()
+    with (
+        patch("cdm_data_loaders.pipelines.all_the_bacteria.FileDownloader", return_value=mock_download_client),
+        patch("cdm_data_loaders.pipelines.all_the_bacteria.stream_to_s3", mock_stream_to_s3),
+        patch("cdm_data_loaders.pipelines.all_the_bacteria.requests", mock_requests),
+    ):
+        output_file = download_atb_index_tsv(test_s3_settings)
+
+    download_url = "https://osf.io/download/r6gcp/"
+    mock_stream_to_s3.assert_called_once_with(
+        url=download_url, s3_path=f"{test_s3_settings.raw_data_dir}/{ALL_ATB_FILE_NAME}", requests=mock_requests
+    )
+    mock_download_client.download.assert_called_once_with(url=download_url, destination=Path(ALL_ATB_FILE_NAME))
+    assert output_file == Path(ALL_ATB_FILE_NAME)
+
+
 @pytest.mark.vcr
 def test_download_atb_index_tsv_error_404(test_settings: AtbSettings) -> None:
     """Ensure that a 404 response causes an error and the function to die."""
     with pytest.raises(HTTPError, match="404 Client Error"):
         download_atb_index_tsv(test_settings)
+
+
+@pytest.mark.default_cassette("test_download_atb_index_tsv_vcr.yaml")
+def test_download_atb_index_s3_error_boom(test_s3_settings: AtbSettings, caplog: pytest.LogCaptureFixture) -> None:
+    """Ensure that an error in the s3 upload causes things to die unpleasantly."""
+    mock_download_client = MagicMock()
+    mock_stream_to_s3 = MagicMock(side_effect=ValueError("ZOMG!"))
+    mock_requests = MagicMock()
+    with (
+        patch("cdm_data_loaders.pipelines.all_the_bacteria.FileDownloader", return_value=mock_download_client),
+        patch("cdm_data_loaders.pipelines.all_the_bacteria.stream_to_s3", mock_stream_to_s3),
+        patch("cdm_data_loaders.pipelines.all_the_bacteria.requests", mock_requests),
+        pytest.raises(ValueError, match="ZOMG!"),
+    ):
+        download_atb_index_tsv(test_s3_settings)
+
+    download_url = "https://osf.io/download/r6gcp/"
+    mock_stream_to_s3.assert_called_once_with(
+        url=download_url, s3_path=f"{test_s3_settings.raw_data_dir}/{ALL_ATB_FILE_NAME}", requests=mock_requests
+    )
+    mock_download_client.assert_not_called()
+    mock_download_client.download.assert_not_called()
+    last_log_record = caplog.records.pop()
+    assert last_log_record.levelno == logging.ERROR
+    assert last_log_record.message == f"Could not transfer {ALL_ATB_FILE_NAME} to s3"
 
 
 @pytest.mark.vcr
@@ -295,7 +346,7 @@ FILE_DOWNLOADER_OUTPUT = [
             "filename": "file2.txt",
             "url": "https://osf.io/file2",
             "md5": "md5sum2",
-            "project": "AllTheBacteria/Side/Project",
+            "project": "AllTheBacteria/Side/Project/",
             "path": "Side/Project/file2.txt",
         }
     ),
@@ -329,41 +380,60 @@ FILE_DOWNLOADER_OUTPUT = [
         FILE_DOWNLOADER_OUTPUT,
     ],
 )
+@pytest.mark.parametrize("use_destination", VALID_DESTINATIONS)
 def test_osf_file_downloader_success(
-    test_settings: AtbSettings,
+    request: pytest.FixtureRequest,
     atb_input: list[dict[str, Any]],
+    use_destination: str,
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Ensure that the osf_file_downloader function correctly calls the download client for each file."""
-    raw_data_dir = Path(test_settings.raw_data_dir)
+    settings = request.getfixturevalue("test_s3_settings" if use_destination == "s3" else "test_settings")
+
     atb_file_list = [{k: v for k, v in f.items() if k != "path"} for f in atb_input]
 
     # expected_output path needs the raw data dir adding to it
     expected_output = [dict(f.items()) for f in atb_input]
     for f in expected_output:
-        f["path"] = str(raw_data_dir / f["path"])
+        f["path"] = f"{settings.raw_data_dir}/{f['path']}"
 
     mock_download_client = MagicMock()
+    mock_stream_to_s3 = MagicMock()
+    mock_requests = MagicMock()
     with (
         patch("cdm_data_loaders.pipelines.all_the_bacteria.FileDownloader", return_value=mock_download_client),
+        patch("cdm_data_loaders.pipelines.all_the_bacteria.stream_to_s3", mock_stream_to_s3),
+        patch("cdm_data_loaders.pipelines.all_the_bacteria.requests", mock_requests),
     ):
         # get the output from the generator
-        output = list(osf_file_downloader(test_settings, atb_file_list))
+        output = list(osf_file_downloader(settings, atb_file_list))
 
     # should have a separate call for each file downloaded
-    assert mock_download_client.download.call_count == len(atb_file_list)
+    if use_destination == "s3":
+        mock_download_client.download.assert_not_called()
+        call_args = [c.kwargs for c in mock_stream_to_s3.call_args_list]
+        assert call_args == [
+            {
+                "url": f["url"],
+                "s3_path": f["path"],
+                "requests": mock_requests,
+            }
+            for f in atb_file_list
+        ]
+    else:
+        assert mock_download_client.download.call_count == len(atb_file_list)
 
-    call_list = [c.kwargs for c in mock_download_client.download.call_args_list]
-    expected_calls = [
-        {
-            "url": f["url"],
-            "destination": raw_data_dir / f["path"],
-            "expected_checksum": f["md5"],
-            "checksum_fn": "md5",
-        }
-        for f in atb_input
-    ]
-    assert call_list == expected_calls
+        call_list = [c.kwargs for c in mock_download_client.download.call_args_list]
+        expected_calls = [
+            {
+                "url": f["url"],
+                "destination": Path(settings.raw_data_dir) / f["path"],
+                "expected_checksum": f["md5"],
+                "checksum_fn": "md5",
+            }
+            for f in atb_input
+        ]
+        assert call_list == expected_calls
 
     # output from dlt.mark.with_table_name
     assert output[0].data == expected_output
@@ -419,15 +489,17 @@ def test_osf_file_downloader_success(
         ),
     ],
 )
-def test_osf_file_downloader_error_handling(
-    test_settings: AtbSettings,
+@pytest.mark.parametrize("use_destination", VALID_DESTINATIONS)
+def test_osf_file_downloader_error_handling(  # noqa: PLR0913
     atb_file_list: list[dict[str, Any]],
     expected_exceptions: list[str],
     expected_paths: dict[str, bool],
+    use_destination: str,
     caplog: pytest.LogCaptureFixture,
+    request: pytest.FixtureRequest,
 ) -> None:
     """Ensure that errors during file download are handled correctly."""
-    mock_download_client = MagicMock()
+    settings = request.getfixturevalue("test_s3_settings" if use_destination == "s3" else "test_settings")
 
     def file_downloader_boom(**args) -> None:  # noqa: ANN003
         if "url" in args:
@@ -438,17 +510,35 @@ def test_osf_file_downloader_error_handling(
                 msg_0 = "Loser!"
                 raise RuntimeError(msg_0)
 
+    mock_requests = MagicMock()
+    mock_download_client = MagicMock()
     mock_download_client.download.side_effect = file_downloader_boom
+    mock_stream_to_s3 = MagicMock(side_effect=file_downloader_boom)
 
     with (
         patch("cdm_data_loaders.pipelines.all_the_bacteria.FileDownloader", return_value=mock_download_client),
+        patch("cdm_data_loaders.pipelines.all_the_bacteria.stream_to_s3", mock_stream_to_s3),
+        patch("cdm_data_loaders.pipelines.all_the_bacteria.requests", mock_requests),
     ):
-        list(osf_file_downloader(test_settings, atb_file_list))
+        list(osf_file_downloader(settings, atb_file_list))
 
-    raw_data_dir = Path(test_settings.raw_data_dir)
+    if use_destination == "s3":
+        mock_download_client.download.assert_not_called()
+        call_args = [c.kwargs for c in mock_stream_to_s3.call_args_list]
+        assert call_args == [
+            {
+                "url": f["url"],
+                "s3_path": f"{settings.raw_data_dir}/{f['project'].replace('AllTheBacteria/', '')}/{f['filename']}",
+                "requests": mock_requests,
+            }
+            for f in atb_file_list
+        ]
+    else:
+        mock_stream_to_s3.assert_not_called()
+
     expected_file_names = {
-        "Two/good_file.txt": str(raw_data_dir / "One/Two/good_file.txt"),
-        "great_file.txt": str(raw_data_dir / "One/Two/great_file.txt"),
+        "Two/good_file.txt": f"{settings.raw_data_dir}/One/Two/good_file.txt",
+        "great_file.txt": f"{settings.raw_data_dir}/One/Two/great_file.txt",
     }
 
     for item in atb_file_list:

--- a/tests/pipelines/test_all_the_bacteria.py
+++ b/tests/pipelines/test_all_the_bacteria.py
@@ -1,5 +1,6 @@
 """Tests for the all_the_bacteria pipeline."""
 
+from copy import deepcopy
 import csv
 import logging
 import re
@@ -9,6 +10,7 @@ from typing import Any
 from unittest.mock import MagicMock, call, patch
 
 import pytest
+from frozendict import frozendict
 from requests.exceptions import HTTPError
 
 from cdm_data_loaders.pipelines import all_the_bacteria, core
@@ -278,125 +280,185 @@ def test_get_file_download_links_no_file(test_settings: AtbSettings) -> None:
         list(get_file_download_links(test_settings, file_path))
 
 
+FILE_DOWNLOADER_OUTPUT = [
+    frozendict(
+        {
+            "filename": "file1.txt",
+            "url": "https://osf.io/file1",
+            "md5": "md5sum1",
+            "project": "AllTheBacteria/Annotation/Project",
+            "path": "Annotation/Project/file1.txt",
+        }
+    ),
+    frozendict(
+        {
+            "filename": "file2.txt",
+            "url": "https://osf.io/file2",
+            "md5": "md5sum2",
+            "project": "AllTheBacteria/Side/Project",
+            "path": "Side/Project/file2.txt",
+        }
+    ),
+    frozendict(
+        {
+            "filename": "some/path/to/file3.txt",
+            "url": "https://osf.io/file3",
+            "md5": "md5sum3",
+            "project": "AllTheBacteria",
+            "path": "some/path/to/file3.txt",
+        }
+    ),
+    frozendict(
+        {
+            "filename": "not/least/file4.txt",
+            "url": "https://osf.io/file4",
+            "md5": "md5sum4",
+            "project": "AllTheBacteria/last/but",
+            "path": "last/but/not/least/file4.txt",
+        }
+    ),
+]
+
+
 # osf_file_downloader tests
 @pytest.mark.parametrize(
-    ("atb_file_list", "expected_calls", "expected_paths"),
+    "atb_input",
     [
-        (
-            [
-                {"filename": "file1.txt", "url": "https://osf.io/file1", "md5": "md5sum1"},
-                {"filename": "file2.txt", "url": "https://osf.io/file2", "md5": "md5sum2"},
-            ],
-            [
-                (
-                    "https://osf.io/file1",
-                    "file1.txt",
-                    "md5sum1",
-                ),
-                (
-                    "https://osf.io/file2",
-                    "file2.txt",
-                    "md5sum2",
-                ),
-            ],
-            ["file1.txt", "file2.txt"],
-        ),
+        # each of the files singly and then the whole lot as a batch
+        *[[f] for f in FILE_DOWNLOADER_OUTPUT],
+        FILE_DOWNLOADER_OUTPUT,
     ],
 )
 def test_osf_file_downloader_success(
     test_settings: AtbSettings,
-    atb_file_list: list[dict[str, Any]],
-    expected_calls: list[tuple[str, str, str]],
-    expected_paths: list[str],
+    atb_input: list[dict[str, Any]],
     caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Ensure that the osf_file_downloader function correctly calls the download client for each file."""
+    raw_data_dir = Path(test_settings.raw_data_dir)
+    atb_file_list = [{k: v for k, v in f.items() if k != "path"} for f in atb_input]
+
+    # expected_output path needs the raw data dir adding to it
+    expected_output = [dict(f.items()) for f in atb_input]
+    for f in expected_output:
+        f["path"] = str(raw_data_dir / f["path"])
+
     mock_download_client = MagicMock()
-    mock_logger = MagicMock()
     with (
         patch("cdm_data_loaders.pipelines.all_the_bacteria.FileDownloader", return_value=mock_download_client),
-        patch("cdm_data_loaders.pipelines.all_the_bacteria.logger", mock_logger),
     ):
+        # get the output from the generator
         output = list(osf_file_downloader(test_settings, atb_file_list))
 
-    for item, filename in zip(atb_file_list, expected_paths, strict=True):
-        assert item["path"] == str(Path(test_settings.raw_data_dir) / filename)
+    # should have a separate call for each file downloaded
+    assert mock_download_client.download.call_count == len(atb_file_list)
 
-    assert output[0].data == [
-        {**f, "path": str(Path(test_settings.raw_data_dir) / f["filename"])} for f in atb_file_list
+    call_list = [c.kwargs for c in mock_download_client.download.call_args_list]
+    expected_calls = [
+        {
+            "url": f["url"],
+            "destination": raw_data_dir / f["path"],
+            "expected_checksum": f["md5"],
+            "checksum_fn": "md5",
+        }
+        for f in atb_input
     ]
+    assert call_list == expected_calls
 
-    assert mock_download_client.download.call_count == len(expected_calls)
+    # output from dlt.mark.with_table_name
+    assert output[0].data == expected_output
+    # the input args are mutated in place
+    assert atb_file_list == expected_output
 
-    for url, filename, checksum in expected_calls:
-        mock_download_client.download.assert_any_call(
-            url,
-            Path(test_settings.raw_data_dir) / filename,
-            expected_checksum=checksum,
-            checksum_fn="md5",
-        )
-
-    mock_logger.assert_not_called()
     # no logs should be emitted for successful downloads
     assert caplog.records == []
 
 
 @pytest.mark.parametrize(
-    ("atb_file_list", "download_side_effect", "expected_exceptions", "expected_paths"),
+    ("atb_file_list", "expected_exceptions", "expected_paths"),
     [
         (
             [
-                {"filename": "good_file.txt", "url": "https://osf.io/good", "md5": "md5sum1"},
-                {"filename": "great_file.txt", "url": "https://osf.io/great", "md5": "md5sum2"},
-                {"filename": "bad_file.txt", "url": "https://osf.io/bad", "md5": "badmd5"},
+                {
+                    "project": "AllTheBacteria/One",
+                    "filename": "Two/good_file.txt",
+                    "url": "https://osf.io/good",
+                    "md5": "md5sum1",
+                },
+                {
+                    "project": "AllTheBacteria/One/Two",
+                    "filename": "great_file.txt",
+                    "url": "https://osf.io/great",
+                    "md5": "md5sum2",
+                },
+                {
+                    "project": "AllTheBacteria/One",
+                    "filename": "fail.txt",
+                    "url": "https://osf.io/fail",
+                    "md5": "badmd5",
+                },
             ],
-            lambda url, _save_path, **_kwargs: (
-                (_ for _ in ()).throw(RuntimeError("download failed")) if url == "https://osf.io/bad" else None
-            ),
-            ["Could not download file from https://osf.io/bad: download failed"],
-            {"good_file.txt": True, "great_file.txt": True, "bad_file.txt": False},
+            ["Could not download file from https://osf.io/fail: Loser!"],
+            {"Two/good_file.txt": True, "great_file.txt": True, "fail.txt": False},
         ),
         (
             [
-                {"filename": "bad_file.txt", "url": "https://osf.io/bad", "md5": "badmd5"},
-                {"filename": "even_worse.txt", "url": "https://osf.io/even_worse", "md5": "badmd5"},
+                {"project": "Dud", "filename": "bad_file.txt", "url": "https://osf.io/bad", "md5": "badmd5"},
+                {
+                    "project": "Dud",
+                    "filename": "also_very_bad.txt",
+                    "url": "https://osf.io/also_very_bad",
+                    "md5": "badmd5",
+                },
             ],
-            lambda _url, _save_path, **_kwargs: (_ for _ in ()).throw(Exception("Boom!")),
             [
-                "Could not download file from https://osf.io/bad: Boom!",
-                "Could not download file from https://osf.io/even_worse: Boom!",
+                "Could not download file from https://osf.io/bad: BOOM!",
+                "Could not download file from https://osf.io/also_very_bad: BOOM!",
             ],
-            {"bad_file.txt": False, "even_worse.txt": False},
+            {"bad_file.txt": False, "also_very_bad.txt": False},
         ),
     ],
 )
 def test_osf_file_downloader_error_handling(
     test_settings: AtbSettings,
     atb_file_list: list[dict[str, Any]],
-    download_side_effect: Callable,
     expected_exceptions: list[str],
     expected_paths: dict[str, bool],
+    caplog: pytest.LogCaptureFixture,
 ) -> None:
     """Ensure that errors during file download are handled correctly."""
     mock_download_client = MagicMock()
-    mock_download_client.download.side_effect = download_side_effect
-    mock_logger = MagicMock()
+
+    def file_downloader_boom(**args) -> None:  # noqa: ANN003
+        if "url" in args:
+            if "bad" in args["url"]:
+                msg = "BOOM!"
+                raise ValueError(msg)
+            if "fail" in args["url"]:
+                msg_0 = "Loser!"
+                raise RuntimeError(msg_0)
+
+    mock_download_client.download.side_effect = file_downloader_boom
 
     with (
         patch("cdm_data_loaders.pipelines.all_the_bacteria.FileDownloader", return_value=mock_download_client),
-        patch("cdm_data_loaders.pipelines.all_the_bacteria.logger", mock_logger),
     ):
         list(osf_file_downloader(test_settings, atb_file_list))
 
+    raw_data_dir = Path(test_settings.raw_data_dir)
+    expected_file_names = {
+        "Two/good_file.txt": str(raw_data_dir / "One/Two/good_file.txt"),
+        "great_file.txt": str(raw_data_dir / "One/Two/great_file.txt"),
+    }
+
     for item in atb_file_list:
         if item["filename"] in expected_paths and expected_paths[item["filename"]]:
-            assert item["path"] == str(Path(test_settings.raw_data_dir) / item["filename"])
+            assert item["path"] == expected_file_names[item["filename"]]
         else:
             assert "path" not in item
 
-    # FIXME: why is caplog not working here? Ideally this should use caplog instead of a mock logger.
-    exception_call_args = [call.args[0] for call in mock_logger.exception.call_args_list]
-    assert exception_call_args == expected_exceptions
+    log_messages = [r.message for r in caplog.records]
+    assert expected_exceptions == log_messages
 
 
 def test_run_atb_pipeline(

--- a/tests/pipelines/test_core.py
+++ b/tests/pipelines/test_core.py
@@ -794,7 +794,7 @@ def test_integration_empty_input_pipeline_run_still_called(
 
 
 # test run_cli + stream_xml_file_resource + run_pipeline
-@pytest.mark.use_fixtures("patched_io_empty_batcher", "test_bfi_settings")
+@pytest.mark.usefixtures("patched_io_empty_batcher", "test_bfi_settings")
 def test_integration_run_cli_calls_pipeline_fn_with_config(mock_dlt: MagicMock) -> None:
     """The exact config produced by run_cli reaches stream_xml_file_resource unchanged."""
     received: list[CtsSettings] = []

--- a/tests/pipelines/test_core.py
+++ b/tests/pipelines/test_core.py
@@ -66,7 +66,7 @@ def test_cts_settings() -> CtsSettings:
     params=[
         pytest.param({"input_dir": "/fake/input"}, id="default"),
         pytest.param(
-            {"input_dir": "/path/to/dir", "use_destination": "s3", "start_at": 15, "output": "/some/dir"},
+            {"input_dir": "/path/to/dir", "use_destination": "local_fs", "start_at": 15, "output": "/some/dir"},
             id="alt",
         ),
     ]
@@ -372,9 +372,8 @@ def test_run_cli_no_slack_env_var_when_vars_missing(
 
 # dlt.config state after successful run
 @pytest.mark.parametrize("settings_cls", SETTINGS_CLASSES)
-@pytest.mark.parametrize("use_destination", VALID_DESTINATIONS)
 @pytest.mark.parametrize("dev_mode", [True, False])
-@pytest.mark.parametrize("output", ["/some/path", "s3://bucket/whatever"])
+@pytest.mark.parametrize(("use_destination", "output"), [("local_fs", "/some/path"), ("s3", "s3://bucket/whatever")])
 def test_run_cli_dlt_config_updated_after_success(
     dlt_config: dict[str, Any], settings_cls: type[CtsSettings], dev_mode: bool, use_destination: str, output: str
 ) -> None:
@@ -413,7 +412,7 @@ def test_run_pipeline_destination_pipeline_pipeline_run_kwargs_set(
     pipeline_run_kwargs: dict[str, Any] | None,
 ) -> None:
     """Ensure a non-empty output sets the correct dlt.config bucket_url key."""
-    settings = make_batched_settings(input_dir="/i", output="/custom/output", use_destination="s3")
+    settings = make_batched_settings(input_dir="/i", output="/custom/output", use_destination="local_fs")
     fake_resource = MagicMock()
     run_pipeline(
         settings,
@@ -425,7 +424,7 @@ def test_run_pipeline_destination_pipeline_pipeline_run_kwargs_set(
     assert_pipeline_run_correctly(
         mock_dlt,
         fake_resource,
-        "s3",
+        "local_fs",
         destination_kwargs,
         pipeline_kwargs,
         pipeline_run_kwargs,

--- a/tests/pipelines/test_cts_defaults.py
+++ b/tests/pipelines/test_cts_defaults.py
@@ -283,45 +283,6 @@ def test_settings_trailing_slash_stripped(
     assert getattr(s, field_name) == expected
 
 
-@pytest.mark.parametrize(
-    "output",
-    list(OUTPUT_PATHS),
-)
-@pytest.mark.parametrize("settings_cls", SETTINGS_CLASSES)
-@pytest.mark.parametrize("use_destination", VALID_DESTINATIONS)
-def test_settings_pipeline_dir_local_only_output_dir_s3(
-    settings_cls: type[CtsSettings],
-    use_destination: str,
-    output: str,
-    dlt_config: dict[str, Any],
-) -> None:
-    """Ensure that the output_dir can only be used for pipeline metadata locally.
-
-    The output_dir parameter overrides what is specified in use_destination.
-    """
-    if OUTPUT_PATHS[output][S3] or (not output and use_destination == "s3"):
-        with pytest.raises(ValueError, match="It is not currently possible to have the pipeline directory on s3"):
-            make_settings(
-                settings_cls,
-                dlt_config=dlt_config,
-                use_destination=use_destination,
-                output=output,
-                use_output_dir_for_pipeline_metadata=True,
-            )
-    else:
-        # settings should be fine!
-        s = make_settings(
-            settings_cls,
-            dlt_config=dlt_config,
-            use_destination=use_destination,
-            output=output,
-            use_output_dir_for_pipeline_metadata=True,
-        )
-        assert s.pipeline_dir
-        assert not s.pipeline_dir.startswith("s3://")
-        assert not s.pipeline_dir.startswith("s3a://")
-
-
 # All arguments set, using CliApp.run
 @pytest.mark.parametrize("settings_cls", SETTINGS_CLASSES)
 @pytest.mark.parametrize("dev_mode", ARG_ALIASES["dev_mode"])
@@ -409,7 +370,7 @@ def test_settings_reconcile_with_dlt_config_output_resolved_from_dlt_config_buck
     assert s.output == dlt_config[f"destination.{use_destination}.bucket_url"]
 
 
-# properties derived from self.output
+# properties derived from self.output: pipeline_dir and raw_data_dir
 @pytest.mark.parametrize("settings_cls", SETTINGS_CLASSES)
 @pytest.mark.parametrize(
     "output",
@@ -423,7 +384,12 @@ def test_settings_generate_pipeline_raw_data_dirs(
     use_output_dir_for_pipeline_metadata: bool,
     use_destination: str,
 ) -> None:
-    """Ensure that the correct paths are generated for pipeline and raw data directories."""
+    """Ensure that the correct paths are generated for pipeline and raw data directories.
+
+    Ensure that the destination set in `use_destination` concurs with any output path set.
+
+    Ensure that pipeline directories cannot be set if the output is set to s3.
+    """
     make_settings_args = {
         "output": output,
         "use_destination": use_destination,
@@ -439,6 +405,13 @@ def test_settings_generate_pipeline_raw_data_dirs(
     if settings_cls == BatchedFileInputSettings:
         expected["start_at"] = DEFAULT_START_AT
 
+    if (OUTPUT_PATHS[expected["output"]][S3] and use_destination == "local_fs") or (
+        OUTPUT_PATHS[expected["output"]][S3] is False and use_destination == "s3"
+    ):
+        with pytest.raises(ValueError, match="Mismatch between output location and use_destination"):
+            make_settings_autofill_config(settings_cls, **make_settings_args)
+        return
+
     if use_output_dir_for_pipeline_metadata and OUTPUT_PATHS[expected["output"]][S3] is True:
         # can't have pipeline dir on s3
         with pytest.raises(ValueError, match="It is not currently possible to have the pipeline directory on s3"):
@@ -449,5 +422,78 @@ def test_settings_generate_pipeline_raw_data_dirs(
 
     # get the pipeline and raw data dirs from OUTPUT_PATHS
     expected["raw_data_dir"] = OUTPUT_PATHS[expected["output"]][RAW]
+    # No pipeline_dir if use_output_dir_for_pipeline_metadata is not set
+    expected["pipeline_dir"] = OUTPUT_PATHS[expected["output"]][PIPE] if use_output_dir_for_pipeline_metadata else None
+    check_settings(s, expected)
+
+
+@pytest.mark.parametrize("settings_cls", SETTINGS_CLASSES)
+@pytest.mark.parametrize(
+    "output",
+    list(OUTPUT_PATHS.keys()),
+)
+@pytest.mark.parametrize("use_output_dir_for_pipeline_metadata", [True, False])
+@pytest.mark.parametrize("use_destination", VALID_DESTINATIONS)
+def test_cli_app_run_generate_pipeline_raw_data_dirs(
+    settings_cls: type[CtsSettings],
+    output: str,
+    use_output_dir_for_pipeline_metadata: bool,
+    use_destination: str,
+    dlt_config: dict[str, Any],
+) -> None:
+    """Ensure that the correct paths are generated for pipeline and raw data directories.
+
+    Ensure that the destination set in `use_destination` concurs with any output path set.
+
+    Ensure that pipeline directories cannot be set if the output is set to s3.
+    """
+    make_settings_args = [
+        "--output",
+        output,
+        "--use_destination",
+        use_destination,
+        "--use_output_dir_for_pipeline_metadata",
+        str(use_output_dir_for_pipeline_metadata),
+    ]
+
+    expected = {
+        **DEFAULT_CTS_SETTINGS_RECONCILED,
+        "use_destination": use_destination,
+        "use_output_dir_for_pipeline_metadata": use_output_dir_for_pipeline_metadata,
+        "output": DESTINATION_TO_OUTPUT[use_destination] if output == "" else OUTPUT_PATHS[output][OUT],
+    }
+    if settings_cls == BatchedFileInputSettings:
+        expected["start_at"] = DEFAULT_START_AT
+
+    if (OUTPUT_PATHS[expected["output"]][S3] and use_destination == "local_fs") or (
+        OUTPUT_PATHS[expected["output"]][S3] is False and use_destination == "s3"
+    ):
+        with pytest.raises(ValueError, match="Mismatch between output location and use_destination"):
+            CliApp.run(
+                settings_cls,
+                dlt_config=dlt_config,
+                cli_args=make_settings_args,
+            )
+        return
+
+    if use_output_dir_for_pipeline_metadata and OUTPUT_PATHS[expected["output"]][S3] is True:
+        # can't have pipeline dir on s3
+        with pytest.raises(ValueError, match="It is not currently possible to have the pipeline directory on s3"):
+            CliApp.run(
+                settings_cls,
+                dlt_config=dlt_config,
+                cli_args=make_settings_args,
+            )
+        return
+
+    s = CliApp.run(
+        settings_cls,
+        dlt_config=dlt_config,
+        cli_args=make_settings_args,
+    )
+
+    # get the pipeline and raw data dirs from OUTPUT_PATHS
+    expected["raw_data_dir"] = OUTPUT_PATHS[expected["output"]][RAW]
+    # No pipeline_dir if use_output_dir_for_pipeline_metadata is not set
     expected["pipeline_dir"] = OUTPUT_PATHS[expected["output"]][PIPE] if use_output_dir_for_pipeline_metadata else None
     check_settings(s, expected)

--- a/tests/pipelines/test_cts_defaults.py
+++ b/tests/pipelines/test_cts_defaults.py
@@ -1,6 +1,5 @@
 """Tests for the Settings objects used by DLT pipelines."""
 
-from pathlib import Path
 from typing import Any
 
 import pytest
@@ -17,18 +16,45 @@ from cdm_data_loaders.pipelines.cts_defaults import (
 from tests.pipelines.conftest import (
     DEFAULT_BATCH_FILE_SETTINGS_RECONCILED,
     DEFAULT_CTS_SETTINGS_RECONCILED,
+    DESTINATION_TO_OUTPUT,
     TEST_BATCH_FILE_SETTINGS,
     TEST_BATCH_FILE_SETTINGS_RECONCILED,
     TEST_CTS_SETTINGS,
     TEST_CTS_SETTINGS_RECONCILED,
     check_settings,
     make_settings,
+    make_settings_autofill_config,
 )
 
 SETTINGS_CLASSES = [CtsSettings, BatchedFileInputSettings]
 
 INVALID_DESTINATIONS = ["gcs", "filesystem", "", "LocalFs", "S3"]
 INVALID_BOOLEAN_VALUES = ["what", "yep", "nope", "2", -1, "", " ", "wtf", None]
+
+S3 = "is_s3"
+OUT = "output"
+RAW = "raw_data_dir"
+PIPE = "pipeline_dir"
+
+
+# manually specify to avoid recapitulating logic
+OUTPUT_PATHS: dict[str, dict[str, Any]] = {
+    "": {S3: False, OUT: "", RAW: "raw_data", PIPE: ".dlt_conf"},
+    "/": {S3: False, OUT: "/", RAW: "/raw_data", PIPE: "/.dlt_conf"},
+    # from destination.local_fs
+    "/output_dir": {S3: False, OUT: "/output_dir", RAW: "/output_dir/raw_data", PIPE: "/output_dir/.dlt_conf"},
+    "/output/dir": {S3: False, OUT: "/output/dir", RAW: "/output/dir/raw_data", PIPE: "/output/dir/.dlt_conf"},
+    "s3/some/path/": {S3: False, OUT: "s3/some/path", RAW: "s3/some/path/raw_data", PIPE: "s3/some/path/.dlt_conf"},
+    # normalised form of the above
+    "s3/some/path": {S3: False, OUT: "s3/some/path", RAW: "s3/some/path/raw_data", PIPE: "s3/some/path/.dlt_conf"},
+    "s3a://bucket/key": {S3: True, OUT: "s3a://bucket/key", RAW: "s3a://bucket/key/raw_data", PIPE: None},
+    "s3://test/bucket/": {S3: True, OUT: "s3://test/bucket", RAW: "s3://test/bucket/raw_data", PIPE: None},
+    # normalised from above
+    "s3://test/bucket": {S3: True, OUT: "s3://test/bucket", RAW: "s3://test/bucket/raw_data", PIPE: None},
+    # from destination.s3
+    "s3://some/s3/bucket": {S3: True, OUT: "s3://some/s3/bucket", RAW: "s3://some/s3/bucket/raw_data", PIPE: None},
+}
+
 
 # a whole load of values that Pydantic will coerce to a boolean
 TRUE_FALSE_VALUES = [
@@ -257,6 +283,45 @@ def test_settings_trailing_slash_stripped(
     assert getattr(s, field_name) == expected
 
 
+@pytest.mark.parametrize(
+    "output",
+    list(OUTPUT_PATHS),
+)
+@pytest.mark.parametrize("settings_cls", SETTINGS_CLASSES)
+@pytest.mark.parametrize("use_destination", VALID_DESTINATIONS)
+def test_settings_pipeline_dir_local_only_output_dir_s3(
+    settings_cls: type[CtsSettings],
+    use_destination: str,
+    output: str,
+    dlt_config: dict[str, Any],
+) -> None:
+    """Ensure that the output_dir can only be used for pipeline metadata locally.
+
+    The output_dir parameter overrides what is specified in use_destination.
+    """
+    if OUTPUT_PATHS[output][S3] or (not output and use_destination == "s3"):
+        with pytest.raises(ValueError, match="It is not currently possible to have the pipeline directory on s3"):
+            make_settings(
+                settings_cls,
+                dlt_config=dlt_config,
+                use_destination=use_destination,
+                output=output,
+                use_output_dir_for_pipeline_metadata=True,
+            )
+    else:
+        # settings should be fine!
+        s = make_settings(
+            settings_cls,
+            dlt_config=dlt_config,
+            use_destination=use_destination,
+            output=output,
+            use_output_dir_for_pipeline_metadata=True,
+        )
+        assert s.pipeline_dir
+        assert not s.pipeline_dir.startswith("s3://")
+        assert not s.pipeline_dir.startswith("s3a://")
+
+
 # All arguments set, using CliApp.run
 @pytest.mark.parametrize("settings_cls", SETTINGS_CLASSES)
 @pytest.mark.parametrize("dev_mode", ARG_ALIASES["dev_mode"])
@@ -346,46 +411,43 @@ def test_settings_reconcile_with_dlt_config_output_resolved_from_dlt_config_buck
 
 # properties derived from self.output
 @pytest.mark.parametrize("settings_cls", SETTINGS_CLASSES)
-@pytest.mark.parametrize("output", ["", "/output/dir", "some/convoluted/path/to/dir/"])
+@pytest.mark.parametrize(
+    "output",
+    list(OUTPUT_PATHS.keys()),
+)
 @pytest.mark.parametrize("use_output_dir_for_pipeline_metadata", [True, False])
 @pytest.mark.parametrize("use_destination", VALID_DESTINATIONS)
 def test_settings_generate_pipeline_raw_data_dirs(
     settings_cls: type[CtsSettings],
     output: str,
     use_output_dir_for_pipeline_metadata: bool,
-    dlt_config: dict[str, Any],
     use_destination: str,
 ) -> None:
     """Ensure that the correct paths are generated for pipeline and raw data directories."""
-    s = make_settings(
-        settings_cls,
-        dlt_config=dlt_config,
-        output=output,
-        use_destination=use_destination,
-        use_output_dir_for_pipeline_metadata=use_output_dir_for_pipeline_metadata,
-    )
+    make_settings_args = {
+        "output": output,
+        "use_destination": use_destination,
+        "use_output_dir_for_pipeline_metadata": use_output_dir_for_pipeline_metadata,
+    }
 
     expected = {
         **DEFAULT_CTS_SETTINGS_RECONCILED,
         "use_destination": use_destination,
         "use_output_dir_for_pipeline_metadata": use_output_dir_for_pipeline_metadata,
-        "output": output.rstrip("/") or dlt_config[f"destination.{use_destination}.bucket_url"],
+        "output": DESTINATION_TO_OUTPUT[use_destination] if output == "" else OUTPUT_PATHS[output][OUT],
     }
-
     if settings_cls == BatchedFileInputSettings:
         expected["start_at"] = DEFAULT_START_AT
 
-    # list containing the projected raw_data_dir and pipeline_dir
-    expected_properties = {
-        "": [str(Path(expected["output"]) / "raw_data"), str(Path(expected["output"]) / ".dlt_conf")],
-        "/output/dir": [str(Path("/output/dir") / "raw_data"), str(Path("/output/dir") / ".dlt_conf")],
-        "some/convoluted/path/to/dir/": [
-            str(Path("some/convoluted/path/to/dir") / "raw_data"),
-            str(Path("some/convoluted/path/to/dir") / ".dlt_conf"),
-        ],
-    }
+    if use_output_dir_for_pipeline_metadata and OUTPUT_PATHS[expected["output"]][S3] is True:
+        # can't have pipeline dir on s3
+        with pytest.raises(ValueError, match="It is not currently possible to have the pipeline directory on s3"):
+            make_settings_autofill_config(settings_cls, **make_settings_args)
+        return
 
-    expected["raw_data_dir"] = expected_properties[output][0]
-    expected["pipeline_dir"] = expected_properties[output][1] if use_output_dir_for_pipeline_metadata else None
+    s = make_settings_autofill_config(settings_cls, **make_settings_args)
 
+    # get the pipeline and raw data dirs from OUTPUT_PATHS
+    expected["raw_data_dir"] = OUTPUT_PATHS[expected["output"]][RAW]
+    expected["pipeline_dir"] = OUTPUT_PATHS[expected["output"]][PIPE] if use_output_dir_for_pipeline_metadata else None
     check_settings(s, expected)

--- a/tests/utils/test_s3.py
+++ b/tests/utils/test_s3.py
@@ -11,7 +11,8 @@ import boto3
 import pytest
 from botocore.exceptions import ClientError
 from moto import mock_aws
-from requests.exceptions import ConnectionError as ConnError, HTTPError
+from requests.exceptions import ConnectionError as ConnError
+from requests.exceptions import HTTPError
 
 import cdm_data_loaders.utils.s3 as s3_utils
 from cdm_data_loaders.utils.s3 import (

--- a/tests/utils/test_s3.py
+++ b/tests/utils/test_s3.py
@@ -1,17 +1,19 @@
 """Tests for s3_utils.py using moto to mock AWS S3."""
 
 import functools
+import io
 from collections.abc import Callable, Generator
 from pathlib import Path
 from typing import Any
-from unittest.mock import patch
+from unittest.mock import MagicMock, patch
 
 import boto3
-import botocore
 import pytest
+from botocore.exceptions import ClientError
 from moto import mock_aws
+from requests.exceptions import ConnectionError as ConnError, HTTPError
 
-import cdm_data_loaders.utils.s3 as s3_utils  # adjust to match your module name
+import cdm_data_loaders.utils.s3 as s3_utils
 from cdm_data_loaders.utils.s3 import (
     CDM_LAKE_BUCKET,
     DEFAULT_EXTRA_ARGS,
@@ -19,10 +21,12 @@ from cdm_data_loaders.utils.s3 import (
     delete_object,
     download_file,
     get_s3_client,
+    head_object,
     list_matching_objects,
     object_exists,
     reset_s3_client,
     split_s3_path,
+    stream_to_s3,
     upload_dir,
     upload_file,
 )
@@ -184,6 +188,13 @@ def test_get_s3_client_returns_same_instance() -> None:
     assert s3_utils._s3_client is None  # noqa: SLF001
 
 
+@pytest.mark.s3
+def test_get_s3_client_populates_from_environment() -> None:
+    # set up the environment
+
+    pass
+
+
 # split_s3_path
 
 PATH = "path"
@@ -324,12 +335,19 @@ def test_list_matching_objects_returns_more_than_1000_entries(
 # object_exists
 @pytest.mark.parametrize("protocol", ["", "s3://", "s3a://"])
 @pytest.mark.s3
-def test_object_exists_returns_true_when_present(mock_s3_client: Any, protocol: str) -> None:
+def test_head_object_and_object_exists_true_and_false(mock_s3_client: Any, protocol: str) -> None:
     """Verify that object_exists returns True for an object that exists in the bucket."""
     populate_mock_s3(mock_s3_client, FILES_IN_BUCKETS)
     for bucket, file_list in FILES_IN_BUCKETS.items():
         for f in file_list:
+            output = head_object(f"{protocol}{bucket}/{f}")
+            assert output.get("ResponseMetadata", {}).get("HTTPStatusCode") == 200
             assert object_exists(f"{protocol}{bucket}/{f}") is True
+
+        nonexistent_file = f"{protocol}{bucket}/a-file-i-just-made-up.txt"
+        assert object_exists(nonexistent_file) is False
+        with pytest.raises(ClientError, match=r"An error occurred \(404\) when calling the HeadObject operation"):
+            head_object(nonexistent_file)
 
 
 @pytest.mark.parametrize("s3_path", ["absent", "dir_one", "dir_one/", "dir_one/file1.tnt"])
@@ -392,6 +410,128 @@ def test_upload_file_error(sample_file: Path) -> None:
     """Verify that upload_file raises ValueError when no destination directory is provided."""
     with pytest.raises(ValueError, match="No destination directory"):
         upload_file(sample_file, "")
+
+
+# TODO: Missing tests
+# - Upload failure (S3 error) - returns False
+
+
+def make_mock_requests(
+    content: bytes = b"hello world",
+    status_code: int = 200,
+    content_type: str = "application/octet-stream",
+) -> tuple[MagicMock, MagicMock]:
+    """Build a mock requests module whose .get() returns a mock response."""
+    mock_response = MagicMock()
+    mock_response.status_code = status_code
+    mock_response.raw = io.BytesIO(content)
+    mock_response.raw.decode_content = True
+    mock_response.headers = {
+        "content-type": content_type,
+    }
+    mock_response.raise_for_status = MagicMock()
+    mock_response.__enter__ = lambda s: s
+    mock_response.__exit__ = MagicMock(return_value=False)
+
+    mock_requests = MagicMock()
+    mock_requests.get.return_value = mock_response
+
+    return mock_requests, mock_response
+
+
+UPLOAD_TEST_KEY = "uploads/test-file.pdf"
+UPLOAD_BUCKET_KEY = f"{ALT_BUCKET}/{UPLOAD_TEST_KEY}"
+TEST_URL = "https://example.com/test-file.pdf"
+
+
+def test_stream_to_s3_happy_path(mock_s3_client: Any) -> None:
+    """File content from the HTTP response is stored correctly in S3."""
+    content = b"hello world"
+    mock_requests, _ = make_mock_requests(content=content)
+
+    saved_path = stream_to_s3(TEST_URL, UPLOAD_BUCKET_KEY, mock_requests)
+
+    mock_requests.get.assert_called_once_with(TEST_URL, stream=True)
+
+    # s3 path including bucket returned
+    assert saved_path == UPLOAD_BUCKET_KEY
+
+    result = mock_s3_client.get_object(Bucket=ALT_BUCKET, Key=UPLOAD_TEST_KEY)
+    # check the content is correct
+    assert result["Body"].read() == content
+
+    # new file shows up in list_objects
+    objects = mock_s3_client.list_objects_v2(Bucket=ALT_BUCKET)["Contents"]
+    keys = [obj["Key"] for obj in objects]
+    assert UPLOAD_TEST_KEY in keys
+
+
+@pytest.mark.parametrize("content_type", [None, "application/json", "application/pdf", "text"])
+def test_stream_to_s3_sets_content_type_from_response_headers(mock_s3_client: Any, content_type: str | None) -> None:
+    """ContentType metadata on the S3 object matches the HTTP response header."""
+    content_type_args = {}
+    if content_type:
+        content_type_args["content_type"] = content_type
+    mock_requests, _ = make_mock_requests(**content_type_args)
+
+    stream_to_s3(TEST_URL, UPLOAD_BUCKET_KEY, mock_requests)
+
+    head = mock_s3_client.head_object(Bucket=ALT_BUCKET, Key=UPLOAD_TEST_KEY)
+    assert head["ContentType"] == content_type or "application/octet-stream"
+
+
+def test_stream_to_s3_raises_on_http_error_status(mock_s3_client: Any) -> None:
+    """An HTTP error status causes raise_for_status() to propagate an exception."""
+    mock_requests, mock_response = make_mock_requests(status_code=404)
+    mock_response.raise_for_status.side_effect = HTTPError("404 Not Found")
+
+    with (
+        pytest.raises(HTTPError, match="404 Not Found"),
+    ):
+        stream_to_s3(TEST_URL, UPLOAD_BUCKET_KEY, mock_requests)
+
+    with pytest.raises(ClientError, match="Not Found"):
+        mock_s3_client.head_object(Bucket=ALT_BUCKET, Key=UPLOAD_TEST_KEY)
+
+
+def test_stream_to_s3_raises_on_connection_error(mock_s3_client: Any) -> None:
+    """A network-level failure raises a ConnectionError."""
+    mock_requests, _ = make_mock_requests(status_code=404)
+    mock_requests.get.side_effect = ConnError("Network unreachable")
+
+    with pytest.raises(ConnError, match="Network unreachable"):
+        stream_to_s3(TEST_URL, UPLOAD_BUCKET_KEY, mock_requests)
+
+    with pytest.raises(ClientError, match="Not Found"):
+        mock_s3_client.head_object(Bucket=ALT_BUCKET, Key=UPLOAD_TEST_KEY)
+
+
+# FIXME: don't upload if there is nothing there?
+def test_stream_to_s3_uploads_empty_file(mock_s3_client: Any) -> None:
+    """An empty HTTP response body results in an empty S3 object."""
+    mock_requests, _ = make_mock_requests(content=b"")
+
+    stream_to_s3(TEST_URL, UPLOAD_BUCKET_KEY, mock_requests)
+
+    result = mock_s3_client.get_object(Bucket=ALT_BUCKET, Key=UPLOAD_TEST_KEY)
+    assert result["Body"].read() == b""
+
+
+def test_stream_to_s3_uploads_large_file(mock_s3_client: Any) -> None:
+    """A large payload (>5MB) is uploaded correctly via multipart."""
+    content = b"x" * (6 * 1024 * 1024)  # 6 MB
+    mock_requests, _ = make_mock_requests(content=content)
+
+    stream_to_s3(TEST_URL, UPLOAD_BUCKET_KEY, mock_requests)
+
+    result = mock_s3_client.get_object(Bucket=ALT_BUCKET, Key=UPLOAD_TEST_KEY)
+    assert result["Body"].read() == content
+
+
+@pytest.mark.skip("TODO: add test(s)")
+def test_accepts_custom_requests_implementation() -> None:
+    """A subclassed or alternate requests module works as a drop-in."""
+    # TODO: add test here?
 
 
 @pytest.mark.parametrize("bucket", BUCKETS)
@@ -475,19 +615,26 @@ def test_download_file_does_not_clobber_existing_file_to_mkdir(mock_s3_client: A
 
 
 @pytest.mark.s3
-def test_download_file_does_not_exist(mock_s3_client: Any, tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
+@pytest.mark.usefixtures("mock_s3_client")
+def test_download_file_does_not_exist(tmp_path: Path, capsys: pytest.CaptureFixture) -> None:
     """Ensure that attempting to download a file that does not exist raises an error."""
     bucket = BUCKETS[0]
     key = "to/the/door.txt"
     assert not object_exists(f"{bucket}/{key}")
 
     with pytest.raises(
-        botocore.exceptions.ClientError,
+        ClientError,
         match=r"An error occurred \(404\) when calling the HeadObject",
     ):
         download_file(f"{bucket}/{key}", tmp_path / "file.txt")
 
     assert "File not found" in capsys.readouterr().out
+
+
+# TODO: Missing tests
+# - Non-404 S3 error during head
+# - Error during directory creation (other than FileExistsError)?
+# - version_id parameter behavior
 
 
 # upload_dir
@@ -577,6 +724,26 @@ def test_copy_file(mocked_s3_client_no_checksum: Any, destination: str) -> None:
     assert response["ResponseMetadata"]["HTTPStatusCode"] == 200
 
 
+@pytest.mark.s3
+@pytest.mark.usefixtures("mock_s3_client")
+def test_copy_file_source_object_nonexistent() -> None:
+    """Ensure that the code throws an error if the source object does not exist."""
+    s3_path = f"{CDM_LAKE_BUCKET}/some/path/to/file"
+    assert object_exists(s3_path) is False
+    with pytest.raises(Exception, match="The specified key does not exist"):
+        copy_object(s3_path, f"{CDM_LAKE_BUCKET}/a/different/path/to/file")
+
+
+@pytest.mark.s3
+@pytest.mark.usefixtures("mock_s3_client")
+def test_copy_file_source_bucket_nonexistent() -> None:
+    """Ensure that the code throws an error if the bucket does not exist."""
+    s3_path = "some-bucket/some/path/to/file"
+    assert object_exists(s3_path) is False
+    with pytest.raises(Exception, match="The specified bucket does not exist"):
+        copy_object(s3_path, f"{CDM_LAKE_BUCKET}/a/different/path/to/file")
+
+
 # delete_object
 @pytest.mark.parametrize("bucket", BUCKETS)
 @pytest.mark.parametrize("protocol", ["", "s3://", "s3a://"])
@@ -595,3 +762,14 @@ def test_delete_object_removes_object(mock_s3_client: Any, bucket: str, protocol
     resp = delete_object(s3_path)
     assert object_exists(s3_path) is False
     assert resp.get("ResponseMetadata", {}).get("HTTPStatusCode") == 204
+
+
+# delete_object - bucket does not exist
+@pytest.mark.s3
+@pytest.mark.usefixtures("mock_s3_client")
+def test_delete_object_no_such_bucket() -> None:
+    """Verify that delete_object removes the object from the specified bucket."""
+    s3_path = "fake-bucket/to/delete.txt"
+    assert object_exists(s3_path) is False
+    with pytest.raises(Exception, match="The specified bucket does not exist"):
+        delete_object(s3_path)


### PR DESCRIPTION
- add a pattern file for getting specific files from the ATB dataset
- upload files directly to s3 instead of downloading to the local file system and then uploading to s3
- a few more bits of functionality for the s3 client, including HTTP => s3