### PR TITLE
Set Trivy scan timeout to 15 minutes

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -49,6 +49,7 @@ jobs:
                   template: "@/contrib/sarif.tpl"
                   output: "trivy-results.sarif"
                   severity: "CRITICAL,HIGH"
+                  timeout: 15m
 
             - name: Upload Trivy scan results to GitHub Security tab
               uses: github/codeql-action/upload-sarif@v3


### PR DESCRIPTION
Increase the timeout for Trivy scan results.

# Description of PR purpose/changes

* Please include a summary of the change and which issue is fixed.
* Please also include relevant motivation and context.
* List any dependencies that are required for this change.

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run Ruff `format` to format my code
- [ ] I have run Ruff `check` and fixed any errors that it uncovered
- [ ] Any dependent changes have been merged and published in downstream modules

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release.
- [ ] [README](/README.md) has been updated for each release.
