### PR TITLE
Replace MinIO with CEPH for testing

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -24,24 +24,30 @@ jobs:
             - name: Checkout
               uses: actions/checkout@v6
 
-            - name: Set up Docker Buildx
-              uses: docker/setup-buildx-action@v3
-
-            - name: Build integration test image
-              uses: docker/build-push-action@v6
-              with:
-                  context: .
-                  load: true
-                  tags: cdm-data-loaders-integration-tests:latest
-                  cache-from: type=gha
-                  cache-to: type=gha,mode=max
-
             - name: Run integration tests
               run: |
                   docker compose up \
-                    --no-build \
+                    --build \
                     --abort-on-container-exit \
                     --exit-code-from integration-tests
+
+            - name: Capture compose diagnostics on failure
+              if: failure()
+              run: |
+                  echo "=== docker compose ps ==="
+                  docker compose ps -a || true
+
+                  echo "=== ceph logs ==="
+                  docker logs cdm-data-loaders-ceph-1 || true
+
+                  echo "=== integration test logs ==="
+                  docker logs cdm-data-loaders-integration-tests-1 || true
+
+                  echo "=== ceph inspect state ==="
+                  docker inspect cdm-data-loaders-ceph-1 --format '{{json .State}}' || true
+
+                  echo "=== ceph health state ==="
+                  docker inspect cdm-data-loaders-ceph-1 --format '{{json .State.Health}}' || true
 
             - name: Tear down
               if: always()

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Repo for CDM input data loading and wrangling
   - [Development](#development)
     - [Spark and other non-python dependencies](#spark-and-other-non-python-dependencies)
     - [Tests](#tests)
-      - [Integration tests (MinIO + NCBI FTP)](#integration-tests-minio--ncbi-ftp)
+      - [Integration tests (CEPH + NCBI FTP)](#integration-tests-ceph--ncbi-ftp)
   - [Loading genomes, contigs, and features](#loading-genomes-contigs-and-features)
   - [Running bbmap stats and checkm2 on genome or contigset files](#running-bbmap-stats-and-checkm2-on-genome-or-contigset-files)
 
@@ -162,17 +162,17 @@ To generate coverage for the tests, run
 The standard python `coverage` package is used and coverage can be generated as html or other formats by changing the parameters.
 
 
-#### Integration tests (MinIO + NCBI FTP)
+#### Integration tests (CEPH + NCBI FTP)
 
-End-to-end integration tests for the NCBI assembly pipeline live in `tests/integration/`. They exercise the full flow — manifest diffing, FTP download, S3 promote/archive — against a locally running [MinIO](https://min.io/) container and the real NCBI FTP server.
+End-to-end integration tests for the NCBI assembly pipeline live in `tests/integration/`. They exercise the full flow — manifest diffing, FTP download, S3 promote/archive — against a locally running [CEPH](https://ceph.io/) container and the real NCBI FTP server.
 
 **Requirements:**
-- Docker (for MinIO)
+- Docker or Podman (for CEPH)
 - Network access to `ftp.ncbi.nlm.nih.gov`
 
 **Running with Docker Compose (easiest)**
 
-The [docker-compose.yml](docker-compose.yml) at the repo root defines both a MinIO service and the integration test runner. To build the image, start MinIO, and run the integration tests in one command:
+The [docker-compose.yml](docker-compose.yml) at the repo root defines both a CEPH service and the integration test runner. To build the image, start CEPH, and run the integration tests in one command:
 
 ```sh
 docker compose up --build --abort-on-container-exit
@@ -186,18 +186,19 @@ docker compose down --volumes
 
 **Running manually**
 
-If you prefer to run the tests directly against a local MinIO instance (e.g. for faster iteration during development), follow the steps below.
+If you prefer to run the tests directly against a local CEPH instance (e.g. for faster iteration during development), follow the steps below.
 
-**1. Start MinIO locally:**
+**1. Start CEPH locally:**
 
 ```sh
 docker run -d \
-  --name minio \
-  -p 9000:9000 \
-  -p 9001:9001 \
-  -e MINIO_ROOT_USER=minioadmin \
-  -e MINIO_ROOT_PASSWORD=minioadmin \
-  minio/minio:RELEASE.2025-02-28T09-55-16Z server /data --console-address ":9001"
+  --name ceph \
+  -p 9000:8080 \
+  -p 9001:8443 \
+  -e RGW_PORT=8080 \
+  -e RGW_ACCESS_KEY=test_access_key \
+  -e RGW_SECRET_KEY=test_access_secret \
+  ghcr.io/kbasetest/ceph-rgw-test-image:0.1.5
 ```
 
 **2. Run the integration tests:**
@@ -206,16 +207,16 @@ docker run -d \
 > uv run pytest tests/integration/ -m integration -v
 ```
 
-Tests are automatically skipped when MinIO is not reachable, so the default `uv run pytest` will never fail due to a missing MinIO instance.
+Tests are automatically skipped when CEPH is not reachable, so the default `uv run pytest` will never fail due to a missing CEPH instance.
 
 **3. Inspect results:**
 
-Buckets are **not** cleaned up after tests. Browse the MinIO console at [http://localhost:9001](http://localhost:9001) (login: `minioadmin` / `minioadmin`) to inspect the final state of each test bucket. Each test method creates its own bucket (e.g. `integ-test-promote-dry-run`).
+Buckets are **not** cleaned up after tests. Browse the CEPH console at [http://localhost:9001](http://localhost:9001) (login: `admin` / `admin`) to inspect the final state of each test bucket. Each test method creates its own bucket (e.g. `integ-test-promote-dry-run`).
 
-**4. Stop MinIO when done:**
+**4. Stop CEPH when done:**
 
 ```sh
-docker stop minio && docker rm minio
+docker stop ceph && docker rm ceph
 ```
 
 > **Note:** These tests download real assemblies from NCBI FTP and are inherently slow (~30–60s per assembly). They are also marked `slow_test` so you can exclude them independently: `uv run pytest -m "not slow_test"`.

--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ Tests are automatically skipped when CEPH is not reachable, so the default `uv r
 
 **3. Inspect results:**
 
-Buckets are **not** cleaned up after tests. Browse the CEPH console at [http://localhost:9001](http://localhost:9001) (login: `admin` / `admin`) to inspect the final state of each test bucket. Each test method creates its own bucket (e.g. `integ-test-promote-dry-run`).
+Buckets are **not** cleaned up after tests. The CEPH dashboard at [http://localhost:9001](http://localhost:9001) (login: `admin` / `admin`) does not support inspecting bucket contents; use the CLI below (e.g. `scripts/s3_local.py ls/head`) to inspect the final state of each test bucket. Each test method creates its own bucket (e.g. `integ-test-promote-dry-run`).
 
 **4. Stop CEPH when done:**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,44 +1,31 @@
 services:
-  minio:
-    image: quay.io/minio/minio:latest
-    command: server /data --console-address ":9001"
+  ceph:
+    image: ghcr.io/kbasetest/ceph-rgw-test-image:0.1.5
     environment:
-      MINIO_ROOT_USER: minioadmin
-      MINIO_ROOT_PASSWORD: minioadmin
+      RGW_PORT: "8080"
+      RGW_ACCESS_KEY: test_access_key
+      RGW_SECRET_KEY: test_access_secret
     ports:
-      - "9000:9000"
-      - "9001:9001"
+      - "9000:8080"
+      - "9001:8443"
     healthcheck:
-      test: [ "CMD", "mc", "ready", "local" ]
-      interval: 5s
+      # Mark healthy only when the RGW/S3 HTTP endpoint is reachable.
+      test: [ "CMD-SHELL", "curl -fsS http://127.0.0.1:8080/ >/dev/null || wget -q -O- http://127.0.0.1:8080/ >/dev/null" ]
+      interval: 10s
       timeout: 5s
-      retries: 5
+      retries: 3
+      start_period: 30s
 
   integration-tests:
     image: cdm-data-loaders-integration-tests:latest
     build:
       context: .
     depends_on:
-      minio:
+      ceph:
         condition: service_healthy
     environment:
-      AWS_ENDPOINT_URL: http://minio:9000
-      AWS_ACCESS_KEY_ID: minioadmin
-      AWS_SECRET_ACCESS_KEY: minioadmin
-    entrypoint:
-      - /bin/sh
-      - -c
-      - |
-        attempts=0
-        until python3 -c "
-        import urllib.request, os
-        urllib.request.urlopen(os.environ['AWS_ENDPOINT_URL'] + '/minio/health/live', timeout=1)
-        " 2>/dev/null; do
-          attempts=$$((attempts + 1))
-          if [ "$$attempts" -ge 30 ]; then
-            echo 'Timed out waiting for MinIO.' && exit 1
-          fi
-          echo 'Waiting for MinIO...' && sleep 1
-        done
-        exec /app/scripts/entrypoint.sh integration_test
+      AWS_ENDPOINT_URL: http://ceph:8080
+      AWS_ACCESS_KEY_ID: test_access_key
+      AWS_SECRET_ACCESS_KEY: test_access_secret
+    entrypoint: [ "/app/scripts/entrypoint.sh", "integration_test" ]
     command: []

--- a/docs/ncbi_ftp_e2e_walkthrough.md
+++ b/docs/ncbi_ftp_e2e_walkthrough.md
@@ -96,10 +96,7 @@ docker run -d \
 (Note that a similar service is included in the `docker-compose` configuration file at the root of
 this repository that is used in CI test workflows.)
 
-Create a test bucket via the [CEPH console](http://localhost:9001)
-(login: `admin` / `admin`), or from the command line using the
-included `scripts/s3_local.py` helper (requires no extra installs — only
-`boto3` which is already a project dependency):
+Create test buckets from the command line using the included `scripts/s3_local.py` helper (requires no extra installs — only `boto3` which is already a project dependency):
 
 ```sh
 uv run python scripts/s3_local.py mb s3://cdm-lake

--- a/docs/ncbi_ftp_e2e_walkthrough.md
+++ b/docs/ncbi_ftp_e2e_walkthrough.md
@@ -395,7 +395,7 @@ cdm-lake/
 
 ## 5. Inspect results in CEPH
 
-Browse the [CEPH console](http://localhost:9001) or use the CLI:
+Use the CLI to inspect the final state of the store:
 
 ```sh
 # List final Lakehouse objects

--- a/docs/ncbi_ftp_e2e_walkthrough.md
+++ b/docs/ncbi_ftp_e2e_walkthrough.md
@@ -1,7 +1,7 @@
 # NCBI FTP Pipeline — Local End-to-End Walkthrough
 
 Step-by-step instructions for running a small (≤ 10 assembly) end-to-end sync
-of NCBI RefSeq records against a local MinIO container.  The walkthrough uses
+of NCBI RefSeq records against a local CEPH container.  The walkthrough uses
 the two existing Jupyter notebooks for Phases 1 and 3, and the project's Docker
 image for the Phase 2 download step.
 
@@ -80,23 +80,24 @@ s3://{STAGING_BUCKET}/{STAGING_KEY_PREFIX}raw_data/{GCF|GCA}/{nnn}/{nnn}/{nnn}/{
 
 ### Local testing
 
-### Start MinIO
+### Start CEPH
 
 ```sh
 docker run -d \
-  --name minio \
-  -p 9000:9000 \
-  -p 9001:9001 \
-  -e MINIO_ROOT_USER=minioadmin \
-  -e MINIO_ROOT_PASSWORD=minioadmin \
-  minio/minio:RELEASE.2025-02-28T09-55-16Z server /data --console-address ":9001"
+  --name ceph \
+  -p 9000:8080 \
+  -p 9001:8443 \
+  -e RGW_PORT=8080 \
+  -e RGW_ACCESS_KEY=test_access_key \
+  -e RGW_SECRET_KEY=test_access_secret \
+  ghcr.io/kbasetest/ceph-rgw-test-image:0.1.5
 ```
 
 (Note that a similar service is included in the `docker-compose` configuration file at the root of
 this repository that is used in CI test workflows.)
 
-Create a test bucket via the [MinIO console](http://localhost:9001)
-(login: `minioadmin` / `minioadmin`), or from the command line using the
+Create a test bucket via the [CEPH console](http://localhost:9001)
+(login: `admin` / `admin`), or from the command line using the
 included `scripts/s3_local.py` helper (requires no extra installs — only
 `boto3` which is already a project dependency):
 
@@ -142,10 +143,10 @@ Open `notebooks/ncbi_ftp_manifest.ipynb` in JupyterLab or VS Code.
 | `STORE_KEY_PREFIX`    | `"tenant-general-warehouse/kbase/datasets/ncbi/"` | S3 key prefix | default Lakehouse path prefix    |
 | `OUTPUT_DIR`          | `Path("output")`                 | local path | keep as-is (local directory)                        |
 
-### Initialise the S3 client for MinIO
+### Initialise the S3 client for CEPH
 
 If you set `PREVIOUS_SUMMARY_URI`, `SNAPSHOT_UPLOAD_URI`, `LAKEHOUSE_BUCKET`,
-or `STAGING_URI` to point at your local MinIO, you must initialise
+or `STAGING_URI` to point at your local CEPH, you must initialise
 the S3 client **before** running the cells that use them.  Insert a new cell
 after Cell 1 (Imports) with:
 
@@ -155,8 +156,8 @@ from cdm_data_loaders.utils.s3 import get_s3_client, reset_s3_client
 reset_s3_client()
 get_s3_client({
     "endpoint_url": "http://localhost:9000",
-    "aws_access_key_id": "minioadmin",
-    "aws_secret_access_key": "minioadmin",
+    "aws_access_key_id": "test_access_key",
+    "aws_secret_access_key": "test_access_secret",
 })
 ```
 
@@ -229,7 +230,7 @@ can stage them into the container.  For local testing, set
 `STAGING_URI = None` (the default) and copy the manifest manually in
 Step 3b below.
 
-If you are testing against MinIO and want to exercise the S3 upload path:
+If you are testing against CEPH and want to exercise the S3 upload path:
 
 ```python
 STAGING_URI = "s3://cdm-lake/staging/run1/"
@@ -321,10 +322,10 @@ the FTP server's `md5checksums.txt`.
 >   --threads 2 --limit 10
 > ```
 
-### 3d. Upload staged files to MinIO
+### 3d. Upload staged files to CEPH
 
 The download step writes to the local filesystem.  To feed Phase 3 we need
-to upload the staged files into MinIO under a staging prefix:
+to upload the staged files into CEPH under a staging prefix:
 
 ```sh
 uv run python scripts/s3_local.py cp notebooks/staging/raw_data/ s3://cts/staging/run1/raw_data/
@@ -356,10 +357,10 @@ Open `notebooks/ncbi_ftp_promote.ipynb`.
 | `LAKEHOUSE_KEY_PREFIX`  | `"tenant-general-warehouse/kbase/datasets/ncbi/"`    | S3 key prefix | keep default                         |
 | `DRY_RUN`               | `True`                                               | bool   | **start with dry-run!**                     |
 
-### Initialise the S3 client for MinIO
+### Initialise the S3 client for CEPH
 
 The notebook calls `get_s3_client()` which, by default, tries to import
-credentials from `berdl_notebook_utils`.  For local MinIO you need to
+credentials from `berdl_notebook_utils`.  For local CEPH you need to
 initialise the client manually **before** running Cell 4.  Insert a new cell
 after Cell 2 (Imports) with:
 
@@ -369,8 +370,8 @@ from cdm_data_loaders.utils.s3 import get_s3_client, reset_s3_client
 reset_s3_client()  # clear any cached client
 get_s3_client({
     "endpoint_url": "http://localhost:9000",
-    "aws_access_key_id": "minioadmin",
-    "aws_secret_access_key": "minioadmin",
+    "aws_access_key_id": "test_access_key",
+    "aws_secret_access_key": "test_access_secret",
 })
 ```
 
@@ -382,7 +383,7 @@ get_s3_client({
 3. If the dry-run looks correct, set `DRY_RUN = False` in Cell 3 and re-run
    from Cell 3.
 
-After promotion the final Lakehouse layout in MinIO will look like:
+After promotion the final Lakehouse layout in CEPH will look like:
 
 ```
 cdm-lake/
@@ -395,9 +396,9 @@ cdm-lake/
 
 ---
 
-## 5. Inspect results in MinIO
+## 5. Inspect results in CEPH
 
-Browse the [MinIO console](http://localhost:9001) or use the CLI:
+Browse the [CEPH console](http://localhost:9001) or use the CLI:
 
 ```sh
 # List final Lakehouse objects
@@ -471,8 +472,8 @@ previous snapshot:
 ## 7. Cleanup
 
 ```sh
-# Stop and remove MinIO
-docker stop minio && docker rm minio
+# Stop and remove CEPH
+docker stop ceph && docker rm ceph
 
 # Remove local staging data
 rm -rf staging/ output/
@@ -484,9 +485,8 @@ rm -rf staging/ output/
 
 | Symptom | Cause | Fix |
 |---------|-------|-----|
-| `berdl_notebook_utils` import error in notebook | Missing local MinIO client init | Add the `get_s3_client({...})` cell described in Step 4 |
+| `berdl_notebook_utils` import error in notebook | Missing local CEPH client init | Add the `get_s3_client({...})` cell described in Step 4 |
 | `connect_ftp() timeout` | NCBI FTP may be slow or rate-limited | Retry; reduce `--threads` to 1 |
-| `CRC64NVME` errors uploading to MinIO | MinIO version too old (needs ≥ `2025-02-07`) | Pin to `minio/minio:RELEASE.2025-02-28T09-55-16Z` or newer |
 | Phase 3 shows 0 promoted | Staging prefix doesn't match or bucket is wrong | Verify `STAGING_KEY_PREFIX` matches the S3 upload path from Step 3d |
 | Container can't reach FTP | Docker network isolation | Use `--network host` or ensure DNS resolution works inside the container |
 

--- a/notebooks/ncbi_ftp_download.ipynb
+++ b/notebooks/ncbi_ftp_download.ipynb
@@ -118,15 +118,15 @@
    "source": [
     "from cdm_data_loaders.utils.s3 import get_s3_client, reset_s3_client\n",
     "\n",
-    "# Provide S3 credentials (use for local testing against MinIO test container)\n",
+    "# Provide S3 credentials (use for local testing against CEPH test container)\n",
     "PROVIDE_CREDENTIALS = False  # Set to False to rely on environment credentials (e.g. IAM role)\n",
     "if PROVIDE_CREDENTIALS:\n",
     "    reset_s3_client()  # Clear any existing client to ensure new credentials are used\n",
     "    get_s3_client(\n",
     "        {\n",
     "            \"endpoint_url\": \"http://localhost:9000\",\n",
-    "            \"aws_access_key_id\": \"minioadmin\",\n",
-    "            \"aws_secret_access_key\": \"minioadmin\",\n",
+    "            \"aws_access_key_id\": \"test_access_key\",\n",
+    "            \"aws_secret_access_key\": \"test_access_secret\",\n",
     "        }\n",
     "    )"
    ]

--- a/notebooks/ncbi_ftp_manifest.ipynb
+++ b/notebooks/ncbi_ftp_manifest.ipynb
@@ -74,15 +74,15 @@
    "source": [
     "from cdm_data_loaders.utils.s3 import reset_s3_client\n",
     "\n",
-    "# Provide S3 credentials (use for local testing against MinIO test container)\n",
+    "# Provide S3 credentials (use for local testing against CEPH test container)\n",
     "PROVIDE_CREDENTIALS = False  # Set to False to rely on environment credentials (e.g. IAM role)\n",
     "if PROVIDE_CREDENTIALS:\n",
     "    reset_s3_client()  # Clear any existing client to ensure new credentials are used\n",
     "    get_s3_client(\n",
     "        {\n",
     "            \"endpoint_url\": \"http://localhost:9000\",\n",
-    "            \"aws_access_key_id\": \"minioadmin\",\n",
-    "            \"aws_secret_access_key\": \"minioadmin\",\n",
+    "            \"aws_access_key_id\": \"test_access_key\",\n",
+    "            \"aws_secret_access_key\": \"test_access_secret\",\n",
     "        }\n",
     "    )"
    ]

--- a/notebooks/ncbi_ftp_promote.ipynb
+++ b/notebooks/ncbi_ftp_promote.ipynb
@@ -133,15 +133,15 @@
    "source": [
     "from cdm_data_loaders.utils.s3 import reset_s3_client\n",
     "\n",
-    "# Provide S3 credentials (use for local testing against MinIO test container)\n",
+    "# Provide S3 credentials (use for local testing against CEPH test container)\n",
     "PROVIDE_CREDENTIALS = False  # Set to False to rely on environment credentials (e.g. IAM role)\n",
     "if PROVIDE_CREDENTIALS:\n",
     "    reset_s3_client()  # Clear any existing client to ensure new credentials are used\n",
     "    get_s3_client(\n",
     "        {\n",
     "            \"endpoint_url\": \"http://localhost:9000\",\n",
-    "            \"aws_access_key_id\": \"minioadmin\",\n",
-    "            \"aws_secret_access_key\": \"minioadmin\",\n",
+    "            \"aws_access_key_id\": \"test_access_key\",\n",
+    "            \"aws_secret_access_key\": \"test_access_secret\",\n",
     "        }\n",
     "    )"
    ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ log_cli = true
 log_cli_level = "INFO"
 log_level = "INFO"
 addopts = ["-v"]
-markers = ["requires_spark: must be run in an environment where spark is available", "s3: tests that mock s3 interactions", "slow_test: does what it says on the tin", "integration: end-to-end tests requiring a running MinIO instance and network access", "external_request: tests that make real network requests to external services (e.g. NCBI FTP)"]
+markers = ["requires_spark: must be run in an environment where spark is available", "s3: tests that mock s3 interactions", "slow_test: does what it says on the tin", "integration: end-to-end tests requiring a running CEPH instance and network access", "external_request: tests that make real network requests to external services (e.g. NCBI FTP)"]
 
 # environment settings for running tests
 [tool.pytest_env]
@@ -209,10 +209,10 @@ S3_ENDPOINT_URL = "http://localhost:9000"
 AWS_CONFIG_FILE = "/dev/null"  # ensure tests don't pick up creds from a real config file
 AWS_DEFAULT_REGION = "us-east-1"
 # default to use containerized S3 test store
-AWS_ENDPOINT_URL = "http://localhost:9000"
+AWS_ENDPOINT_URL = { value = "http://localhost:9000", skip_if_set = true } 
 AWS_ENDPOINT_URL_S3 = { unset = true }
-AWS_ACCESS_KEY_ID = "minioadmin"
-AWS_SECRET_ACCESS_KEY = "minioadmin"
+AWS_ACCESS_KEY_ID = "test_access_key"
+AWS_SECRET_ACCESS_KEY = "test_access_secret"
 
 [tool.uv.sources]
 cdm-schema = { git = "https://github.com/kbase/cdm-schema.git" }

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -41,7 +41,7 @@ case "$cmd" in
     exec /usr/bin/tini -- uv run --no-sync pytest -m "not requires_spark"
     ;;
   integration_test)
-    # run the integration tests (requires a running MinIO instance)
+    # run the integration tests (requires a running CEPH instance)
     exec /usr/bin/tini -- uv run --no-sync pytest -m "integration" -v "$@"
     ;;
   bash)

--- a/scripts/s3_local.py
+++ b/scripts/s3_local.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 # ruff: noqa: T201, EM101, EM102, TRY003, D103
-"""Thin S3 CLI for local MinIO testing (no aws-cli install required).
+"""Thin S3 CLI for local CEPH testing (no aws-cli install required).
 
 Usage (all commands assume ``uv run`` from the repo root):
 
@@ -12,8 +12,8 @@ Usage (all commands assume ``uv run`` from the repo root):
 Environment variables (with defaults for the walkthrough):
 
     AWS_ENDPOINT_URL         http://localhost:9000
-    AWS_ACCESS_KEY_ID        minioadmin
-    AWS_SECRET_ACCESS_KEY    minioadmin
+    AWS_ACCESS_KEY_ID        test_access_key
+    AWS_SECRET_ACCESS_KEY    test_access_secret
 """
 
 import os
@@ -27,8 +27,8 @@ def _client() -> None:
     _ = s3.get_s3_client(
         {
             "endpoint_url": os.environ.get("AWS_ENDPOINT_URL", "http://localhost:9000"),
-            "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY_ID", "minioadmin"),
-            "aws_secret_access_key": os.environ.get("AWS_SECRET_ACCESS_KEY", "minioadmin"),
+            "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY_ID", "test_access_key"),
+            "aws_secret_access_key": os.environ.get("AWS_SECRET_ACCESS_KEY", "test_access_secret"),
         }
     )
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,9 @@
-"""Shared fixtures and helpers for MinIO-backed integration tests.
+"""Shared fixtures and helpers for CEPH-backed integration tests.
 
-Integration tests are auto-skipped when MinIO is not reachable.  Each test
+Integration tests are auto-skipped when CEPH is not reachable.  Each test
 method gets its own bucket (derived from the test node name) that is emptied
 on re-run but **never deleted** after the test — this lets developers inspect
-the final state of the object store via the MinIO console.
+the final state of the object store via the CEPH console.
 """
 
 import hashlib
@@ -27,13 +27,13 @@ from cdm_data_loaders.utils.s3 import reset_s3_client
 _MAX_BUCKET_LEN = 63
 
 
-# MinIO reachability check
+# CEPH reachability check
 
-_minio_available: bool | None = None
+_ceph_available: bool | None = None
 
 
-def _minio_reachable() -> bool:
-    """Return True if the MinIO endpoint accepts connections."""
+def _ceph_reachable() -> bool:
+    """Return True if the CEPH endpoint accepts connections."""
     try:
         client = boto3.client(
             "s3",
@@ -50,13 +50,13 @@ def _minio_reachable() -> bool:
 
 
 def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:  # noqa: ARG001
-    """Auto-skip ``@pytest.mark.integration`` tests when MinIO is unreachable."""
-    global _minio_available  # noqa: PLW0603
-    if _minio_available is None:
-        _minio_available = _minio_reachable()
-    if _minio_available:
+    """Auto-skip ``@pytest.mark.integration`` tests when CEPH is unreachable."""
+    global _ceph_available  # noqa: PLW0603
+    if _ceph_available is None:
+        _ceph_available = _ceph_reachable()
+    if _ceph_available:
         return
-    skip_marker = pytest.mark.skip(reason="MinIO not reachable — skipping integration tests")
+    skip_marker = pytest.mark.skip(reason="CEPH not reachable — skipping integration tests")
     for item in items:
         if "integration" in item.keywords:
             item.add_marker(skip_marker)
@@ -66,11 +66,11 @@ def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item
 
 
 @pytest.fixture
-def minio_s3_client() -> botocore.client.BaseClient:
-    """Session-scoped real boto3 S3 client pointed at the local MinIO instance.
+def ceph_s3_client() -> botocore.client.BaseClient:
+    """Session-scoped real boto3 S3 client pointed at the local CEPH instance.
 
     Patches ``get_s3_client`` on every module that uses it so internal calls
-    are transparently routed to MinIO.
+    are transparently routed to CEPH.
     """
     client = boto3.client("s3")
 
@@ -105,14 +105,14 @@ def _bucket_name_from_node(node_id: str) -> str:
 
 
 @pytest.fixture
-def test_bucket(minio_s3_client: botocore.client.BaseClient, request: pytest.FixtureRequest) -> str:
-    """Create a per-test-method bucket in MinIO and return its name.
+def test_bucket(ceph_s3_client: botocore.client.BaseClient, request: pytest.FixtureRequest) -> str:
+    """Create a per-test-method bucket in CEPH and return its name.
 
     On re-run, any existing objects are deleted first so the test starts clean.
     The bucket is **not** deleted after the test.
     """
     bucket = _bucket_name_from_node(request.node.nodeid)
-    s3 = minio_s3_client
+    s3 = ceph_s3_client
 
     try:
         s3.head_bucket(Bucket=bucket)
@@ -133,8 +133,8 @@ def test_bucket(minio_s3_client: botocore.client.BaseClient, request: pytest.Fix
 
 
 @pytest.fixture
-def staging_test_bucket(minio_s3_client: botocore.client.BaseClient, request: pytest.FixtureRequest) -> str:
-    """Create a per-test staging bucket in MinIO and return its name.
+def staging_test_bucket(ceph_s3_client: botocore.client.BaseClient, request: pytest.FixtureRequest) -> str:
+    """Create a per-test staging bucket in CEPH and return its name.
 
     Mirrors ``test_bucket`` but uses a ``staging-`` prefix so staging and
     Lakehouse buckets are distinct within the same test.
@@ -143,7 +143,7 @@ def staging_test_bucket(minio_s3_client: botocore.client.BaseClient, request: py
     if len(bucket) > _MAX_BUCKET_LEN:
         suffix = hashlib.md5(bucket.encode()).hexdigest()[:6]  # noqa: S324
         bucket = f"{bucket[: _MAX_BUCKET_LEN - 7]}-{suffix}"
-    s3 = minio_s3_client
+    s3 = ceph_s3_client
 
     try:
         s3.head_bucket(Bucket=bucket)
@@ -165,13 +165,13 @@ def staging_test_bucket(minio_s3_client: botocore.client.BaseClient, request: py
 # Helpers
 
 
-def stage_files_to_minio(
+def stage_files_to_ceph(
     s3: botocore.client.BaseClient,
     bucket: str,
     local_dir: str | Path,
     staging_prefix: str,
 ) -> list[str]:
-    """Upload a local directory tree to a MinIO staging prefix.
+    """Upload a local directory tree to a CEPH staging prefix.
 
     :param s3: boto3 S3 client
     :param bucket: target bucket
@@ -199,7 +199,7 @@ def seed_lakehouse(  # noqa: PLR0913
     path_prefix: str,
     assembly_dir: str | None = None,
 ) -> list[str]:
-    """Seed assembly files at the final Lakehouse path in MinIO.
+    """Seed assembly files at the final Lakehouse path in CEPH.
 
     :param s3: boto3 S3 client
     :param bucket: target bucket

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -3,7 +3,8 @@
 Integration tests are auto-skipped when CEPH is not reachable.  Each test
 method gets its own bucket (derived from the test node name) that is emptied
 on re-run but **never deleted** after the test — this lets developers inspect
-the final state of the object store via the CEPH console.
+the final state of the object store. The CEPH dashboard does not currently
+allow inspection of the store, but the `s3_local` command-line tool can be used.
 """
 
 import hashlib

--- a/tests/integration/test_download_e2e.py
+++ b/tests/integration/test_download_e2e.py
@@ -1,7 +1,7 @@
 """End-to-end tests for Phase 2 — FTP download of assemblies.
 
 These tests download real (small) assemblies from the NCBI FTP server.
-Marked ``integration`` and ``slow_test``; auto-skipped when MinIO is
+Marked ``integration`` and ``slow_test``; auto-skipped when CEPH is
 unreachable.
 """
 
@@ -133,7 +133,7 @@ class TestDownloadResumeIncomplete:
 @pytest.mark.external_request
 def test_download_and_stage_e2e(
     tmp_path: Path,
-    minio_s3_client,
+    ceph_s3_client,
     test_bucket: str,
 ) -> None:
     """Download one assembly and verify it is staged under the expected S3 prefix."""
@@ -141,15 +141,15 @@ def test_download_and_stage_e2e(
 
     staging_prefix = "staging/e2e-test/"
 
-    # Seed the manifest in MinIO so download_and_stage can read it from S3
+    # Seed the manifest in CEPH so download_and_stage can read it from S3
     manifest_s3_key = f"{staging_prefix}input/transfer_manifest.txt"
-    minio_s3_client.put_object(
+    ceph_s3_client.put_object(
         Bucket=test_bucket,
         Key=manifest_s3_key,
         Body=manifest_path.read_bytes(),
     )
 
-    with patch.object(s3_utils, "get_s3_client", return_value=minio_s3_client):
+    with patch.object(s3_utils, "get_s3_client", return_value=ceph_s3_client):
         report = download_and_stage(
             bucket=test_bucket,
             staging_key_prefix=staging_prefix,
@@ -166,7 +166,7 @@ def test_download_and_stage_e2e(
     assert report["dry_run"] is False
 
     # Verify raw_data/ files and .md5 sidecars are staged
-    paginator = minio_s3_client.get_paginator("list_objects_v2")
+    paginator = ceph_s3_client.get_paginator("list_objects_v2")
     staged_keys = [
         obj["Key"]
         for page in paginator.paginate(Bucket=test_bucket, Prefix=f"{staging_prefix}raw_data/")
@@ -181,6 +181,6 @@ def test_download_and_stage_e2e(
 
     # Verify download_report.json was also uploaded
     report_key = f"{staging_prefix}download_report.json"
-    resp = minio_s3_client.get_object(Bucket=test_bucket, Key=report_key)
+    resp = ceph_s3_client.get_object(Bucket=test_bucket, Key=report_key)
     saved_report = json.loads(resp["Body"].read())
     assert saved_report["succeeded"] >= 1

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -1,9 +1,9 @@
 """End-to-end tests for the full NCBI assembly pipeline (Phase 1 → 2 → 3).
 
 Exercises the entire flow: download summary from real NCBI FTP, compute diff,
-download a single assembly, stage in MinIO, promote to final Lakehouse path.
+download a single assembly, stage in CEPH, promote to final Lakehouse path.
 
-Marked ``integration`` and ``slow_test``; auto-skipped when MinIO is
+Marked ``integration`` and ``slow_test``; auto-skipped when CEPH is
 unreachable.
 """
 
@@ -29,7 +29,7 @@ from cdm_data_loaders.ncbi_ftp.manifest import (
 from cdm_data_loaders.ncbi_ftp.promote import DEFAULT_LAKEHOUSE_KEY_PREFIX, promote_from_s3
 from cdm_data_loaders.pipelines.ncbi_ftp_download import download_batch
 
-from .conftest import get_object_metadata, list_all_keys, stage_files_to_minio, staging_test_bucket  # noqa: F401
+from .conftest import get_object_metadata, list_all_keys, stage_files_to_ceph, staging_test_bucket  # noqa: F401
 
 STABLE_PREFIX = "900"
 STAGING_PREFIX = "staging/run1/"
@@ -44,13 +44,13 @@ class TestFullPipelineSmallBatch:
 
     def test_full_pipeline_small_batch(
         self,
-        minio_s3_client: object,
+        ceph_s3_client: object,
         test_bucket: str,
         staging_test_bucket: str,
         tmp_path: Path,
     ) -> None:
-        """Single assembly flows through all three phases into MinIO."""
-        s3 = minio_s3_client
+        """Single assembly flows through all three phases into CEPH."""
+        s3 = ceph_s3_client
 
         # Step 1: Manifest generation
         raw = download_assembly_summary(database="refseq")
@@ -76,9 +76,9 @@ class TestFullPipelineSmallBatch:
         assert report["succeeded"] >= 1
         assert report["failed"] == 0
 
-        # Upload local output to MinIO staging
-        keys = stage_files_to_minio(s3, staging_test_bucket, output_dir, STAGING_PREFIX)
-        assert len(keys) > 0, "Expected files staged to MinIO"
+        # Upload local output to CEPH staging
+        keys = stage_files_to_ceph(s3, staging_test_bucket, output_dir, STAGING_PREFIX)
+        assert len(keys) > 0, "Expected files staged to CEPH"
 
         # Step 3: Promote from staging to final path
         promote_report = promote_from_s3(
@@ -112,13 +112,13 @@ class TestFullPipelineIncrementalSync:
 
     def test_full_pipeline_incremental(
         self,
-        minio_s3_client: object,
+        ceph_s3_client: object,
         test_bucket: str,
         staging_test_bucket: str,
         tmp_path: Path,
     ) -> None:
         """Second sync archives the old version and promotes the new one."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
 
         # First sync: Steps 1 -> 2 -> 3
         raw = download_assembly_summary(database="refseq")
@@ -136,9 +136,9 @@ class TestFullPipelineIncrementalSync:
         report1 = download_batch(str(manifest1), str(output1), threads=1, limit=1)
         assert report1["succeeded"] >= 1
 
-        stage_files_to_minio(s3, staging_test_bucket, output1, STAGING_PREFIX)
+        stage_files_to_ceph(s3, staging_test_bucket, output1, STAGING_PREFIX)
 
-        # Upload manifest to MinIO for trimming (manifest lives in staging bucket)
+        # Upload manifest to CEPH for trimming (manifest lives in staging bucket)
         manifest_key = "ncbi/transfer_manifest.txt"
         s3.upload_file(Filename=str(manifest1), Bucket=staging_test_bucket, Key=manifest_key)
 
@@ -197,7 +197,7 @@ class TestFullPipelineIncrementalSync:
         staging_keys = list_all_keys(s3, staging_test_bucket, STAGING_PREFIX)
         for key in staging_keys:
             s3.delete_object(Bucket=staging_test_bucket, Key=key)
-        stage_files_to_minio(s3, staging_test_bucket, output2, STAGING_PREFIX)
+        stage_files_to_ceph(s3, staging_test_bucket, output2, STAGING_PREFIX)
 
         # Phase 3 — promote with archival
         promote2 = promote_from_s3(

--- a/tests/integration/test_manifest_e2e.py
+++ b/tests/integration/test_manifest_e2e.py
@@ -1,12 +1,13 @@
 """End-to-end tests for Phase 1 — manifest generation and diffing.
 
 These tests hit the real NCBI FTP server (with tight prefix filters) and
-optionally use MinIO for checksum verification.  Marked ``integration``
-and ``slow_test``; auto-skipped when MinIO is unreachable.
+optionally use CEPH for checksum verification.  Marked ``integration``
+and ``slow_test``; auto-skipped when CEPH is unreachable.
 """
 
 from __future__ import annotations
 
+from itertools import islice
 from typing import TYPE_CHECKING
 
 import pytest
@@ -164,16 +165,17 @@ class TestVerifyTransferCandidatesPrunes:
 
     def test_prunes_existing_matching_md5(
         self,
-        minio_s3_client: object,
+        ceph_s3_client: object,
         test_bucket: str,
     ) -> None:
-        """Assemblies with matching MD5 metadata in MinIO are pruned from the transfer list."""
+        """Assemblies with matching MD5 metadata in CEPH are pruned from the transfer list."""
         _full, filtered = _download_and_filter()
-        latest = {a: r for a, r in filtered.items() if r.status == "latest"}
+        # keep just the first 100 items for testing
+        latest = dict(islice(((a, r) for a, r in filtered.items() if r.status == "latest"), 100))
         if not latest:
             pytest.skip(f"No latest assemblies in prefix {STABLE_PREFIX}")
 
-        # Pick one assembly to pre-seed in MinIO with correct checksums
+        # Pick one assembly to pre-seed in CEPH with correct checksums
         # and one to partially pre-seed to ensure it doesn't get pruned
         i_latest = iter(sorted(latest))
         acc = next(i_latest)
@@ -191,8 +193,8 @@ class TestVerifyTransferCandidatesPrunes:
 
         checksums = parse_md5_checksums_file(md5_text)
 
-        # Seed MinIO with dummy files that have the right MD5 metadata
-        s3 = minio_s3_client
+        # Seed CEPH with dummy files that have the right MD5 metadata
+        s3 = ceph_s3_client
         path_prefix = DEFAULT_LAKEHOUSE_KEY_PREFIX
         rel = build_accession_path(rec.assembly_dir)
         for fname, md5 in checksums.items():
@@ -239,18 +241,18 @@ class TestVerifyTransferCandidatesPrunes:
 @pytest.mark.integration
 @pytest.mark.slow_test
 class TestScanStoreToSyntheticSummary:
-    """Test synthetic assembly summary generation from MinIO store."""
+    """Test synthetic assembly summary generation from CEPH store."""
 
-    def test_builds_summary_from_minio_store(
+    def test_builds_summary_from_ceph_store(
         self,
-        minio_s3_client: object,
+        ceph_s3_client: object,
         test_bucket: str,
     ) -> None:
-        """Verify synthetic summary captures assemblies from MinIO."""
-        s3 = minio_s3_client
+        """Verify synthetic summary captures assemblies from CEPH."""
+        s3 = ceph_s3_client
         path_prefix = DEFAULT_LAKEHOUSE_KEY_PREFIX
 
-        # Seed MinIO with a couple of assemblies
+        # Seed CEPH with a couple of assemblies
         assemblies = {
             "GCF_000001215.4_v1": ["_genomic.fna.gz", "_protein.faa.gz"],
             "GCF_000005845.2_v2": ["_genomic.fna.gz"],
@@ -280,14 +282,14 @@ class TestScanStoreToSyntheticSummary:
 
     def test_synthetic_summary_diff_against_current(
         self,
-        minio_s3_client: object,
+        ceph_s3_client: object,
         test_bucket: str,
     ) -> None:
         """Verify synthetic summary can be used as baseline for diffing."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         path_prefix = DEFAULT_LAKEHOUSE_KEY_PREFIX
 
-        # Seed MinIO with one assembly
+        # Seed CEPH with one assembly
         key1 = f"{path_prefix}refseq/GCF_000001215.4_old/GCF_000001215.4_old_genomic.fna.gz"
         s3.put_object(Bucket=test_bucket, Key=key1, Body=b"data")
 

--- a/tests/integration/test_promote_e2e.py
+++ b/tests/integration/test_promote_e2e.py
@@ -1,10 +1,10 @@
-"""End-to-end tests for Phase 3 — promote and archive in MinIO.
+"""End-to-end tests for Phase 3 — promote and archive in CEPH.
 
-Pre-stages fake assembly files in MinIO and exercises ``promote_from_s3``
+Pre-stages fake assembly files in CEPH and exercises ``promote_from_s3``
 with various combinations of manifests, archive operations, dry-run mode,
 manifest trimming, and incomplete staging.
 
-Marked ``integration`` and ``slow_test``; auto-skipped when MinIO is
+Marked ``integration`` and ``slow_test``; auto-skipped when CEPH is
 unreachable.  Each test method gets its own bucket.
 """
 
@@ -81,9 +81,9 @@ def _write_manifest(tmp_path: Path, accessions: list[str], name: str) -> Path:
 class TestPromoteFromStaging:
     """Promote staged files to final Lakehouse paths."""
 
-    def test_promote_from_staging(self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
+    def test_promote_from_staging(self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
         """Staged files appear at the final Lakehouse path with MD5 metadata."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_assembly(s3, staging_test_bucket, ASSEMBLY_DIR_A)
 
         report = promote_from_s3(
@@ -112,14 +112,14 @@ class TestPromoteFromStaging:
 class TestPromoteIdempotent:
     """Promoting the same staging data twice should succeed without errors."""
 
-    def test_promote_idempotent(self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
+    def test_promote_idempotent(self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
         """Second promote on empty staging succeeds and leaves the lakehouse unchanged.
 
         After the first promote, staged files are deleted.  A second run therefore
         finds nothing to promote — which is correct and expected.  The lakehouse
         contents must be identical after both runs.
         """
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_assembly(s3, staging_test_bucket, ASSEMBLY_DIR_A)
 
         report1 = promote_from_s3(
@@ -151,10 +151,10 @@ class TestPromoteArchiveUpdated:
     """Archive existing assemblies before overwriting with updated versions."""
 
     def test_archive_updated(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """Updated assemblies are archived before being overwritten."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
 
         # Seed "old" version at the final Lakehouse path
         old_files = {
@@ -197,10 +197,10 @@ class TestPromoteArchiveRemoved:
     """Archive and delete replaced/suppressed assemblies."""
 
     def test_archive_removed(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """Removed assemblies are archived and source objects are deleted."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
 
         # Seed assemblies at final path
         files = {
@@ -242,9 +242,9 @@ class TestPromoteArchiveRemoved:
 class TestPromoteDryRun:
     """Dry-run mode should not create any objects."""
 
-    def test_promote_dry_run(self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
+    def test_promote_dry_run(self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
         """Dry-run logs actions but creates no objects at the final path."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_assembly(s3, staging_test_bucket, ASSEMBLY_DIR_A)
 
         report = promote_from_s3(
@@ -269,12 +269,12 @@ class TestPromoteTrimsManifest:
     """Manifest trimming removes promoted accessions."""
 
     def test_trims_manifest(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
-        """Transfer manifest in MinIO is trimmed to exclude promoted accessions."""
-        s3 = minio_s3_client
+        """Transfer manifest in CEPH is trimmed to exclude promoted accessions."""
+        s3 = ceph_s3_client
 
-        # Upload a transfer manifest with 3 entries to MinIO (manifest lives in staging)
+        # Upload a transfer manifest with 3 entries to CEPH (manifest lives in staging)
         manifest_key = "ncbi/transfer_manifest.txt"
         manifest_lines = [
             "/genomes/all/GCF/900/000/001/GCF_900000001.1_FakeAssemblyA/\n",
@@ -297,7 +297,7 @@ class TestPromoteTrimsManifest:
 
         assert report["failed"] == 0
 
-        # Read back the manifest from MinIO (it lives in staging)
+        # Read back the manifest from CEPH (it lives in staging)
         resp = s3.get_object(Bucket=staging_test_bucket, Key=manifest_key)
         remaining = resp["Body"].read().decode()
         remaining_lines = [line.strip() for line in remaining.strip().splitlines() if line.strip()]
@@ -312,9 +312,9 @@ class TestPromoteTrimsManifest:
 class TestPromoteIncompleteStaging:
     """Incomplete staging (sidecar only, no data) should not promote anything."""
 
-    def test_incomplete_staging(self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
+    def test_incomplete_staging(self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
         """Only .md5 sidecars staged → nothing promoted."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
 
         # Stage only .md5 sidecars (no data files)
         rel = build_accession_path(ASSEMBLY_DIR_A)
@@ -344,9 +344,9 @@ class TestPromoteIncompleteStaging:
 class TestPromoteCreatesDescriptor:
     """Promote step writes a frictionless descriptor for each promoted assembly."""
 
-    def test_descriptor_created(self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
+    def test_descriptor_created(self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
         """After promote, a JSON descriptor exists under ``metadata/``."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_assembly(s3, staging_test_bucket, ASSEMBLY_DIR_A)
 
         promote_from_s3(
@@ -364,10 +364,10 @@ class TestPromoteCreatesDescriptor:
         assert body["resource_type"] == "dataset"
 
     def test_descriptor_resources_include_promoted_files(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """Descriptor's ``resources`` list references the final Lakehouse key."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_assembly(s3, staging_test_bucket, ASSEMBLY_DIR_A)
 
         promote_from_s3(
@@ -385,10 +385,10 @@ class TestPromoteCreatesDescriptor:
         assert any(PATH_PREFIX + "raw_data/" in p for p in resource_paths)
 
     def test_descriptor_resources_have_md5(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """Resources with .md5 sidecars include the hash value."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_assembly(s3, staging_test_bucket, ASSEMBLY_DIR_A)
 
         promote_from_s3(
@@ -407,10 +407,10 @@ class TestPromoteCreatesDescriptor:
             assert "hash" in resource, f"Expected hash in resource: {resource}"
 
     def test_multiple_assemblies_get_separate_descriptors(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """Each assembly gets its own descriptor file."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_assembly(s3, staging_test_bucket, ASSEMBLY_DIR_A)
         _stage_assembly(s3, staging_test_bucket, ASSEMBLY_DIR_B)
 
@@ -434,17 +434,17 @@ class TestPromoteArchiveUpdatedIncludesDescriptor:
     """Archiving updated assemblies also archives the descriptor."""
 
     def test_archive_copies_descriptor(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """After archiving an updated assembly, the descriptor appears under archive/."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
 
         # Seed old version at Lakehouse path *including* a live descriptor
         old_files = {f"{ASSEMBLY_DIR_A}_genomic.fna.gz": "old content"}
         seed_lakehouse(s3, test_bucket, ACCESSION_A, old_files, PATH_PREFIX, ASSEMBLY_DIR_A)
         # Pre-upload a descriptor so archive_descriptor can find it
         descriptor = create_descriptor(ASSEMBLY_DIR_A, ACCESSION_A, [])
-        # Upload directly to MinIO (not via promote)
+        # Upload directly to CEPH (not via promote)
         descriptor_key = build_descriptor_key(ASSEMBLY_DIR_A, PATH_PREFIX)
         s3.put_object(Bucket=test_bucket, Key=descriptor_key, Body=json.dumps(descriptor).encode())
 
@@ -472,10 +472,10 @@ class TestPromoteArchiveRemovedIncludesDescriptor:
     """Archiving removed assemblies also archives the descriptor."""
 
     def test_archive_removed_copies_descriptor(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """After archiving a removed assembly, the descriptor is under archive/."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
 
         # Seed the assembly at final Lakehouse path
         files = {f"{ASSEMBLY_DIR_A}_genomic.fna.gz": "content"}
@@ -506,9 +506,9 @@ class TestPromoteArchiveRemovedIncludesDescriptor:
 class TestPromoteDryRunNoDescriptor:
     """Dry-run must not write any descriptor files."""
 
-    def test_dry_run_no_descriptor(self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
+    def test_dry_run_no_descriptor(self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
         """Dry-run does not upload a descriptor to the metadata/ prefix."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_assembly(s3, staging_test_bucket, ASSEMBLY_DIR_A)
 
         promote_from_s3(
@@ -532,12 +532,12 @@ class TestArchiveMultiFileConcurrent:
     """Verify parallel copy archives all files correctly with correct content."""
 
     def test_all_files_archived_with_correct_content(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """Every file is archived with byte-identical content when copied concurrently."""
         from cdm_data_loaders.ncbi_ftp.promote import _archive_assemblies
 
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
 
         # Seed many files for assembly A at final Lakehouse path
         many_files = {
@@ -572,12 +572,12 @@ class TestArchiveMultiFileConcurrent:
             assert actual_body == expected_body, f"Content mismatch for {fname}"
 
     def test_archive_key_paths_are_correct(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """Archived keys follow the exact ``archive/{release}/{reason}/{rel_path}`` pattern."""
         from cdm_data_loaders.ncbi_ftp.promote import _archive_assemblies
 
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         files = {f"{ASSEMBLY_DIR_B}_genomic.fna.gz": b"content"}
         seed_lakehouse(s3, test_bucket, ACCESSION_B, files, PATH_PREFIX, ASSEMBLY_DIR_B)
 
@@ -603,12 +603,12 @@ class TestArchiveDeleteSourceBatch:
     """Verify batch delete removes all source objects after concurrent copy."""
 
     def test_all_sources_deleted_after_archive(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """After archive with delete_source=True, no source objects remain."""
         from cdm_data_loaders.ncbi_ftp.promote import _archive_assemblies
 
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         many_files = {
             f"{ASSEMBLY_DIR_A}_genomic.fna.gz": b"genomic",
             f"{ASSEMBLY_DIR_A}_protein.faa.gz": b"protein",
@@ -634,12 +634,12 @@ class TestArchiveDeleteSourceBatch:
             assert len(remaining) == 0, f"Source not deleted: {key}"
 
     def test_archive_present_source_gone(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """Archive destinations exist AND sources are gone after replaced_or_suppressed archive."""
         from cdm_data_loaders.ncbi_ftp.promote import _archive_assemblies
 
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         files = {
             f"{ASSEMBLY_DIR_A}_genomic.fna.gz": b"genomic",
             f"{ASSEMBLY_DIR_A}_protein.faa.gz": b"protein",
@@ -676,7 +676,7 @@ class TestPartialArchiveResume:
     """
 
     def test_partial_updated_archive_resumes(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """Re-running after a partial updated archive overwrites stale copies and archives missing files.
 
@@ -686,7 +686,7 @@ class TestPartialArchiveResume:
         """
         from cdm_data_loaders.ncbi_ftp.promote import _archive_assemblies
 
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         rel = build_accession_path(ASSEMBLY_DIR_A)
 
         file_a = f"{ASSEMBLY_DIR_A}_genomic.fna.gz"
@@ -724,7 +724,7 @@ class TestPartialArchiveResume:
         assert len(source_keys) == len(current_content)
 
     def test_partial_replaced_archive_resumes_and_deletes(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """Re-running replaced_or_suppressed archive after partial run completes and deletes all sources.
 
@@ -734,7 +734,7 @@ class TestPartialArchiveResume:
         """
         from cdm_data_loaders.ncbi_ftp.promote import _archive_assemblies
 
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         rel = build_accession_path(ASSEMBLY_DIR_A)
 
         file_a = f"{ASSEMBLY_DIR_A}_genomic.fna.gz"
@@ -782,12 +782,12 @@ class TestPartialArchiveResume:
         assert resp_a["ResponseMetadata"]["HTTPStatusCode"] == 200  # noqa: PLR2004
 
     def test_full_rerun_after_complete_archive_is_idempotent(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """Running archive again when all files already exist at archive paths is safe (no errors)."""
         from cdm_data_loaders.ncbi_ftp.promote import _archive_assemblies
 
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         files = {
             f"{ASSEMBLY_DIR_A}_genomic.fna.gz": b"genomic",
             f"{ASSEMBLY_DIR_A}_protein.faa.gz": b"protein",
@@ -832,12 +832,12 @@ class TestArchiveMultiAccessionManifest:
     """Multiple accessions in a single manifest are all archived."""
 
     def test_two_accessions_both_archived(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """Both accessions are archived with correct keys when listed in one manifest."""
         from cdm_data_loaders.ncbi_ftp.promote import _archive_assemblies
 
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
 
         files_a = {f"{ASSEMBLY_DIR_A}_genomic.fna.gz": b"genomic-A"}
         files_b = {f"{ASSEMBLY_DIR_B}_genomic.fna.gz": b"genomic-B"}
@@ -867,12 +867,12 @@ class TestArchiveMultiAccessionManifest:
         assert len(list_all_keys(s3, test_bucket, f"{PATH_PREFIX}{rel_b}")) == 0
 
     def test_three_accessions_correct_archive_reason_segment(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """Archive keys for all three accessions include the archive_reason segment."""
         from cdm_data_loaders.ncbi_ftp.promote import _archive_assemblies
 
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         accessions_and_dirs = [
             (ACCESSION_A, ASSEMBLY_DIR_A),
             (ACCESSION_B, ASSEMBLY_DIR_B),
@@ -911,12 +911,12 @@ class TestArchiveDryRunParallel:
     """Dry-run with many files leaves everything unchanged."""
 
     def test_dry_run_no_copies_no_deletes(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str, tmp_path: Path
     ) -> None:
         """Dry-run with multiple files per accession creates no archive keys and keeps sources."""
         from cdm_data_loaders.ncbi_ftp.promote import _archive_assemblies
 
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         many_files = {
             f"{ASSEMBLY_DIR_A}_genomic.fna.gz": b"genomic",
             f"{ASSEMBLY_DIR_A}_protein.faa.gz": b"protein",
@@ -972,10 +972,10 @@ class TestPromoteMultiFileConcurrent:
     """Verify concurrent promotion lands all files with correct content and MD5."""
 
     def test_six_files_all_promoted_with_correct_content(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """Every staged file arrives at the correct final key with byte-identical content."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         many_files = {
             f"{ASSEMBLY_DIR_A}_genomic.fna.gz": b"GENOMIC",
             f"{ASSEMBLY_DIR_A}_protein.faa.gz": b"PROTEIN",
@@ -1003,10 +1003,10 @@ class TestPromoteMultiFileConcurrent:
             assert obj["Body"].read() == expected_body, f"Content mismatch: {fname}"
 
     def test_md5_metadata_correct_per_file(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """Each promoted file carries MD5 metadata matching its own content, not another file's."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         files = {
             f"{ASSEMBLY_DIR_A}_genomic.fna.gz": b"GENOMIC_UNIQUE",
             f"{ASSEMBLY_DIR_A}_protein.faa.gz": b"PROTEIN_UNIQUE",
@@ -1028,10 +1028,10 @@ class TestPromoteMultiFileConcurrent:
             assert meta.get("md5") == _md5(content), f"Wrong MD5 metadata on {fname}"
 
     def test_file_without_sidecar_has_no_md5_metadata(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """A file staged without a .md5 sidecar is promoted but has no md5 metadata key."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         fname = f"{ASSEMBLY_DIR_A}_genomic.fna.gz"
         _stage_many(s3, staging_test_bucket, ASSEMBLY_DIR_A, {fname: FAKE_GENOMIC}, with_md5=False)
 
@@ -1053,10 +1053,10 @@ class TestPromoteStagingCleanup:
     """After a fully successful promote, all staged files and sidecars are deleted."""
 
     def test_staged_data_files_deleted(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """Data files are removed from staging after a successful assembly promote."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         files = {
             f"{ASSEMBLY_DIR_A}_genomic.fna.gz": FAKE_GENOMIC,
             f"{ASSEMBLY_DIR_A}_protein.faa.gz": FAKE_PROTEIN,
@@ -1073,9 +1073,9 @@ class TestPromoteStagingCleanup:
         remaining_staging = list_all_keys(s3, staging_test_bucket, STAGING_PREFIX)
         assert len(remaining_staging) == 0, f"Staging not cleaned: {remaining_staging}"
 
-    def test_md5_sidecars_deleted(self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
+    def test_md5_sidecars_deleted(self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
         """Both data files and .md5 sidecars are removed from staging after promote."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         files = {
             f"{ASSEMBLY_DIR_A}_genomic.fna.gz": FAKE_GENOMIC,
             f"{ASSEMBLY_DIR_A}_protein.faa.gz": FAKE_PROTEIN,
@@ -1097,10 +1097,10 @@ class TestPromoteStagingCleanup:
         assert len(after_keys) == 0, f"Staging not fully cleaned (including sidecars): {after_keys}"
 
     def test_two_assemblies_staging_both_cleaned(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """Staging for both assemblies is fully cleaned when both assemblies succeed."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_many(
             s3,
             staging_test_bucket,
@@ -1135,10 +1135,10 @@ class TestPromoteTwoAssembliesBothLand:
     """Both assemblies staged together are both promoted to correct Lakehouse paths."""
 
     def test_both_assemblies_at_correct_final_paths(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """Each assembly's files appear at distinct, correctly-routed final Lakehouse paths."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         files_a = {f"{ASSEMBLY_DIR_A}_genomic.fna.gz": b"genomic-A"}
         files_b = {f"{ASSEMBLY_DIR_B}_genomic.fna.gz": b"genomic-B"}
         _stage_many(s3, staging_test_bucket, ASSEMBLY_DIR_A, files_a)
@@ -1162,10 +1162,10 @@ class TestPromoteTwoAssembliesBothLand:
         assert obj_b["Body"].read() == b"genomic-B"
 
     def test_final_path_keys_do_not_overlap(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """Files for assembly A and assembly B land at distinct paths — no key collision."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_many(s3, staging_test_bucket, ASSEMBLY_DIR_A, {f"{ASSEMBLY_DIR_A}_genomic.fna.gz": b"a"})
         _stage_many(s3, staging_test_bucket, ASSEMBLY_DIR_B, {f"{ASSEMBLY_DIR_B}_genomic.fna.gz": b"b"})
 
@@ -1191,10 +1191,10 @@ class TestPromoteDryRunMultiFile:
     """dry_run leaves staging untouched and writes nothing to the Lakehouse."""
 
     def test_dry_run_many_files_staging_untouched(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """All staged files (data + .md5) survive a dry-run promote unchanged."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         many_files = {
             f"{ASSEMBLY_DIR_A}_genomic.fna.gz": FAKE_GENOMIC,
             f"{ASSEMBLY_DIR_A}_protein.faa.gz": FAKE_PROTEIN,
@@ -1223,10 +1223,10 @@ class TestPromoteDryRunMultiFile:
         assert len(final_keys) == 0, f"Dry-run created Lakehouse objects: {final_keys}"
 
     def test_dry_run_two_assemblies_nothing_written(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """Dry-run with two staged assemblies creates no Lakehouse objects."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_many(s3, staging_test_bucket, ASSEMBLY_DIR_A, {f"{ASSEMBLY_DIR_A}_genomic.fna.gz": FAKE_GENOMIC})
         _stage_many(s3, staging_test_bucket, ASSEMBLY_DIR_B, {f"{ASSEMBLY_DIR_B}_genomic.fna.gz": FAKE_GENOMIC})
 
@@ -1247,11 +1247,9 @@ class TestPromoteDryRunMultiFile:
 class TestPromoteSecondRunOnEmptyStaging:
     """After staging is cleaned, a second promote run promotes 0 files without error."""
 
-    def test_second_run_promoted_zero(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
-    ) -> None:
+    def test_second_run_promoted_zero(self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str) -> None:
         """Re-running promote on already-cleaned staging succeeds with promoted=0."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_many(
             s3,
             staging_test_bucket,
@@ -1283,10 +1281,10 @@ class TestPromoteSecondRunOnEmptyStaging:
         assert len(final_keys) == 1
 
     def test_lakehouse_unchanged_on_second_run(
-        self, minio_s3_client: object, test_bucket: str, staging_test_bucket: str
+        self, ceph_s3_client: object, test_bucket: str, staging_test_bucket: str
     ) -> None:
         """Lakehouse contents are identical before and after a second (no-op) promote run."""
-        s3 = minio_s3_client
+        s3 = ceph_s3_client
         _stage_many(
             s3,
             staging_test_bucket,

--- a/tests/utils/test_s3.py
+++ b/tests/utils/test_s3.py
@@ -215,17 +215,10 @@ def test_get_s3_client_incomplete_creds_via_args(
     aws_access_key_id: str | None, aws_secret_access_key: str | None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Verify that get_s3_client raises ValueError when only one of aws_access_key_id or aws_secret_access_key is provided via arguments."""
-    # Remove any real endpoint/credential env vars so moto intercepts all HTTP calls.
-    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
-    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
-    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
-    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
-    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
-    boto3.DEFAULT_SESSION = None
+    prep_client_init(monkeypatch)
     reset_s3_client()
     assert s3_utils._s3_client is None  # noqa: SLF001
     args = {
-        "endpoint_url": None,
         "aws_access_key_id": aws_access_key_id,
         "aws_secret_access_key": aws_secret_access_key,
     }

--- a/tests/utils/test_s3.py
+++ b/tests/utils/test_s3.py
@@ -218,6 +218,7 @@ def test_get_s3_client_incomplete_creds_via_args(
     reset_s3_client()
     assert s3_utils._s3_client is None  # noqa: SLF001
     args = {
+        "endpoint_url": None,
         "aws_access_key_id": aws_access_key_id,
         "aws_secret_access_key": aws_secret_access_key,
     }

--- a/tests/utils/test_s3.py
+++ b/tests/utils/test_s3.py
@@ -256,6 +256,7 @@ def test_get_s3_client_incomplete_creds_via_env(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     """Verify that get_s3_client raises ValueError when only one of aws_access_key_id or aws_secret_access_key is provided."""
+    prep_client_init(monkeypatch)
     reset_s3_client()
     assert s3_utils._s3_client is None  # noqa: SLF001
     args = {

--- a/tests/utils/test_s3.py
+++ b/tests/utils/test_s3.py
@@ -212,9 +212,16 @@ def test_get_s3_client_success_via_env(endpoint_url: str | None, monkeypatch: py
     ("aws_access_key_id", "aws_secret_access_key"), [("aws_access_key_id", None), (None, "aws_secret_access_key")]
 )
 def test_get_s3_client_incomplete_creds_via_args(
-    aws_access_key_id: str | None, aws_secret_access_key: str | None
+    aws_access_key_id: str | None, aws_secret_access_key: str | None, monkeypatch: pytest.MonkeyPatch
 ) -> None:
     """Verify that get_s3_client raises ValueError when only one of aws_access_key_id or aws_secret_access_key is provided via arguments."""
+    # Remove any real endpoint/credential env vars so moto intercepts all HTTP calls.
+    monkeypatch.delenv("AWS_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("AWS_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+    boto3.DEFAULT_SESSION = None
     reset_s3_client()
     assert s3_utils._s3_client is None  # noqa: SLF001
     args = {


### PR DESCRIPTION
# Description of PR purpose/changes
This PR swaps out MinIO for CEPH in documentation and test scripts.

The CEPH containerized test store seems quite a bit slower than the MinIO one was. I needed to reduce the number of records being processed in one of the integration tests to keep the runtime reasonable for CI. Also, there is a documented limitation of this CEPH test store that prevents inspecting the store contents via the dashboard, which means it's no longer possible to check the results of running the tests on the store directly (see https://github.com/kbasetest/ceph-rgw-test-image#known-issues)

There might be a race condition or something similar going on during the setup of the CEPH container. It failed once and just rerunning the action was enough for it to pass. If similar failures occur periodically, I can try to narrow down the problem enough to submit it as an issue on the `ceph-rgw-test-image` repo. There was also a seemingly unrelated error that popped up in the S3 tests that just required resetting the environment variables for S3 credentials.

closes #170

# Testing Instructions
* Details for how to test the PR:
Testing instructions in the README have been updated to use the CEPH test container.

- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
  * I can't access this
- [x] My submission follows the [AI Covenant](/AI_COVENANT.md) principles
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] (N/A) I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run Ruff `format` to format my code
- [x] I have run Ruff `check` and fixed any errors that it uncovered
- [x] (N/A) Any dependent changes have been merged and published in downstream modules