### PR TITLE
Update CEPH-backed integration tests

### DIFF
--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -1,4 +1,4 @@
-name: Integration tests
+name: CEPH Integration tests
 
 on:
     workflow_call:
@@ -17,14 +17,14 @@ permissions:
     contents: read
 
 jobs:
-    integration_tests:
+    ceph_integration_tests:
         runs-on: ubuntu-latest
 
         steps:
             - name: Checkout
               uses: actions/checkout@v6
 
-            - name: Run integration tests
+            - name: Run CEPH-backed integration tests
               run: |
                   docker compose up \
                     --build \
@@ -40,7 +40,7 @@ jobs:
                   echo "=== ceph logs ==="
                   docker logs cdm-data-loaders-ceph-1 || true
 
-                  echo "=== integration test logs ==="
+                  echo "=== ceph integration test logs ==="
                   docker logs cdm-data-loaders-integration-tests-1 || true
 
                   echo "=== ceph inspect state ==="

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -91,4 +91,4 @@ jobs:
       - name: Run local tests
         shell: bash
         continue-on-error: false
-        run: uv run pytest -m "not requires_spark"
+        run: uv run pytest -m "not requires_spark and not requires_ceph"

--- a/README.md
+++ b/README.md
@@ -142,16 +142,16 @@ See the [BERDataLakehouse/spark_notebook](https://github.com/BERDataLakehouse/sp
 
 Tests are categorised using pytest markers to allow developers to execute some or all the tests. See [pyproject.toml](pyproject.toml) for the markers used.
 
-To run all tests (requires a running Spark instance), execute the command:
+To run all tests (requires a running Spark instance and a running CEPH test container), execute the command:
 
 ```sh
 > uv run pytest
 ```
 
-To run only tests that do not require Spark, run
+To run only tests that do not require Spark or CEPH, run
 
 ```sh
-> uv run pytest -m "not requires_spark"
+> uv run pytest -m "not requires_spark and not requires_ceph"
 ```
 
 To generate coverage for the tests, run

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Repo for CDM input data loading and wrangling
   - [Development](#development)
     - [Spark and other non-python dependencies](#spark-and-other-non-python-dependencies)
     - [Tests](#tests)
-      - [Integration tests (CEPH + NCBI FTP)](#integration-tests-ceph--ncbi-ftp)
+      - [CEPH-Backed integration tests (CEPH + NCBI FTP)](#ceph-backed-integration-tests-ceph--ncbi-ftp)
   - [Loading genomes, contigs, and features](#loading-genomes-contigs-and-features)
   - [Running bbmap stats and checkm2 on genome or contigset files](#running-bbmap-stats-and-checkm2-on-genome-or-contigset-files)
 
@@ -162,7 +162,7 @@ To generate coverage for the tests, run
 The standard python `coverage` package is used and coverage can be generated as html or other formats by changing the parameters.
 
 
-#### Integration tests (CEPH + NCBI FTP)
+#### CEPH-Backed integration tests (CEPH + NCBI FTP)
 
 End-to-end integration tests for the NCBI assembly pipeline live in `tests/integration/`. They exercise the full flow — manifest diffing, FTP download, S3 promote/archive — against a locally running [CEPH](https://ceph.io/) container and the real NCBI FTP server.
 
@@ -204,10 +204,8 @@ docker run -d \
 **2. Run the integration tests:**
 
 ```sh
-> uv run pytest tests/integration/ -m integration -v
+> uv run pytest tests/integration/ -m requires_ceph -v
 ```
-
-Tests are automatically skipped when CEPH is not reachable, so the default `uv run pytest` will never fail due to a missing CEPH instance.
 
 **3. Inspect results:**
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -27,5 +27,5 @@ services:
       AWS_ENDPOINT_URL: http://ceph:8080
       AWS_ACCESS_KEY_ID: test_access_key
       AWS_SECRET_ACCESS_KEY: test_access_secret
-    entrypoint: [ "/app/scripts/entrypoint.sh", "integration_test" ]
+    entrypoint: [ "/app/scripts/entrypoint.sh", "ceph_integration_test" ]
     command: []

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -191,7 +191,7 @@ log_cli = true
 log_cli_level = "INFO"
 log_level = "INFO"
 addopts = ["-v"]
-markers = ["requires_spark: must be run in an environment where spark is available", "s3: tests that mock s3 interactions", "slow_test: does what it says on the tin", "integration: end-to-end tests requiring a running CEPH instance and network access", "external_request: tests that make real network requests to external services (e.g. NCBI FTP)"]
+markers = ["requires_spark: must be run in an environment where spark is available", "s3: tests that mock s3 interactions", "slow_test: does what it says on the tin", "requires_ceph: end-to-end tests requiring a running CEPH instance and network access", "external_request: tests that make real network requests to external services (e.g. NCBI FTP)"]
 
 # environment settings for running tests
 [tool.pytest_env]

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-VALID_COMMANDS=(all_the_bacteria ncbi_ftp_sync ncbi_rest_api uniprot uniref xml_split test integration_test bash)
+VALID_COMMANDS=(all_the_bacteria ncbi_ftp_sync ncbi_rest_api uniprot uniref xml_split test ceph_integration_test bash)
 
 usage() {
   local joined
@@ -40,9 +40,9 @@ case "$cmd" in
   test)
     exec /usr/bin/tini -- uv run --no-sync pytest -m "not requires_spark"
     ;;
-  integration_test)
-    # run the integration tests (requires a running CEPH instance)
-    exec /usr/bin/tini -- uv run --no-sync pytest -m "integration" -v "$@"
+  ceph_integration_test)
+    # run the CEPH-backed integration tests (requires a running CEPH instance)
+    exec /usr/bin/tini -- uv run --no-sync pytest -m "requires_ceph" -v "$@"
     ;;
   bash)
     exec /usr/bin/tini -- /bin/bash

--- a/scripts/entrypoint.sh
+++ b/scripts/entrypoint.sh
@@ -38,7 +38,7 @@ case "$cmd" in
     exec /usr/bin/tini -- xml_file_splitter "$@"
     ;;
   test)
-    exec /usr/bin/tini -- uv run --no-sync pytest -m "not requires_spark"
+    exec /usr/bin/tini -- uv run --no-sync pytest -m "not requires_spark and not requires_ceph"
     ;;
   ceph_integration_test)
     # run the CEPH-backed integration tests (requires a running CEPH instance)

--- a/scripts/run_tests.sh
+++ b/scripts/run_tests.sh
@@ -10,4 +10,4 @@ cd "$SCRIPT_DIR"
 uv venv --system-site-packages
 
 # run the tests using the active venv and with the dev dependencies installed.
-uv run --active --frozen --group dev pytest --cov=src --cov-report=xml
+uv run --active --frozen --group dev pytest -m "not requires_ceph" --cov=src --cov-report=xml

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -14,6 +14,7 @@ from unittest.mock import patch
 
 import boto3
 import botocore.client
+import botocore.config
 import pytest
 
 import cdm_data_loaders.ncbi_ftp.manifest as manifest_mod
@@ -24,6 +25,44 @@ from cdm_data_loaders.utils.s3 import reset_s3_client
 
 # Maximum length of a bucket name per S3/DNS spec
 _MAX_BUCKET_LEN = 63
+
+
+# CEPH reachability check
+
+_ceph_available: bool | None = None
+
+
+def _ceph_reachable() -> bool:
+    """Return True if the CEPH endpoint accepts connections."""
+    try:
+        client = boto3.client(
+            "s3",
+            config=botocore.config.Config(
+                connect_timeout=1,
+                read_timeout=1,
+                retries={"max_attempts": 1},
+            ),
+        )
+        client.list_buckets()
+    except Exception:  # noqa: BLE001
+        return False
+    return True
+
+
+def pytest_runtest_setup(item: pytest.Item) -> None:
+    """Fail CEPH-required tests early when CEPH is unavailable."""
+    if "requires_ceph" not in item.keywords:
+        return
+
+    global _ceph_available  # noqa: PLW0603
+    if _ceph_available is None:
+        _ceph_available = _ceph_reachable()
+
+    if not _ceph_available:
+        pytest.fail(
+            "CEPH not reachable. Start a CEPH test store or deselect with -m 'not requires_ceph'.",
+            pytrace=False,
+        )
 
 
 # Fixtures

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -1,9 +1,8 @@
 """Shared fixtures and helpers for CEPH-backed integration tests.
 
-Integration tests are auto-skipped when CEPH is not reachable.  Each test
-method gets its own bucket (derived from the test node name) that is emptied
-on re-run but **never deleted** after the test — this lets developers inspect
-the final state of the object store. The CEPH dashboard does not currently
+Each test method gets its own bucket (derived from the test node name) that is
+emptied on re-run but **never deleted** after the test — this lets developers
+inspect the final state of the object store. The CEPH dashboard does not currently
 allow inspection of the store, but the `s3_local` command-line tool can be used.
 """
 
@@ -15,7 +14,6 @@ from unittest.mock import patch
 
 import boto3
 import botocore.client
-import botocore.config
 import pytest
 
 import cdm_data_loaders.ncbi_ftp.manifest as manifest_mod
@@ -26,41 +24,6 @@ from cdm_data_loaders.utils.s3 import reset_s3_client
 
 # Maximum length of a bucket name per S3/DNS spec
 _MAX_BUCKET_LEN = 63
-
-
-# CEPH reachability check
-
-_ceph_available: bool | None = None
-
-
-def _ceph_reachable() -> bool:
-    """Return True if the CEPH endpoint accepts connections."""
-    try:
-        client = boto3.client(
-            "s3",
-            config=botocore.config.Config(
-                connect_timeout=1,
-                read_timeout=1,
-                retries={"max_attempts": 1},
-            ),
-        )
-        client.list_buckets()
-    except Exception:  # noqa: BLE001
-        return False
-    return True
-
-
-def pytest_collection_modifyitems(config: pytest.Config, items: list[pytest.Item]) -> None:  # noqa: ARG001
-    """Auto-skip ``@pytest.mark.integration`` tests when CEPH is unreachable."""
-    global _ceph_available  # noqa: PLW0603
-    if _ceph_available is None:
-        _ceph_available = _ceph_reachable()
-    if _ceph_available:
-        return
-    skip_marker = pytest.mark.skip(reason="CEPH not reachable — skipping integration tests")
-    for item in items:
-        if "integration" in item.keywords:
-            item.add_marker(skip_marker)
 
 
 # Fixtures

--- a/tests/integration/test_download_e2e.py
+++ b/tests/integration/test_download_e2e.py
@@ -1,8 +1,8 @@
 """End-to-end tests for Phase 2 — FTP download of assemblies.
 
 These tests download real (small) assemblies from the NCBI FTP server.
-Marked ``requires_ceph`` and ``slow_test``; auto-skipped when CEPH is
-unreachable.
+Marked ``requires_ceph`` (if a running CEPH test store is required) and
+``slow_test``.
 """
 
 import json
@@ -44,7 +44,6 @@ def _manifest_for_one_assembly(tmp_path: Path) -> tuple[Path, str]:
     return manifest_path, diff.new[0]
 
 
-@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 class TestDownloadSmallBatch:
@@ -87,7 +86,6 @@ class TestDownloadSmallBatch:
         assert saved_report["succeeded"] >= 1
 
 
-@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 class TestDownloadResumeIncomplete:

--- a/tests/integration/test_download_e2e.py
+++ b/tests/integration/test_download_e2e.py
@@ -1,7 +1,7 @@
 """End-to-end tests for Phase 2 — FTP download of assemblies.
 
 These tests download real (small) assemblies from the NCBI FTP server.
-Marked ``integration`` and ``slow_test``; auto-skipped when CEPH is
+Marked ``requires_ceph`` and ``slow_test``; auto-skipped when CEPH is
 unreachable.
 """
 
@@ -44,7 +44,7 @@ def _manifest_for_one_assembly(tmp_path: Path) -> tuple[Path, str]:
     return manifest_path, diff.new[0]
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 class TestDownloadSmallBatch:
@@ -87,7 +87,7 @@ class TestDownloadSmallBatch:
         assert saved_report["succeeded"] >= 1
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 class TestDownloadResumeIncomplete:
@@ -128,7 +128,7 @@ class TestDownloadResumeIncomplete:
         assert files_after_first.issubset(files_after_second)
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 def test_download_and_stage_e2e(

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -7,7 +7,6 @@ Marked ``requires_ceph`` (when a runnning CEPH test store is required) and
 ``slow_test``.
 """
 
-
 from pathlib import Path
 
 import pytest

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -3,8 +3,8 @@
 Exercises the entire flow: download summary from real NCBI FTP, compute diff,
 download a single assembly, stage in CEPH, promote to final Lakehouse path.
 
-Marked ``requires_ceph`` and ``slow_test``; auto-skipped when CEPH is
-unreachable.
+Marked ``requires_ceph`` (when a runnning CEPH test store is required) and
+``slow_test``.
 """
 
 from __future__ import annotations

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -7,14 +7,10 @@ Marked ``requires_ceph`` (when a runnning CEPH test store is required) and
 ``slow_test``.
 """
 
-from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from pathlib import Path
 
 import pytest
-
-if TYPE_CHECKING:
-    from pathlib import Path
 
 from cdm_data_loaders.ncbi_ftp.manifest import (
     AssemblyRecord,
@@ -29,7 +25,7 @@ from cdm_data_loaders.ncbi_ftp.manifest import (
 from cdm_data_loaders.ncbi_ftp.promote import DEFAULT_LAKEHOUSE_KEY_PREFIX, promote_from_s3
 from cdm_data_loaders.pipelines.ncbi_ftp_download import download_batch
 
-from .conftest import get_object_metadata, list_all_keys, stage_files_to_ceph, staging_test_bucket  # noqa: F401
+from .conftest import get_object_metadata, list_all_keys, stage_files_to_ceph
 
 STABLE_PREFIX = "900"
 STAGING_PREFIX = "staging/run1/"

--- a/tests/integration/test_full_pipeline.py
+++ b/tests/integration/test_full_pipeline.py
@@ -3,7 +3,7 @@
 Exercises the entire flow: download summary from real NCBI FTP, compute diff,
 download a single assembly, stage in CEPH, promote to final Lakehouse path.
 
-Marked ``integration`` and ``slow_test``; auto-skipped when CEPH is
+Marked ``requires_ceph`` and ``slow_test``; auto-skipped when CEPH is
 unreachable.
 """
 
@@ -36,7 +36,7 @@ STAGING_PREFIX = "staging/run1/"
 PATH_PREFIX = DEFAULT_LAKEHOUSE_KEY_PREFIX
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 class TestFullPipelineSmallBatch:
@@ -104,7 +104,7 @@ class TestFullPipelineSmallBatch:
         assert has_md5, "Expected at least one file with MD5 metadata"
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 class TestFullPipelineIncrementalSync:

--- a/tests/integration/test_manifest_e2e.py
+++ b/tests/integration/test_manifest_e2e.py
@@ -2,7 +2,7 @@
 
 These tests hit the real NCBI FTP server (with tight prefix filters) and
 optionally use CEPH for checksum verification.  Marked ``requires_ceph``
-and ``slow_test``; auto-skipped when CEPH is unreachable.
+(if a running CEPH test store is required) and ``slow_test``.
 """
 
 from __future__ import annotations
@@ -56,7 +56,6 @@ def _download_and_filter() -> tuple[dict[str, AssemblyRecord], dict[str, Assembl
 # Tests
 
 
-@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 class TestFreshSyncNoPrevious:
@@ -94,7 +93,6 @@ class TestFreshSyncNoPrevious:
         assert summary_path.exists()
 
 
-@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 class TestIncrementalDiffSyntheticPrevious:

--- a/tests/integration/test_manifest_e2e.py
+++ b/tests/integration/test_manifest_e2e.py
@@ -1,7 +1,7 @@
 """End-to-end tests for Phase 1 — manifest generation and diffing.
 
 These tests hit the real NCBI FTP server (with tight prefix filters) and
-optionally use CEPH for checksum verification.  Marked ``integration``
+optionally use CEPH for checksum verification.  Marked ``requires_ceph``
 and ``slow_test``; auto-skipped when CEPH is unreachable.
 """
 
@@ -56,7 +56,7 @@ def _download_and_filter() -> tuple[dict[str, AssemblyRecord], dict[str, Assembl
 # Tests
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 class TestFreshSyncNoPrevious:
@@ -94,7 +94,7 @@ class TestFreshSyncNoPrevious:
         assert summary_path.exists()
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 class TestIncrementalDiffSyntheticPrevious:
@@ -157,7 +157,7 @@ class TestIncrementalDiffSyntheticPrevious:
         assert updated_acc in updated_list
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 @pytest.mark.external_request
 class TestVerifyTransferCandidatesPrunes:
@@ -238,7 +238,7 @@ class TestVerifyTransferCandidatesPrunes:
             assert c in result, f"Expected {c} to remain (not seeded)"
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestScanStoreToSyntheticSummary:
     """Test synthetic assembly summary generation from CEPH store."""

--- a/tests/integration/test_promote_e2e.py
+++ b/tests/integration/test_promote_e2e.py
@@ -4,8 +4,8 @@ Pre-stages fake assembly files in CEPH and exercises ``promote_from_s3``
 with various combinations of manifests, archive operations, dry-run mode,
 manifest trimming, and incomplete staging.
 
-Marked ``requires_ceph`` and ``slow_test``; auto-skipped when CEPH is
-unreachable.  Each test method gets its own bucket.
+Marked ``requires_ceph`` (when a running CEPH test store is required) and
+``slow_test``.  Each test method gets its own bucket.
 """
 
 import hashlib

--- a/tests/integration/test_promote_e2e.py
+++ b/tests/integration/test_promote_e2e.py
@@ -4,7 +4,7 @@ Pre-stages fake assembly files in CEPH and exercises ``promote_from_s3``
 with various combinations of manifests, archive operations, dry-run mode,
 manifest trimming, and incomplete staging.
 
-Marked ``integration`` and ``slow_test``; auto-skipped when CEPH is
+Marked ``requires_ceph`` and ``slow_test``; auto-skipped when CEPH is
 unreachable.  Each test method gets its own bucket.
 """
 
@@ -76,7 +76,7 @@ def _write_manifest(tmp_path: Path, accessions: list[str], name: str) -> Path:
 # Tests
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteFromStaging:
     """Promote staged files to final Lakehouse paths."""
@@ -107,7 +107,7 @@ class TestPromoteFromStaging:
             assert "md5" in meta, f"Missing md5 metadata on {key}"
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteIdempotent:
     """Promoting the same staging data twice should succeed without errors."""
@@ -145,7 +145,7 @@ class TestPromoteIdempotent:
         assert keys_after_first == keys_after_second
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteArchiveUpdated:
     """Archive existing assemblies before overwriting with updated versions."""
@@ -191,7 +191,7 @@ class TestPromoteArchiveUpdated:
             assert "/2024-01/" in key
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteArchiveRemoved:
     """Archive and delete replaced/suppressed assemblies."""
@@ -237,7 +237,7 @@ class TestPromoteArchiveRemoved:
         assert len(source_keys) == 0, f"Expected source objects deleted, found: {source_keys}"
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteDryRun:
     """Dry-run mode should not create any objects."""
@@ -263,7 +263,7 @@ class TestPromoteDryRun:
         assert len(final_keys) == 0, f"Dry-run should not create objects, found: {final_keys}"
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteTrimsManifest:
     """Manifest trimming removes promoted accessions."""
@@ -307,7 +307,7 @@ class TestPromoteTrimsManifest:
         assert "GCF_900000003" in remaining_lines[0]
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteIncompleteStaging:
     """Incomplete staging (sidecar only, no data) should not promote anything."""
@@ -339,7 +339,7 @@ class TestPromoteIncompleteStaging:
         assert len(final_keys) == 0
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteCreatesDescriptor:
     """Promote step writes a frictionless descriptor for each promoted assembly."""
@@ -428,7 +428,7 @@ class TestPromoteCreatesDescriptor:
             assert body["identifier"] == f"NCBI:{accession}"
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteArchiveUpdatedIncludesDescriptor:
     """Archiving updated assemblies also archives the descriptor."""
@@ -466,7 +466,7 @@ class TestPromoteArchiveUpdatedIncludesDescriptor:
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200  # noqa: PLR2004
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteArchiveRemovedIncludesDescriptor:
     """Archiving removed assemblies also archives the descriptor."""
@@ -501,7 +501,7 @@ class TestPromoteArchiveRemovedIncludesDescriptor:
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200  # noqa: PLR2004
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteDryRunNoDescriptor:
     """Dry-run must not write any descriptor files."""
@@ -526,7 +526,7 @@ class TestPromoteDryRunNoDescriptor:
 # Parallel archiving tests
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestArchiveMultiFileConcurrent:
     """Verify parallel copy archives all files correctly with correct content."""
@@ -597,7 +597,7 @@ class TestArchiveMultiFileConcurrent:
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == 200  # noqa: PLR2004
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestArchiveDeleteSourceBatch:
     """Verify batch delete removes all source objects after concurrent copy."""
@@ -665,7 +665,7 @@ class TestArchiveDeleteSourceBatch:
         assert len(source_keys) == 0, f"Source objects remain: {source_keys}"
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPartialArchiveResume:
     """Corner case: a prior archive run was interrupted mid-way.
@@ -826,7 +826,7 @@ class TestPartialArchiveResume:
             assert obj["Body"].read() == expected_body
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestArchiveMultiAccessionManifest:
     """Multiple accessions in a single manifest are all archived."""
@@ -905,7 +905,7 @@ class TestArchiveMultiAccessionManifest:
             assert "/2024-03/" in key, f"Archive key missing release segment: {key}"
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestArchiveDryRunParallel:
     """Dry-run with many files leaves everything unchanged."""
@@ -966,7 +966,7 @@ def _stage_many(
             s3.put_object(Bucket=bucket, Key=f"{key}.md5", Body=_md5(content).encode())
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteMultiFileConcurrent:
     """Verify concurrent promotion lands all files with correct content and MD5."""
@@ -1047,7 +1047,7 @@ class TestPromoteMultiFileConcurrent:
         assert "md5" not in meta, f"Expected no md5 metadata, got: {meta}"
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteStagingCleanup:
     """After a fully successful promote, all staged files and sidecars are deleted."""
@@ -1129,7 +1129,7 @@ class TestPromoteStagingCleanup:
         assert len(remaining) == 0, f"Staging not fully cleaned after two-assembly promote: {remaining}"
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteTwoAssembliesBothLand:
     """Both assemblies staged together are both promoted to correct Lakehouse paths."""
@@ -1185,7 +1185,7 @@ class TestPromoteTwoAssembliesBothLand:
         assert keys_a[0] != keys_b[0]
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteDryRunMultiFile:
     """dry_run leaves staging untouched and writes nothing to the Lakehouse."""
@@ -1242,7 +1242,7 @@ class TestPromoteDryRunMultiFile:
         assert len(final_keys) == 0, f"Dry-run created objects: {final_keys}"
 
 
-@pytest.mark.integration
+@pytest.mark.requires_ceph
 @pytest.mark.slow_test
 class TestPromoteSecondRunOnEmptyStaging:
     """After staging is cleaned, a second promote run promotes 0 files without error."""


### PR DESCRIPTION
# Description of PR purpose/changes
This PR relabels the CEPH-backed integration tests as `requires_ceph` and lets those tests fail if the CEPH test store is not reachable to flag any potential issues with the CI test setup.

closes #176

# Testing Instructions
Locally, without a CEPH container running, run:
```
uv pytest -m "not requires_spark"
```
You should see about 40 or so test failures (the ones that require the CEPH test store)
Then, run:
```
uv pytest -m "not requires_spark and not requires_ceph"
```
and all tests should pass (CEPH tests skipped).

Then, run:
```
docker run -d \
  --name ceph \
  -p 9000:8080 \
  -p 9001:8443 \
  -e RGW_PORT=8080 \
  -e RGW_ACCESS_KEY=test_access_key \
  -e RGW_SECRET_KEY=test_access_secret \
  ghcr.io/kbasetest/ceph-rgw-test-image:0.1.5
uv pytest -m "not requires_spark"
```
All the tests should pass (CEPH tests not skipped)

- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [ ] My code follows the guidelines at https://sites.google.com/lbl.gov/trussresources/home?authuser=0
  - I can't access this
- [x] My submission follows the [AI Covenant](/AI_COVENANT.md) principles
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] N/A I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run Ruff `format` to format my code
- [x] (errors are preexisting) I have run Ruff `check` and fixed any errors that it uncovered
- [x] N/A Any dependent changes have been merged and published in downstream modules
