### PR TITLE
Make private dependency optional

### DIFF
--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -78,4 +78,4 @@ jobs:
                   labels: ${{ steps.meta.outputs.labels }}
                   platforms: linux/amd64,linux/arm64/v8
                   secrets: |
-                        "github_berdl_token=${{ secrets.GITHUB_BERDL_TOKEN }}"
+                        github_berdl_token=${{ secrets.GITHUB_BERDL_TOKEN }}

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -58,6 +58,8 @@ jobs:
                   tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.TEST_TAG }}
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
+                  secrets: |
+                        "github_berdl_token=${{ secrets.GITHUB_BERDL_TOKEN }}"
 
             - name: Run non-spark tests on the built image
               id: run-tests-docker
@@ -75,3 +77,5 @@ jobs:
                   tags: ${{ steps.meta.outputs.tags }}
                   labels: ${{ steps.meta.outputs.labels }}
                   platforms: linux/amd64,linux/arm64/v8
+                  secrets: |
+                        "github_berdl_token=${{ secrets.GITHUB_BERDL_TOKEN }}"

--- a/.github/workflows/docker_build.yaml
+++ b/.github/workflows/docker_build.yaml
@@ -59,7 +59,7 @@ jobs:
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
                   secrets: |
-                        "github_berdl_token=${{ secrets.GITHUB_BERDL_TOKEN }}"
+                        github_berdl_token=${{ secrets.GITHUB_BERDL_TOKEN }}
 
             - name: Run non-spark tests on the built image
               id: run-tests-docker

--- a/.github/workflows/integration_tests.yaml
+++ b/.github/workflows/integration_tests.yaml
@@ -25,6 +25,8 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Run CEPH-backed integration tests
+              env:
+                  GITHUB_BERDL_TOKEN: ${{ secrets.GITHUB_BERDL_TOKEN }}
               run: |
                   docker compose up \
                     --build \

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,6 +26,8 @@ jobs:
           enable-cache: true
 
       - name: Install dependencies
+        env:
+          GITHUB_BERDL_TOKEN: ${{ secrets.GITHUB_BERDL_TOKEN }}
         run: uv sync
 
       - name: Run code formatting checks
@@ -86,6 +88,8 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
+        env:
+          GITHUB_BERDL_TOKEN: ${{ secrets.GITHUB_BERDL_TOKEN }}
         run: uv sync --dev
 
       - name: Run local tests

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -47,7 +47,7 @@ jobs:
                   cache-from: type=gha
                   cache-to: type=gha,mode=max
                   secrets: |
-                      "github_berdl_token=${{ secrets.GITHUB_BERDL_TOKEN }}"
+                      github_berdl_token=${{ secrets.GITHUB_BERDL_TOKEN }}
 
             - name: Run Trivy vulnerability scanner
               uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe

--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -38,8 +38,16 @@ jobs:
               uses: actions/checkout@v6
 
             - name: Build an image from Dockerfile
-              run: |
-                  docker build -t ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }} .
+              uses: docker/build-push-action@v7
+              id: build-image
+              with:
+                  context: .
+                  load: true
+                  tags: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:${{ github.sha }}
+                  cache-from: type=gha
+                  cache-to: type=gha,mode=max
+                  secrets: |
+                      "github_berdl_token=${{ secrets.GITHUB_BERDL_TOKEN }}"
 
             - name: Run Trivy vulnerability scanner
               uses: aquasecurity/trivy-action@7b7aa264d83dc58691451798b4d117d53d21edfe

--- a/Dockerfile
+++ b/Dockerfile
@@ -53,7 +53,12 @@ RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
     --mount=type=secret,id=github_berdl_token \
-    GITHUB_BERDL_TOKEN=$(cat /run/secrets/github_berdl_token) \
+    if [ -f /run/secrets/github_berdl_token ]; then \
+        export GITHUB_BERDL_TOKEN=$(cat /run/secrets/github_berdl_token); \
+        export GIT_CONFIG_COUNT=1; \
+        export GIT_CONFIG_KEY_0="url.https://x-access-token:${GITHUB_BERDL_TOKEN}@github.com/.insteadOf"; \
+        export GIT_CONFIG_VALUE_0="https://github.com/"; \
+    fi && \
     uv sync ${EXTRAS} --locked --no-install-project --no-editable
 
 # Then, add the rest of the project source code and install it
@@ -69,7 +74,12 @@ COPY --chown=nonroot:nonroot uv.lock /app/uv.lock
 
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=secret,id=github_berdl_token \
-    GITHUB_BERDL_TOKEN=$(cat /run/secrets/github_berdl_token) \
+    if [ -f /run/secrets/github_berdl_token ]; then \
+        export GITHUB_BERDL_TOKEN=$(cat /run/secrets/github_berdl_token); \
+        export GIT_CONFIG_COUNT=1; \
+        export GIT_CONFIG_KEY_0="url.https://x-access-token:${GITHUB_BERDL_TOKEN}@github.com/.insteadOf"; \
+        export GIT_CONFIG_VALUE_0="https://github.com/"; \
+    fi && \
     uv sync ${EXTRAS} --locked --no-editable
 
 # Place executables in the environment at the front of the path

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
 
 ARG QSV_VERSION="20.1.0"
 ARG XML_FILE_SPLITTER_VERSION="v0.1.2"
+ARG EXTRAS="--extra spark"
 
 # Set environment variable to noninteractive to prevent prompts during apt operations
 ENV DEBIAN_FRONTEND=noninteractive
@@ -51,7 +52,9 @@ WORKDIR /app
 RUN --mount=type=cache,target=/root/.cache/uv \
     --mount=type=bind,source=uv.lock,target=uv.lock \
     --mount=type=bind,source=pyproject.toml,target=pyproject.toml \
-    uv sync --locked --no-install-project --no-editable
+    --mount=type=secret,id=github_berdl_token \
+    GITHUB_BERDL_TOKEN=$(cat /run/secrets/github_berdl_token) \
+    uv sync ${EXTRAS} --locked --no-install-project --no-editable
 
 # Then, add the rest of the project source code and install it
 # Installing separately from its dependencies allows optimal layer caching
@@ -65,7 +68,9 @@ COPY --chown=nonroot:nonroot pyproject.toml /app/pyproject.toml
 COPY --chown=nonroot:nonroot uv.lock /app/uv.lock
 
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --locked --no-editable
+    --mount=type=secret,id=github_berdl_token \
+    GITHUB_BERDL_TOKEN=$(cat /run/secrets/github_berdl_token) \
+    uv sync ${EXTRAS} --locked --no-editable
 
 # Place executables in the environment at the front of the path
 ENV PATH="/app/.venv/bin:$PATH"

--- a/README.md
+++ b/README.md
@@ -40,6 +40,12 @@ To manually set up the virtual environment and install dependencies (including p
 > uv sync
 ```
 
+Note that this will exclude some Spark dependencies in private repos and disable Spark tests.
+To include these:
+```sh
+> uv sync --extra spark
+```
+
 To activate a virtual environment with these dependencies installed, run
 
 ```sh

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -20,6 +20,10 @@ services:
     image: cdm-data-loaders-integration-tests:latest
     build:
       context: .
+      args:
+        EXTRAS: ${EXTRAS---extra spark}
+      secrets:
+        - github_berdl_token
     depends_on:
       ceph:
         condition: service_healthy
@@ -29,3 +33,7 @@ services:
       AWS_SECRET_ACCESS_KEY: test_access_secret
     entrypoint: [ "/app/scripts/entrypoint.sh", "ceph_integration_test" ]
     command: []
+
+secrets:
+  github_berdl_token:
+    environment: GITHUB_BERDL_TOKEN

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -227,5 +227,5 @@ AWS_SECRET_ACCESS_KEY = "test_access_secret"
 
 [tool.uv.sources]
 cdm-schema = { git = "https://github.com/kbase/cdm-schema.git" }
-berdl-notebook-utils = { git = "https://{GITHUB_BERDL_TOKEN}@github.com/KBaseDataLakehouse/spark_notebook.git", subdirectory = "notebook_utils" }
+berdl-notebook-utils = { git = "https://github.com/KBaseDataLakehouse/spark_notebook.git", subdirectory = "notebook_utils" }
 cdm-task-service-client = { git = "https://github.com/kbase/cdm-task-service-client.git" }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ uniref = "cdm_data_loaders.pipelines.uniref:cli"
 
 [dependency-groups]
 dev = [
-    "berdl-notebook-utils>=0.0.1",
     "cdm-task-service-client>=0.2.1",
     "moto[s3]>=5.2.1",
     "pytest>=9.0.2",
@@ -53,6 +52,10 @@ xml = [
 ]
 
 [project.optional-dependencies]
+
+spark = [
+    "berdl-notebook-utils>=0.0.1",
+]
 
 [tool.ruff]
 line-length = 120
@@ -224,5 +227,5 @@ AWS_SECRET_ACCESS_KEY = "test_access_secret"
 
 [tool.uv.sources]
 cdm-schema = { git = "https://github.com/kbase/cdm-schema.git" }
-berdl-notebook-utils = { git = "https://github.com/KBaseDataLakehouse/spark_notebook.git", subdirectory = "notebook_utils" }
+berdl-notebook-utils = { git = "https://{GITHUB_BERDL_TOKEN}@github.com/KBaseDataLakehouse/spark_notebook.git", subdirectory = "notebook_utils" }
 cdm-task-service-client = { git = "https://github.com/kbase/cdm-task-service-client.git" }

--- a/src/cdm_data_loaders/utils/spark.py
+++ b/src/cdm_data_loaders/utils/spark.py
@@ -6,7 +6,6 @@ from typing import Any
 
 from pyspark.sql import DataFrame, DataFrameWriter, SparkSession
 
-_spark_import_error: ModuleNotFoundError | None = None
 # Always export berdl functions for monkeypatching in tests, even when not present
 get_spark_session: Callable[..., Any] | None = None
 create_namespace_if_not_exists: Callable[..., str] | None = None
@@ -14,8 +13,8 @@ create_namespace_if_not_exists: Callable[..., str] | None = None
 try:
     from berdl_notebook_utils.setup_spark_session import get_spark_session
     from berdl_notebook_utils.spark.database import create_namespace_if_not_exists
-except ModuleNotFoundError as e:
-    _spark_import_error = e
+except ModuleNotFoundError:
+    pass
 
 
 logger: Logger = getLogger(__name__)

--- a/src/cdm_data_loaders/utils/spark.py
+++ b/src/cdm_data_loaders/utils/spark.py
@@ -6,17 +6,24 @@ from typing import Any
 
 from pyspark.sql import DataFrame, DataFrameWriter, SparkSession
 
-# Always export berdl functions for monkeypatching in tests, even when not present
-get_spark_session: Callable[..., Any] | None = None
-create_namespace_if_not_exists: Callable[..., str] | None = None
+_spark_import_error: ModuleNotFoundError | None = None
+
+
+def _missing_berdl(*args: Any, **kwargs: Any) -> Any:  # noqa: ANN401, ARG001
+    msg = "berdl-notebook-utils is required for Spark helpers; install with `uv sync --extra spark`."
+    raise ModuleNotFoundError(msg) from _spark_import_error
+
+
+# Always export berdl functions for monkeypatching in tests, even when optional deps aren't installed.
+get_spark_session: Callable[..., Any] = _missing_berdl
+create_namespace_if_not_exists: Callable[..., Any] = _missing_berdl
 
 try:
     from berdl_notebook_utils.setup_spark_session import get_spark_session
     from berdl_notebook_utils.spark.database import create_namespace_if_not_exists
 except ModuleNotFoundError as exc:
     # Optional dependency in non-notebook environments; keep defaults as None for monkeypatching/tests.
-    logger = getLogger(__name__)
-    logger.debug("Optional module 'berdl_notebook_utils' not available: %s", exc)
+    _spark_import_error = exc
 
 
 logger: Logger = getLogger(__name__)

--- a/src/cdm_data_loaders/utils/spark.py
+++ b/src/cdm_data_loaders/utils/spark.py
@@ -1,10 +1,22 @@
 """Utilities for interacting with Spark."""
 
+from collections.abc import Callable
 from logging import Logger, getLogger
+from typing import Any
 
-from berdl_notebook_utils.setup_spark_session import get_spark_session
-from berdl_notebook_utils.spark.database import create_namespace_if_not_exists
 from pyspark.sql import DataFrame, DataFrameWriter, SparkSession
+
+_spark_import_error: ModuleNotFoundError | None = None
+# Always export berdl functions for monkeypatching in tests, even when not present
+get_spark_session: Callable[..., Any] | None = None
+create_namespace_if_not_exists: Callable[..., str] | None = None
+
+try:
+    from berdl_notebook_utils.setup_spark_session import get_spark_session
+    from berdl_notebook_utils.spark.database import create_namespace_if_not_exists
+except ModuleNotFoundError as e:
+    _spark_import_error = e
+
 
 logger: Logger = getLogger(__name__)
 

--- a/src/cdm_data_loaders/utils/spark.py
+++ b/src/cdm_data_loaders/utils/spark.py
@@ -13,8 +13,10 @@ create_namespace_if_not_exists: Callable[..., str] | None = None
 try:
     from berdl_notebook_utils.setup_spark_session import get_spark_session
     from berdl_notebook_utils.spark.database import create_namespace_if_not_exists
-except ModuleNotFoundError:
-    pass
+except ModuleNotFoundError as exc:
+    # Optional dependency in non-notebook environments; keep defaults as None for monkeypatching/tests.
+    logger = getLogger(__name__)
+    logger.debug("Optional module 'berdl_notebook_utils' not available: %s", exc)
 
 
 logger: Logger = getLogger(__name__)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,7 @@
 """Global configuration settings for tests."""
 
 import datetime
+import importlib.util
 import logging
 import shutil
 from collections.abc import Generator
@@ -9,7 +10,6 @@ from pathlib import Path
 from typing import Any, Final
 
 import pytest
-from berdl_notebook_utils.setup_spark_session import generate_spark_conf
 from frozendict import frozendict
 from pyspark.conf import SparkConf
 from pyspark.sql import DataFrame, SparkSession
@@ -42,6 +42,24 @@ PIPELINE_RUN = frozendict({RUN_ID: "1234-5678-90", PIPELINE: "KeystoneXL", SOURC
 ALT_PIPELINE_RUN = frozendict({RUN_ID: "9876-5432-10", PIPELINE: "KeystoneXXXL", SOURCE: "/path/to/dir"})
 
 
+def _spark_extra_available() -> bool:
+    """Detects whether spark dependencies are present."""
+    return importlib.util.find_spec("berdl_notebook_utils") is not None
+
+
+SPARK_EXTRA_AVAILABLE = _spark_extra_available()
+
+
+def pytest_collection_modifyitems(items: list[pytest.Item]) -> None:
+    """Skip spark tests when dependencies are not present."""
+    if SPARK_EXTRA_AVAILABLE:
+        return
+    skip_spark = pytest.mark.skip(reason="requires_spark: install with `uv sync --extra spark`")
+    for item in items:
+        if "requires_spark" in item.keywords:
+            item.add_marker(skip_spark)
+
+
 @pytest.fixture(autouse=True)
 def logging_setup(caplog: pytest.LogCaptureFixture) -> None:
     """Fiddle with the loggers used in the tests for a better experience."""
@@ -57,6 +75,9 @@ def logging_setup(caplog: pytest.LogCaptureFixture) -> None:
 @pytest.fixture
 def spark(tmp_path: Path) -> Generator[SparkSession, Any]:
     """Generate a spark session with spark.sql.warehouse.dir set to the pytest temporary directory."""
+    # function level import to avoid failures when spark dependencies are not present
+    from berdl_notebook_utils.setup_spark_session import generate_spark_conf  # noqa: PLC0415
+
     logger = logging.getLogger(__name__)
     config = generate_spark_conf("test_delta_app", local=True, use_delta_lake=True)
     test_config = {

--- a/uv.lock
+++ b/uv.lock
@@ -502,9 +502,13 @@ dependencies = [
     { name = "tqdm" },
 ]
 
+[package.optional-dependencies]
+spark = [
+    { name = "berdl-notebook-utils" },
+]
+
 [package.dev-dependencies]
 dev = [
-    { name = "berdl-notebook-utils" },
     { name = "cdm-task-service-client" },
     { name = "moto", extra = ["s3"] },
     { name = "pytest" },
@@ -525,6 +529,7 @@ xml = [
 
 [package.metadata]
 requires-dist = [
+    { name = "berdl-notebook-utils", marker = "extra == 'spark'", git = "https://github.com/KBaseDataLakehouse/spark_notebook.git?subdirectory=notebook_utils" },
     { name = "bioregistry", specifier = ">=0.13.58" },
     { name = "boto3", extras = ["crt"], specifier = ">=1.42.55" },
     { name = "click", specifier = ">=8.4.1" },
@@ -539,10 +544,10 @@ requires-dist = [
     { name = "pydantic-settings", specifier = ">=2.14.1" },
     { name = "tqdm", specifier = ">=4.67.3" },
 ]
+provides-extras = ["spark"]
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "berdl-notebook-utils", git = "https://github.com/KBaseDataLakehouse/spark_notebook.git?subdirectory=notebook_utils" },
     { name = "cdm-task-service-client", git = "https://github.com/kbase/cdm-task-service-client.git" },
     { name = "moto", extras = ["s3"], specifier = ">=5.2.1" },
     { name = "pytest", specifier = ">=9.0.2" },


### PR DESCRIPTION
# Description of PR purpose/changes
This PR modifies the project configuration files, source, tests, and actions to make the newly private berdl-notebook-utils repo an optional dependency. When not included, tests marked `requires_spark` are skipped.

The actions updates haven't been tested yet because they require a GH secret `GITHUB_BERDL_TOKEN` to be set to a valid GH token with access to clone the private repo. I'll leave this in draft until this is added and the actions pass.

I tried to set up the actions and docker files so that the token is never written to log files. But, we should make sure this works (I haven't used Docker secrets, etc. much before)

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [ ] My submission follows the [AI Covenant](/AI_COVENANT.md) principles
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run Ruff `format` to format my code
- [ ] I have run Ruff `check` and fixed any errors that it uncovered

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release.
- [ ] [README](/README.md) has been updated for each release.
