### PR TITLE
Add `xsv-validate.sh` to Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,7 @@ RUN wget https://github.com/ialarmedalien/xml_file_splitter/releases/download/${
     wget https://github.com/cohere-llc/xsv-validator/archive/refs/tags/${XSV_VALIDATOR_VERSION}.tar.gz && \
     mkdir /tmp/xsv-validator && tar -xvf ${XSV_VALIDATOR_VERSION}.tar.gz --strip-components=1 -C /tmp/xsv-validator/ && \
     mv /tmp/xsv-validator/xsv-validate.sh /usr/local/bin/ && \
+    chmod +x /usr/local/bin/xsv-validate.sh && \
     rm -fr /tmp/* && \
     # qsv release -- only need the `qsv` binary from it
     wget https://github.com/dathere/qsv/releases/download/${QSV_VERSION}/qsv-${QSV_VERSION}-aarch64-unknown-linux-gnu.zip && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ FROM ghcr.io/astral-sh/uv:python3.13-trixie-slim
 
 ARG QSV_VERSION="20.1.0"
 ARG XML_FILE_SPLITTER_VERSION="v0.1.2"
+ARG XSV_VALIDATOR_VERSION="v2026-07"
 
 # Set environment variable to noninteractive to prevent prompts during apt operations
 ENV DEBIAN_FRONTEND=noninteractive
@@ -17,15 +18,23 @@ RUN apt-get update -y && apt-get install -y --no-install-recommends tini git ca-
 
 WORKDIR /tmp
 
-# download and install the xml_file_splitter and qsv binaries, and copy them to /usr/local/bin
+# download and install the xml_file_splitter, xsv-validator, and qsv binaries, and copy them to /usr/local/bin
 RUN wget https://github.com/ialarmedalien/xml_file_splitter/releases/download/${XML_FILE_SPLITTER_VERSION}/xml_file_splitter-aarch64-unknown-linux-gnu.tar.gz && \
     tar -xvf xml_file_splitter-aarch64-unknown-linux-gnu.tar.gz && \
     mv xml_file_splitter-aarch64-unknown-linux-gnu/xml_file_splitter /usr/local/bin/ && \
+    # xsv-validator, only need the script
+    wget https://github.com/cohere-llc/xsv-validator/archive/refs/tags/${XSV_VALIDATOR_VERSION}.tar.gz && \
+    mkdir /tmp/xsv-validator && tar -xvf ${XSV_VALIDATOR_VERSION}.tar.gz --strip-components=1 -C /tmp/xsv-validator/ && \
+    mv /tmp/xsv-validator/xsv-validate.sh /usr/local/bin/ && \
+    rm -fr /tmp/* && \
     # qsv release -- only need the `qsv` binary from it
     wget https://github.com/dathere/qsv/releases/download/${QSV_VERSION}/qsv-${QSV_VERSION}-aarch64-unknown-linux-gnu.zip && \
     unzip qsv-${QSV_VERSION}-aarch64-unknown-linux-gnu.zip -d /tmp/qsv && \
     mv /tmp/qsv/qsv /usr/local/bin/ && \
     rm -rf /tmp/*
+
+# check install of xsv-validate
+RUN xsv-validate.sh --help
 
 # Setup a non-root user
 RUN groupadd --system --gid 999 nonroot \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,9 @@ services:
     ports:
       - "9000:8080"
       - "9001:8443"
+    tmpfs:
+      - /var/lib/ceph
+    restart: on-failure
     healthcheck:
       # Two-part check:
       # 1. ceph osd stat: verifies at least one OSD has joined the cluster.


### PR DESCRIPTION
# Description of PR purpose/changes

This PR adds the newly minted [xsv-validator](https://github.com/cohere-llc/xsv-validator) to the `cdm-data-loaders` `Dockerfile` for use in validating CSV/TSV files using `qsv`

## List any dependencies that are required for this change.
- [xsv-validator](https://github.com/cohere-llc/xsv-validator)
- [qsv](https://github.com/dathere/qsv/tree/master)

## Minor Update
- I needed to add a Copilot-suggested workaround for the failing CEPH action. The problem appears to be a race condition of some kind. It doesn't seem like it's something that can be fixed on our end, so the work-around is to just try to speed up the build with a temporary filesystem, and restart the `ceph` service on a failure.

# Testing Instructions
Clone the repo and from the top-level folder run:
```sh
docker build -t cdm-data-loaders .
docker run --rm --entrypoint bash cdm-data-loaders -c "xsv-validate.sh --help"
```
You should see something like:
```sh
xsv-validate.sh — Normalize and validate a TSV/CSV file using qsv

Usage:
  ./xsv-validate.sh <input_file> -s <schema.json> -o <output_folder> [options]

Arguments:
  <input_file>       Path to the CSV or TSV file to validate

Options:
  --comment CHAR     Comment character to strip (default: #)
  --delimiter SEP    Field delimiter: 'tab' or any single char (default: auto-detect)
  -h, --help         Show this help message
  --keep-temp        Keep intermediate temporary files for debugging
  --missing-header   Indicates the input file lacks a header row. The schema will be used to create one.
  --null STRING      String to treat as a null value (multiple allowed; default: common set of strings)
  -o, --output PATH  Relative path to output folder. Will be created if needed. (REQUIRED)
  -s, --schema PATH  Relative file path for the JSONSchema file (REQUIRED)
  --skip-lines N     Number of header/preamble lines to skip (default: 0)
  --summary-file     Output a summary file for the validation (default: disabled)

Outputs (written to output folder):
  <input_file>.valid                 - Rows that passed validation
  <input_file>.invalid               - Rows that failed validation
  <input_file>.validation-errors.tsv - Detailed per-field error report
  <input_file>.summary.json          - Summary file for the validation
-----------------------------------------------------------------------------
```

- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My submission follows the [AI Covenant](/AI_COVENANT.md) principles
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] N/A I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] N/A I have run Ruff `format` to format my code
- [x] N/A I have run Ruff `check` and fixed any errors that it uncovered

