### PR TITLE
Moving the settings objects to cdm_data_loaders.core

### DIFF
--- a/src/cdm_data_loaders/core/fields.py
+++ b/src/cdm_data_loaders/core/fields.py
@@ -44,8 +44,8 @@ SHORT_ALIASES = frozendict(
     {
         DEV_MODE: [],
         LOG_CONFIG_FILE: [],
-        USE_DESTINATION: ["-d"],
-        USE_OUTPUT_DIR_FOR_PIPELINE_METADATA: ["-p"],
+        USE_DESTINATION: ["d"],
+        USE_OUTPUT_DIR_FOR_PIPELINE_METADATA: ["p"],
     }
 )
 
@@ -60,16 +60,16 @@ def generate_aliases(field_name: str, short_aliases: bool = True) -> list[str]: 
     :return: A list of aliases for the field.
     :rtype: list[str]
     """
-    field_names = [f"--{field_name}"]
+    field_names = [field_name]
     if "_" in field_name:
-        field_names.append(f"--{field_name.replace('_', '-')}")
+        field_names.append(field_name.replace("_", "-"))
 
     if short_aliases:
-        return [*SHORT_ALIASES.get(field_name, [f"-{field_name[0]}"]), *field_names]
+        return [*SHORT_ALIASES.get(field_name, [field_name[0]]), *field_names]
     return field_names
 
 
-ARG_ALIASES = frozendict(
+ALIASES = frozendict(
     {
         k: generate_aliases(k)
         for k in [
@@ -84,12 +84,13 @@ ARG_ALIASES = frozendict(
     }
 )
 
+
 DevMode = Annotated[
     bool,
     Field(
         default=DEFAULTS[DEV_MODE],
         description="Whether to run the pipeline in dev mode, which saves raw API responses to disk and disables compression for easier debugging.",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[DEV_MODE]]),
+        validation_alias=AliasChoices(*ALIASES[DEV_MODE]),
     ),
 ]
 # this should really just be _Accessor but leaving the dict version in for ease of testing
@@ -105,7 +106,7 @@ InputDir = Annotated[
         default=DEFAULTS[INPUT_DIR],
         description="Location of directory containing file(s) to import",
         # explicitly allow both kebab case and snake case
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[INPUT_DIR]]),
+        validation_alias=AliasChoices(*ALIASES[INPUT_DIR]),
     ),
 ]
 LogConfigFile = Annotated[
@@ -113,7 +114,7 @@ LogConfigFile = Annotated[
     Field(
         default=DEFAULTS[LOG_CONFIG_FILE],
         description="Location of configuration file for the logger",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[LOG_CONFIG_FILE]]),
+        validation_alias=AliasChoices(*ALIASES[LOG_CONFIG_FILE]),
     ),
 ]
 Output = Annotated[
@@ -121,7 +122,7 @@ Output = Annotated[
     Field(
         default=DEFAULTS[OUTPUT],
         description="Location to save imported data to, if different from the default supplied by the destination config",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[OUTPUT]]),
+        validation_alias=AliasChoices(*ALIASES[OUTPUT]),
     ),
 ]
 StartAt = Annotated[
@@ -129,7 +130,7 @@ StartAt = Annotated[
     Field(
         default=DEFAULTS[START_AT],
         description="File to start import at",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[START_AT]]),
+        validation_alias=AliasChoices(*ALIASES[START_AT]),
     ),
 ]
 UseDestination = Annotated[
@@ -137,7 +138,7 @@ UseDestination = Annotated[
     Field(
         default=DEFAULTS[USE_DESTINATION],
         description=f"DLT destination configuration to use for data output. Data to be saved to s3 should use the destination 's3'; to save data locally, use the destination 'local_fs'. The output directory can be specified using the 'output' field. Choices: {VALID_DESTINATIONS}",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[USE_DESTINATION]]),
+        validation_alias=AliasChoices(*ALIASES[USE_DESTINATION]),
     ),
 ]
 UseOutputDirForPipelineMetadata = Annotated[
@@ -145,8 +146,6 @@ UseOutputDirForPipelineMetadata = Annotated[
     Field(
         default=DEFAULTS[USE_OUTPUT_DIR_FOR_PIPELINE_METADATA],
         description="If true, use the output directory for pipeline metadata. Note: pipeline metadata cannot be stored in an S3 bucket, so this option should only be used when the destination is 'local_fs'.",
-        validation_alias=AliasChoices(
-            *[alias.strip("-") for alias in ARG_ALIASES[USE_OUTPUT_DIR_FOR_PIPELINE_METADATA]]
-        ),
+        validation_alias=AliasChoices(*ALIASES[USE_OUTPUT_DIR_FOR_PIPELINE_METADATA]),
     ),
 ]

--- a/src/cdm_data_loaders/core/fields.py
+++ b/src/cdm_data_loaders/core/fields.py
@@ -1,0 +1,154 @@
+"""Common defaults for running pipelines on the KBase CTS."""
+
+from typing import Annotated, Any, Final
+
+import dlt.common.configuration.accessors
+from frozendict import frozendict
+from pydantic import AliasChoices, Field
+from pydantic_settings import CliSuppress
+
+from cdm_data_loaders.utils.batcher import MIN_START_AT
+
+# TODO: frozendict can be moved to the stdlib implementation when py 3.15 is released.
+
+
+INPUT_MOUNT: Final[str] = "/input_dir"
+OUTPUT_MOUNT: Final[str] = "/output_dir"
+
+VALID_DESTINATIONS: list[str] = ["local_fs", "s3"]
+
+# Common fields
+DEV_MODE = "dev_mode"
+INPUT_DIR = "input_dir"
+LOG_CONFIG_FILE = "log_config_file"
+OUTPUT = "output"
+START_AT = "start_at"
+USE_DESTINATION = "use_destination"
+USE_OUTPUT_DIR_FOR_PIPELINE_METADATA = "use_output_dir_for_pipeline_metadata"
+
+# Default values for the common fields
+DEFAULTS = frozendict(
+    {
+        DEV_MODE: False,
+        INPUT_DIR: INPUT_MOUNT,
+        LOG_CONFIG_FILE: None,
+        # N.b. this gets replaced by destination.local_fs.bucket_url
+        OUTPUT: "",
+        START_AT: MIN_START_AT,
+        USE_DESTINATION: "local_fs",
+        USE_OUTPUT_DIR_FOR_PIPELINE_METADATA: False,
+    }
+)
+
+DEFAULT_PIPELINE_BATCH_SIZE: Final[int] = 50
+
+# short aliases for the fields, used for CLI parsing
+SHORT_ALIASES = frozendict(
+    {
+        DEV_MODE: [],
+        USE_DESTINATION: ["-d"],
+        USE_OUTPUT_DIR_FOR_PIPELINE_METADATA: ["-p"],
+    }
+)
+
+
+def generate_aliases(field_name: str, short_aliases: bool = True) -> list[str]:  # noqa: FBT001, FBT002
+    """Generate a list of aliases for a given field name.
+
+    :param field_name: The name of the field for which to generate aliases.
+    :type field_name: str
+    :param short_aliases: Whether to include short aliases.
+    :type short_aliases: bool
+    :return: A list of aliases for the field.
+    :rtype: list[str]
+    """
+    field_names = [f"--{field_name}"]
+    if "_" in field_name:
+        field_names.append(f"--{field_name.replace('_', '-')}")
+
+    if short_aliases:
+        return [*SHORT_ALIASES.get(field_name, [f"-{field_name[0]}"]), *field_names]
+    return field_names
+
+
+ARG_ALIASES = frozendict(
+    {
+        k: generate_aliases(k)
+        for k in [
+            DEV_MODE,
+            INPUT_DIR,
+            LOG_CONFIG_FILE,
+            OUTPUT,
+            START_AT,
+            USE_DESTINATION,
+            USE_OUTPUT_DIR_FOR_PIPELINE_METADATA,
+        ]
+    }
+)
+
+DevMode = Annotated[
+    bool,
+    Field(
+        default=DEFAULTS[DEV_MODE],
+        description="Whether to run the pipeline in dev mode, which saves raw API responses to disk and disables compression for easier debugging.",
+        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[DEV_MODE]]),
+    ),
+]
+# this should really just be _Accessor but leaving the dict version in for ease of testing
+DltConfig = Annotated[
+    CliSuppress[dlt.common.configuration.accessors._Accessor | dict[str, Any]],  # noqa: SLF001
+    Field(
+        description="DLT configuration for the pipeline.",
+    ),
+]
+InputDir = Annotated[
+    str,
+    Field(
+        default=DEFAULTS[INPUT_DIR],
+        description="Location of directory containing file(s) to import",
+        # explicitly allow both kebab case and snake case
+        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[INPUT_DIR]]),
+    ),
+]
+LogConfigFile = Annotated[
+    str | None,
+    Field(
+        default=DEFAULTS[LOG_CONFIG_FILE],
+        description="Location of configuration file for the logger",
+        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[LOG_CONFIG_FILE]]),
+    ),
+]
+Output = Annotated[
+    str,
+    Field(
+        default=DEFAULTS[OUTPUT],
+        description="Location to save imported data to, if different from the default supplied by the destination config",
+        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[OUTPUT]]),
+    ),
+]
+StartAt = Annotated[
+    int,
+    Field(
+        default=DEFAULTS[START_AT],
+        description="File to start import at",
+        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[START_AT]]),
+    ),
+]
+UseDestination = Annotated[
+    str,
+    Field(
+        default=DEFAULTS[USE_DESTINATION],
+        description=f"DLT destination configuration to use for data output. Data to be saved to s3 should use the destination 's3'; to save data locally, use the destination 'local_fs'. The output directory can be specified using the 'output' field. Choices: {VALID_DESTINATIONS}",
+        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES[USE_DESTINATION]]),
+    ),
+]
+UseOutputDirForPipelineMetadata = Annotated[
+    bool,
+    Field(
+        default=DEFAULTS[USE_OUTPUT_DIR_FOR_PIPELINE_METADATA],
+        description="If true, use the output directory for pipeline metadata. Note: pipeline metadata cannot be stored in an S3 bucket, so this option should only be used when the destination is 'local_fs'.",
+        validation_alias=AliasChoices(
+            *[alias.strip("-") for alias in ARG_ALIASES[USE_OUTPUT_DIR_FOR_PIPELINE_METADATA]]
+        ),
+    ),
+]

--- a/src/cdm_data_loaders/core/fields.py
+++ b/src/cdm_data_loaders/core/fields.py
@@ -9,9 +9,6 @@ from pydantic_settings import CliSuppress
 
 from cdm_data_loaders.utils.batcher import MIN_START_AT
 
-# TODO: frozendict can be moved to the stdlib implementation when py 3.15 is released.
-
-
 INPUT_MOUNT: Final[str] = "/input_dir"
 OUTPUT_MOUNT: Final[str] = "/output_dir"
 
@@ -46,6 +43,7 @@ DEFAULT_PIPELINE_BATCH_SIZE: Final[int] = 50
 SHORT_ALIASES = frozendict(
     {
         DEV_MODE: [],
+        LOG_CONFIG_FILE: [],
         USE_DESTINATION: ["-d"],
         USE_OUTPUT_DIR_FOR_PIPELINE_METADATA: ["-p"],
     }

--- a/src/cdm_data_loaders/core/settings.py
+++ b/src/cdm_data_loaders/core/settings.py
@@ -1,64 +1,31 @@
 """Common defaults for running pipelines on the KBase CTS."""
 
-from typing import Any, Final, Self
+from typing import Any, Self
 
-import dlt.common.configuration.accessors
 from frozendict import frozendict
-from pydantic import AliasChoices, Field, computed_field, field_validator, model_validator
-from pydantic_settings import CliSuppress, SettingsConfigDict
+from pydantic import computed_field, field_validator, model_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
 
-from cdm_data_loaders.utils.batcher import MIN_START_AT
-from cdm_data_loaders.utils.cdm_logger import ARG_ALIASES as LOGGER_ARG_ALIASES
-from cdm_data_loaders.utils.cdm_logger import DEFAULT_LOG_CONFIG_FILE, LoggerSettings
+from cdm_data_loaders.core.fields import (
+    DEFAULTS,
+    DEV_MODE,
+    INPUT_DIR,
+    LOG_CONFIG_FILE,
+    OUTPUT,
+    START_AT,
+    USE_DESTINATION,
+    USE_OUTPUT_DIR_FOR_PIPELINE_METADATA,
+    DevMode,
+    DltConfig,
+    InputDir,
+    LogConfigFile,
+    Output,
+    StartAt,
+    UseDestination,
+    UseOutputDirForPipelineMetadata,
+)
 
 # TODO: frozendict can be moved to the stdlib implementation when py 3.15 is released.
-
-
-INPUT_MOUNT: Final[str] = "/input_dir"
-OUTPUT_MOUNT: Final[str] = "/output_dir"
-
-VALID_DESTINATIONS: list[str] = ["local_fs", "s3"]
-
-
-DEFAULT_CTS_SETTINGS = frozendict(
-    {
-        "dev_mode": False,
-        "input_dir": INPUT_MOUNT,
-        "log_config_file": DEFAULT_LOG_CONFIG_FILE,
-        # N.b. this gets replaced by destination.local_fs.bucket_url
-        "output": "",
-        "use_destination": "local_fs",
-        "use_output_dir_for_pipeline_metadata": False,
-    }
-)
-
-DEFAULT_BATCH_FILE_SETTINGS = frozendict(
-    {
-        **DEFAULT_CTS_SETTINGS,
-        "start_at": MIN_START_AT,
-    }
-)
-
-DEFAULT_PIPELINE_BATCH_SIZE: Final[int] = 50
-
-
-ARG_ALIASES = frozendict(
-    {
-        "batch_size": ["-b", "--batch_size", "--batch-size"],
-        "dev_mode": ["--dev_mode", "--dev-mode", "--dev"],
-        "input_dir": ["-i", "--input_dir", "--input-dir"],
-        "log_config_file": LOGGER_ARG_ALIASES,
-        "output": ["-o", "--output"],
-        "start_at": ["-s", "--start_at", "--start-at"],
-        "use_destination": ["-d", "--use_destination", "--use-destination"],
-        "use_output_dir_for_pipeline_metadata": [
-            "-p",
-            "--use_output_dir_for_pipeline_metadata",
-            "--use-output-dir-for-pipeline-metadata",
-        ],
-    }
-)
-
 DEFAULT_SETTINGS_CONFIG_DICT = frozendict(
     {
         "cli_parse_args": True,
@@ -69,43 +36,45 @@ DEFAULT_SETTINGS_CONFIG_DICT = frozendict(
 )
 
 
+DEFAULT_CTS_SETTINGS = frozendict(
+    {
+        k: DEFAULTS[k]
+        for k in [
+            DEV_MODE,
+            INPUT_DIR,
+            LOG_CONFIG_FILE,
+            OUTPUT,
+            USE_DESTINATION,
+            USE_OUTPUT_DIR_FOR_PIPELINE_METADATA,
+        ]
+    }
+)
+
+DEFAULT_BATCH_FILE_SETTINGS = frozendict(
+    {
+        **DEFAULT_CTS_SETTINGS,
+        START_AT: DEFAULTS[START_AT],
+    }
+)
+
+
+class LoggerSettings(BaseSettings):
+    """Configuration for a class with a logger config."""
+
+    log_config_file: LogConfigFile
+
+
 class CtsSettings(LoggerSettings):
     """Configuration for running a basic import pipeline."""
 
     model_config = SettingsConfigDict(**DEFAULT_SETTINGS_CONFIG_DICT)
 
-    dev_mode: bool = Field(
-        default=DEFAULT_CTS_SETTINGS["dev_mode"],
-        description="Whether to run the pipeline in dev mode, which saves raw API responses to disk and disables compression for easier debugging.",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES["dev_mode"]]),
-    )
-    input_dir: str = Field(
-        default=DEFAULT_CTS_SETTINGS["input_dir"],
-        description="Location of directory containing file(s) to import",
-        # explicitly allow both kebab case and snake case
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES["input_dir"]]),
-    )
-    output: str = Field(
-        default=DEFAULT_CTS_SETTINGS["output"],
-        description="Location to save imported data to, if different from the default supplied by the destination config",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES["output"]]),
-    )
-    use_destination: str = Field(
-        default=DEFAULT_CTS_SETTINGS["use_destination"],
-        description=f"DLT destination configuration to use for data output. Data to be saved to s3 should use the destination 's3'; to save data locally, use the destination 'local_fs'. The output directory can be specified using the 'output' field. Choices: {VALID_DESTINATIONS}",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES["use_destination"]]),
-    )
-    use_output_dir_for_pipeline_metadata: bool = Field(
-        default=DEFAULT_CTS_SETTINGS["use_output_dir_for_pipeline_metadata"],
-        description="If true, use the output directory for pipeline metadata.",
-        validation_alias=AliasChoices(
-            *[alias.strip("-") for alias in ARG_ALIASES["use_output_dir_for_pipeline_metadata"]]
-        ),
-    )
-    # this should really just be _Accessor but leaving it as-is for ease of testing
-    dlt_config: CliSuppress[dlt.common.configuration.accessors._Accessor | dict[str, Any]] = Field(
-        description="DLT configuration for the pipeline.",
-    )
+    dev_mode: DevMode
+    input_dir: InputDir
+    output: Output
+    use_destination: UseDestination
+    use_output_dir_for_pipeline_metadata: UseOutputDirForPipelineMetadata
+    dlt_config: DltConfig
 
     @model_validator(mode="after")
     def reconcile_with_dlt_config(self) -> Self:
@@ -129,7 +98,7 @@ class CtsSettings(LoggerSettings):
             if self.output != "/":
                 self.output.rstrip("/")
 
-        # TODO: this should never happen
+        # N.b. this should never happen
         if not self.output:
             err_msg = "No output specified!"
             raise ValueError(err_msg)
@@ -192,8 +161,4 @@ class CtsSettings(LoggerSettings):
 class BatchedFileInputSettings(CtsSettings):
     """Settings object for an importer that deals with batches of files."""
 
-    start_at: int = Field(
-        default=DEFAULT_BATCH_FILE_SETTINGS["start_at"],
-        description="File to start import at",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES["start_at"]]),
-    )
+    start_at: StartAt

--- a/src/cdm_data_loaders/core/settings.py
+++ b/src/cdm_data_loaders/core/settings.py
@@ -25,7 +25,6 @@ from cdm_data_loaders.core.fields import (
     UseOutputDirForPipelineMetadata,
 )
 
-# TODO: frozendict can be moved to the stdlib implementation when py 3.15 is released.
 DEFAULT_SETTINGS_CONFIG_DICT = frozendict(
     {
         "cli_parse_args": True,

--- a/src/cdm_data_loaders/pipelines/all_the_bacteria.py
+++ b/src/cdm_data_loaders/pipelines/all_the_bacteria.py
@@ -25,6 +25,7 @@ from frozendict import frozendict
 from pydantic import AliasChoices, Field, computed_field
 from pydantic_settings import SettingsConfigDict
 
+from cdm_data_loaders.core.fields import generate_aliases
 from cdm_data_loaders.core.settings import DEFAULT_SETTINGS_CONFIG_DICT, CtsSettings
 from cdm_data_loaders.pipelines.core import (
     run_cli,
@@ -44,8 +45,8 @@ ATB_VERSION = "2025-05"
 
 ARG_ALIASES = frozendict(
     {
-        "version": ["-v", "--version"],
-        "pattern_file": ["-f", "--pattern-file", "--pattern_file"],
+        "version": generate_aliases("version"),
+        "pattern_file": ["-f", *generate_aliases("pattern_file", False)],
     },
 )
 

--- a/src/cdm_data_loaders/pipelines/all_the_bacteria.py
+++ b/src/cdm_data_loaders/pipelines/all_the_bacteria.py
@@ -25,11 +25,11 @@ from frozendict import frozendict
 from pydantic import AliasChoices, Field, computed_field
 from pydantic_settings import SettingsConfigDict
 
+from cdm_data_loaders.core.settings import DEFAULT_SETTINGS_CONFIG_DICT, CtsSettings
 from cdm_data_loaders.pipelines.core import (
     run_cli,
     run_pipeline,
 )
-from cdm_data_loaders.pipelines.cts_defaults import DEFAULT_SETTINGS_CONFIG_DICT, CtsSettings
 from cdm_data_loaders.utils.download.sync_client import FileDownloader
 from cdm_data_loaders.utils.s3 import stream_to_s3
 

--- a/src/cdm_data_loaders/pipelines/all_the_bacteria.py
+++ b/src/cdm_data_loaders/pipelines/all_the_bacteria.py
@@ -15,7 +15,7 @@ import re
 from collections.abc import Generator
 from logging import Logger, getLogger
 from pathlib import Path
-from typing import Any
+from typing import Any, Final
 
 import dlt
 from dlt.extract.items import DataItemWithMeta
@@ -43,10 +43,13 @@ ALL_ATB_FILE_NAME = "all_atb_files.tsv"
 REGEX_FILE = "filters.txt"
 ATB_VERSION = "2025-05"
 
-ARG_ALIASES = frozendict(
+VERSION: Final[str] = "version"
+PATTERN_FILE: Final[str] = "pattern_file"
+
+ALIASES = frozendict(
     {
-        "version": generate_aliases("version"),
-        "pattern_file": ["-f", *generate_aliases("pattern_file", False)],
+        VERSION: generate_aliases(VERSION),
+        PATTERN_FILE: ["f", *generate_aliases(PATTERN_FILE, False)],
     },
 )
 
@@ -66,13 +69,13 @@ class AtbSettings(CtsSettings):
     version: str = Field(
         default=ATB_VERSION,
         description="Name of the current AllTheBacteria version",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES["version"]]),
+        validation_alias=AliasChoices(*ALIASES[VERSION]),
     )
 
     pattern_file: str | None = Field(
         default=None,
         description="Path, relative to the input dir, of a file containing patterns to match when downloading ATB files",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES["pattern_file"]]),
+        validation_alias=AliasChoices(*ALIASES[PATTERN_FILE]),
     )
 
     @computed_field

--- a/src/cdm_data_loaders/pipelines/core.py
+++ b/src/cdm_data_loaders/pipelines/core.py
@@ -12,7 +12,8 @@ from dlt.extract.items import DataItemWithMeta
 from pydantic import ValidationError
 from pydantic_settings import SettingsError
 
-from cdm_data_loaders.pipelines.cts_defaults import DEFAULT_PIPELINE_BATCH_SIZE, BatchedFileInputSettings, CtsSettings
+from cdm_data_loaders.core.fields import DEFAULT_PIPELINE_BATCH_SIZE
+from cdm_data_loaders.core.settings import BatchedFileInputSettings, CtsSettings
 from cdm_data_loaders.utils.batcher import NumericFileSequenceBatcher
 from cdm_data_loaders.utils.cdm_logger import init_logger
 from cdm_data_loaders.utils.xml_utils import stream_xml_file

--- a/src/cdm_data_loaders/pipelines/ncbi_ftp_download.py
+++ b/src/cdm_data_loaders/pipelines/ncbi_ftp_download.py
@@ -28,7 +28,12 @@ from cdm_data_loaders.ncbi_ftp.assembly import (
     parse_assembly_path,
 )
 from cdm_data_loaders.pipelines.core import run_cli
+<<<<<<< HEAD
 from cdm_data_loaders.pipelines.cts_defaults import INPUT_MOUNT, OUTPUT_MOUNT, CtsSettings
+=======
+from cdm_data_loaders.core.fields import INPUT_MOUNT, OUTPUT_MOUNT
+from cdm_data_loaders.core.settings import DEFAULT_SETTINGS_CONFIG_DICT
+>>>>>>> ef5128f (WIP [skip ci])
 from cdm_data_loaders.utils.ftp_client import ThreadLocalFTP
 from cdm_data_loaders.utils.s3 import get_s3_client, upload_file
 

--- a/src/cdm_data_loaders/pipelines/ncbi_ftp_download.py
+++ b/src/cdm_data_loaders/pipelines/ncbi_ftp_download.py
@@ -21,6 +21,8 @@ import tqdm
 from pydantic import AliasChoices, Field
 from tenacity import before_sleep_log, retry, retry_if_exception_type, stop_after_attempt, wait_exponential
 
+from cdm_data_loaders.core.fields import INPUT_MOUNT, OUTPUT_MOUNT
+from cdm_data_loaders.core.settings import CtsSettings
 from cdm_data_loaders.ncbi_ftp.assembly import (
     FTP_HOST,
     build_accession_path,
@@ -28,7 +30,6 @@ from cdm_data_loaders.ncbi_ftp.assembly import (
     parse_assembly_path,
 )
 from cdm_data_loaders.pipelines.core import run_cli
-from cdm_data_loaders.pipelines.cts_defaults import INPUT_MOUNT, OUTPUT_MOUNT, CtsSettings
 from cdm_data_loaders.utils.ftp_client import ThreadLocalFTP
 from cdm_data_loaders.utils.s3 import get_s3_client, upload_file
 

--- a/src/cdm_data_loaders/pipelines/ncbi_ftp_download.py
+++ b/src/cdm_data_loaders/pipelines/ncbi_ftp_download.py
@@ -28,12 +28,7 @@ from cdm_data_loaders.ncbi_ftp.assembly import (
     parse_assembly_path,
 )
 from cdm_data_loaders.pipelines.core import run_cli
-<<<<<<< HEAD
 from cdm_data_loaders.pipelines.cts_defaults import INPUT_MOUNT, OUTPUT_MOUNT, CtsSettings
-=======
-from cdm_data_loaders.core.fields import INPUT_MOUNT, OUTPUT_MOUNT
-from cdm_data_loaders.core.settings import DEFAULT_SETTINGS_CONFIG_DICT
->>>>>>> ef5128f (WIP [skip ci])
 from cdm_data_loaders.utils.ftp_client import ThreadLocalFTP
 from cdm_data_loaders.utils.s3 import get_s3_client, upload_file
 

--- a/src/cdm_data_loaders/pipelines/ncbi_ftp_promote.py
+++ b/src/cdm_data_loaders/pipelines/ncbi_ftp_promote.py
@@ -10,9 +10,9 @@ from pathlib import Path, PurePosixPath
 from pydantic import AliasChoices, Field
 from pydantic_settings import CliImplicitFlag
 
+from cdm_data_loaders.core.settings import CtsSettings
 from cdm_data_loaders.ncbi_ftp.promote import promote_from_s3
 from cdm_data_loaders.pipelines.core import run_cli
-from cdm_data_loaders.pipelines.cts_defaults import CtsSettings
 
 DEFAULT_STAGING_BUCKET: PurePosixPath = PurePosixPath("cts")
 DEFAULT_DESTINATION_BUCKET: PurePosixPath = PurePosixPath("cdm-lake")

--- a/src/cdm_data_loaders/pipelines/ncbi_rest_api.py
+++ b/src/cdm_data_loaders/pipelines/ncbi_rest_api.py
@@ -23,6 +23,7 @@ from dlt.sources.helpers.rest_client.client import RESTClient
 from dlt.sources.helpers.rest_client.paginators import (
     JSONResponseCursorPaginator,
 )
+from frozendict import frozendict
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import SettingsConfigDict
 from requests.exceptions import HTTPError
@@ -55,8 +56,10 @@ QUERY_TYPE_REGEX: Final[re.Pattern[str]] = re.compile(r"^(" + DATASET + r"|" + A
 
 REST_CLIENT_HOOKS = {}
 
-ARG_ALIAS_BATCH_SIZE = generate_aliases("batch_size")
-ARG_ALIAS_QUERY_TYPE = generate_aliases("query_type")
+BATCH_SIZE: Final[str] = "batch_size"
+QUERY_TYPE: Final[str] = "query_type"
+
+ALIASES = frozendict({k: generate_aliases(k) for k in [BATCH_SIZE, QUERY_TYPE]})
 
 
 class NcbiRestApiSettings(CtsSettings):
@@ -67,7 +70,7 @@ class NcbiRestApiSettings(CtsSettings):
     batch_size: int = Field(
         default=MAX_IDS_PER_QUERY,
         description="Number of IDs to send in each request to the NCBI REST API.",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIAS_BATCH_SIZE]),
+        validation_alias=AliasChoices(*ALIASES[BATCH_SIZE]),
         ge=1,
         le=MAX_IDS_PER_QUERY,
     )
@@ -75,7 +78,7 @@ class NcbiRestApiSettings(CtsSettings):
     query_type: str | None = Field(
         default=None,
         description="The type of query to perform, dataset or annotation. By default, both are performed.",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIAS_QUERY_TYPE]),
+        validation_alias=AliasChoices(*ALIASES[QUERY_TYPE]),
         pattern=QUERY_TYPE_REGEX,
     )
 

--- a/src/cdm_data_loaders/pipelines/ncbi_rest_api.py
+++ b/src/cdm_data_loaders/pipelines/ncbi_rest_api.py
@@ -27,11 +27,11 @@ from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import SettingsConfigDict
 from requests.exceptions import HTTPError
 
+from cdm_data_loaders.core.settings import DEFAULT_SETTINGS_CONFIG_DICT, CtsSettings
 from cdm_data_loaders.pipelines.core import (
     run_cli,
     run_pipeline,
 )
-from cdm_data_loaders.pipelines.cts_defaults import DEFAULT_SETTINGS_CONFIG_DICT, CtsSettings
 from cdm_data_loaders.utils.batcher import NumericFileSequenceBatcher
 
 logger: Logger = getLogger(__name__)
@@ -58,7 +58,7 @@ ARG_ALIAS_BATCH_SIZE = ["-b", "--batch-size", "--batch_size"]
 ARG_ALIAS_QUERY_TYPE = ["-q", "--query-type", "--query_type"]
 
 
-class NcbiSettings(CtsSettings):
+class NcbiRestApiSettings(CtsSettings):
     """Configuration for running the NCBI REST API import pipeline."""
 
     model_config = SettingsConfigDict(**DEFAULT_SETTINGS_CONFIG_DICT, cli_prog_name="ncbi_rest_api")
@@ -91,7 +91,7 @@ class NcbiSettings(CtsSettings):
         return v.strip().lower() if v and v.strip() else None
 
 
-def generate_file_path_name_from_url(settings: NcbiSettings, url_string: str) -> Path:
+def generate_file_path_name_from_url(settings: NcbiRestApiSettings, url_string: str) -> Path:
     """Given an NCBI URL, generate a save directory and file name for the raw HTTP responses.
 
     :param url_string: the URL
@@ -116,7 +116,7 @@ def generate_file_path_name_from_url(settings: NcbiSettings, url_string: str) ->
     return save_dir / file_name
 
 
-def save_raw_response(settings: NcbiSettings, response: Response, *_: Any, **__: Any) -> Response:  # noqa: ANN401
+def save_raw_response(settings: NcbiRestApiSettings, response: Response, *_: Any, **__: Any) -> Response:  # noqa: ANN401
     """Save the response content to disk.
 
     :param response: HTTP Response object
@@ -129,25 +129,25 @@ def save_raw_response(settings: NcbiSettings, response: Response, *_: Any, **__:
     return response
 
 
-PIPELINE_SETTINGS: NcbiSettings | None = None
+PIPELINE_SETTINGS: NcbiRestApiSettings | None = None
 
 
-def set_settings(settings_obj: NcbiSettings) -> None:
+def set_settings(settings_obj: NcbiRestApiSettings) -> None:
     """Set the global PIPELINE_SETTINGS object to the supplied obj.
 
     :param settings_obj: settings object
-    :type settings_obj: NcbiSettings
+    :type settings_obj: NcbiRestApiSettings
     """
     # ugh, somewhat horrible
     global PIPELINE_SETTINGS
     PIPELINE_SETTINGS = settings_obj
 
 
-def get_settings() -> NcbiSettings:
+def get_settings() -> NcbiRestApiSettings:
     """Get the pipeline settings.
 
     return: pipeline settings
-    :rtype: NcbiSettings
+    :rtype: NcbiRestApiSettings
     """
     if PIPELINE_SETTINGS is None:
         err_msg = "Pipeline settings have not been initialised"
@@ -362,11 +362,11 @@ def assembly_report_parser(
     return assemble_assembly_reports(assembly_reports)
 
 
-def run_ncbi_pipeline(settings: NcbiSettings) -> None:
+def run_ncbi_pipeline(settings: NcbiRestApiSettings) -> None:
     """Run the NCBI datasets API pipeline.
 
     :param settings: configuration for the pipeline
-    :type settings: NcbiSettings
+    :type settings: NcbiRestApiSettings
     """
     set_settings(settings)
 
@@ -389,7 +389,7 @@ def run_ncbi_pipeline(settings: NcbiSettings) -> None:
 
 def cli() -> None:
     """CLI interface for the NCBI REST API importer pipeline."""
-    run_cli(NcbiSettings, run_ncbi_pipeline)
+    run_cli(NcbiRestApiSettings, run_ncbi_pipeline)
 
 
 if __name__ == "__main__":

--- a/src/cdm_data_loaders/pipelines/ncbi_rest_api.py
+++ b/src/cdm_data_loaders/pipelines/ncbi_rest_api.py
@@ -27,6 +27,7 @@ from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import SettingsConfigDict
 from requests.exceptions import HTTPError
 
+from cdm_data_loaders.core.fields import generate_aliases
 from cdm_data_loaders.core.settings import DEFAULT_SETTINGS_CONFIG_DICT, CtsSettings
 from cdm_data_loaders.pipelines.core import (
     run_cli,
@@ -54,8 +55,8 @@ QUERY_TYPE_REGEX: Final[re.Pattern[str]] = re.compile(r"^(" + DATASET + r"|" + A
 
 REST_CLIENT_HOOKS = {}
 
-ARG_ALIAS_BATCH_SIZE = ["-b", "--batch-size", "--batch_size"]
-ARG_ALIAS_QUERY_TYPE = ["-q", "--query-type", "--query_type"]
+ARG_ALIAS_BATCH_SIZE = generate_aliases("batch_size")
+ARG_ALIAS_QUERY_TYPE = generate_aliases("query_type")
 
 
 class NcbiRestApiSettings(CtsSettings):

--- a/src/cdm_data_loaders/pipelines/uniprot_kb.py
+++ b/src/cdm_data_loaders/pipelines/uniprot_kb.py
@@ -7,13 +7,13 @@ import dlt
 from dlt.extract.items import DataItemWithMeta
 from pydantic_settings import SettingsConfigDict
 
+from cdm_data_loaders.core.settings import DEFAULT_SETTINGS_CONFIG_DICT, BatchedFileInputSettings
 from cdm_data_loaders.parsers.uniprot.uniprot_kb import ENTRY_XML_TAG, parse_uniprot_entry
 from cdm_data_loaders.pipelines.core import (
     run_cli,
     run_pipeline,
     stream_xml_file_resource,
 )
-from cdm_data_loaders.pipelines.cts_defaults import DEFAULT_SETTINGS_CONFIG_DICT, BatchedFileInputSettings
 
 APP_NAME: Final[str] = "uniprot_kb_importer"
 UNIPROT_LOG_INTERVAL: Final[int] = 1000

--- a/src/cdm_data_loaders/pipelines/uniref.py
+++ b/src/cdm_data_loaders/pipelines/uniref.py
@@ -8,15 +8,15 @@ from dlt.extract.items import DataItemWithMeta
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import SettingsConfigDict
 
+from cdm_data_loaders.core.settings import (
+    DEFAULT_SETTINGS_CONFIG_DICT,
+    BatchedFileInputSettings,
+)
 from cdm_data_loaders.parsers.uniprot.uniref import ENTRY_XML_TAG, UNIREF_VARIANTS, parse_uniref_entry
 from cdm_data_loaders.pipelines.core import (
     run_cli,
     run_pipeline,
     stream_xml_file_resource,
-)
-from cdm_data_loaders.pipelines.cts_defaults import (
-    DEFAULT_SETTINGS_CONFIG_DICT,
-    BatchedFileInputSettings,
 )
 
 APP_NAME: Final[str] = "uniref_importer"

--- a/src/cdm_data_loaders/pipelines/uniref.py
+++ b/src/cdm_data_loaders/pipelines/uniref.py
@@ -1,10 +1,11 @@
 """DLT pipeline to import UniRef data."""
 
 from collections.abc import Generator
-from typing import Any, Final
+from typing import Annotated, Any, Final
 
 import dlt
 from dlt.extract.items import DataItemWithMeta
+from frozendict import frozendict
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import SettingsConfigDict
 
@@ -24,7 +25,8 @@ APP_NAME: Final[str] = "uniref_importer"
 UNIREF_LOG_INTERVAL: Final[int] = 10000
 
 
-UNIREF_VARIANT_ALIASES = generate_aliases("uniref_variant")
+UNIREF_VARIANT: Final[str] = "uniref_variant"
+ALIASES = frozendict({UNIREF_VARIANT: generate_aliases(UNIREF_VARIANT)})
 
 
 class UnirefSettings(BatchedFileInputSettings):
@@ -35,10 +37,13 @@ class UnirefSettings(BatchedFileInputSettings):
         cli_prog_name="uniref",
     )
 
-    uniref_variant: str = Field(
-        description=f"Which UniRef variant to import. Choices: {UNIREF_VARIANTS}",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in UNIREF_VARIANT_ALIASES]),
-    )
+    uniref_variant: Annotated[
+        str,
+        Field(
+            description=f"Which UniRef variant to import. Choices: {UNIREF_VARIANTS}",
+            validation_alias=AliasChoices(*[ALIASES[UNIREF_VARIANT]]),
+        ),
+    ]
 
     @field_validator("uniref_variant")
     @classmethod

--- a/src/cdm_data_loaders/pipelines/uniref.py
+++ b/src/cdm_data_loaders/pipelines/uniref.py
@@ -41,7 +41,7 @@ class UnirefSettings(BatchedFileInputSettings):
         str,
         Field(
             description=f"Which UniRef variant to import. Choices: {UNIREF_VARIANTS}",
-            validation_alias=AliasChoices(*[ALIASES[UNIREF_VARIANT]]),
+            validation_alias=AliasChoices(*ALIASES[UNIREF_VARIANT]),
         ),
     ]
 

--- a/src/cdm_data_loaders/pipelines/uniref.py
+++ b/src/cdm_data_loaders/pipelines/uniref.py
@@ -8,6 +8,7 @@ from dlt.extract.items import DataItemWithMeta
 from pydantic import AliasChoices, Field, field_validator
 from pydantic_settings import SettingsConfigDict
 
+from cdm_data_loaders.core.fields import generate_aliases
 from cdm_data_loaders.core.settings import (
     DEFAULT_SETTINGS_CONFIG_DICT,
     BatchedFileInputSettings,
@@ -23,7 +24,7 @@ APP_NAME: Final[str] = "uniref_importer"
 UNIREF_LOG_INTERVAL: Final[int] = 10000
 
 
-UNIREF_VARIANT_ALIASES = ["-u", "--uniref", "--uniref-variant", "--uniref_variant"]
+UNIREF_VARIANT_ALIASES = generate_aliases("uniref_variant")
 
 
 class UnirefSettings(BatchedFileInputSettings):

--- a/src/cdm_data_loaders/utils/cdm_logger.py
+++ b/src/cdm_data_loaders/utils/cdm_logger.py
@@ -6,21 +6,20 @@ import json
 import logging
 import logging.config
 from pathlib import Path
-from typing import Any, Final
+from typing import Any
 
 import yaml
 from dlt.common.runtime.json_logging import config_root_logger
 from frozendict import frozendict
-from pydantic import AliasChoices, Field
-from pydantic_settings import BaseSettings
+
+from cdm_data_loaders.core.settings import LoggerSettings
 
 ROOT_LOGGER_CONFIGURED: bool = False
 
 
-# no default logger config file -- falls back to LOGGING_CONFIG if file not found.
-DEFAULT_LOG_CONFIG_FILE: Final = None
-
-# Immutable fallback config used when no external config file can be found
+# There is no default logger config file (see cdm_data_loaders.core.fields.DEFAULTS[LOG_CONFIG_FILE])
+# so the logger falls back to LOGGING_CONFIG if an external config file is not found.
+# Immutable fallback config
 LOGGING_CONFIG = frozendict(
     {
         "version": 1,
@@ -34,18 +33,6 @@ LOGGING_CONFIG = frozendict(
         "disable_existing_loggers": False,
     }
 )
-
-ARG_ALIASES = ["--log-config-file", "--log_config_file"]
-
-
-class LoggerSettings(BaseSettings):
-    """Configuration for a class with a logger config."""
-
-    log_config_file: str | None = Field(
-        default=DEFAULT_LOG_CONFIG_FILE,
-        description="Location of configuration file for the logger",
-        validation_alias=AliasChoices(*[alias.strip("-") for alias in ARG_ALIASES]),
-    )
 
 
 def _load_config_from_path(path: str | Path) -> dict[str, Any]:
@@ -87,7 +74,7 @@ def init_logger(settings: LoggerSettings | None = None) -> None:
     """Initialise logger configuration."""
     if not settings:
         # init settings (pulling in log_config_file from cmd line args / env vars) if not provided
-        settings = LoggerSettings()
+        settings = LoggerSettings()  # pyright: ignore[reportCallIssue]
 
     if settings and settings.log_config_file:
         config = _load_config_from_path(settings.log_config_file)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -40,6 +40,21 @@ TEST_NS: Final[str] = "test_ns"
 PIPELINE_RUN = frozendict({RUN_ID: "1234-5678-90", PIPELINE: "KeystoneXL", SOURCE: "/path/to/file"})
 ALT_PIPELINE_RUN = frozendict({RUN_ID: "9876-5432-10", PIPELINE: "KeystoneXXXL", SOURCE: "/path/to/dir"})
 
+CASSETTES_DIR = "tests/cassettes"
+
+DEFAULT_VCR_CONFIG = frozendict(
+    {
+        "cassette_library_dir": CASSETTES_DIR,
+        "record_mode": "once",  # record on first run, replay thereafter
+        "serializer": "yaml",
+        "match_on": ["method", "scheme", "host", "path", "query"],
+        # strip the NCBI API key from cassettes
+        "filter_query_parameters": ["api_key"],
+        "filter_headers": ["api_key"],
+        "decode_compressed_response": True,
+        "allow_playback_repeats": True,
+    }
+)
 
 _notebook_utils_available: bool | None = None
 
@@ -175,6 +190,38 @@ def json_test_strings() -> dict[str, Any]:
         "array_of_objects": '[{"key": "value"}]',
         "object": '{"key": "value"}',
     }
+
+
+CONFIG_BUCKET = frozendict({"local_fs": "/output_dir", "s3": "s3://some/s3/bucket"})
+
+TEST_DLT_CONFIG = frozendict(
+    {
+        "destination.local_fs.bucket_url": CONFIG_BUCKET["local_fs"],
+        "destination.local_fs.destination_type": "filesystem",
+        "destination.s3.bucket_url": CONFIG_BUCKET["s3"],
+        "destination.s3.destination_type": "filesystem",
+        "normalize.data_writer.disable_compression": False,
+    }
+)
+
+
+def _generate_dlt_config() -> dict[str, Any]:
+    """Return a fresh DLT config dict (same shape as the conftest fixture)."""
+    return {
+        "destination": {
+            "local_fs": {"bucket_url": CONFIG_BUCKET["local_fs"]},
+            "s3": {"bucket_url": CONFIG_BUCKET["s3"]},
+        },
+        "destination.local_fs.bucket_url": CONFIG_BUCKET["local_fs"],
+        "destination.s3.bucket_url": CONFIG_BUCKET["s3"],
+        "normalize.data_writer.disable_compression": False,
+    }
+
+
+@pytest.fixture
+def dlt_config() -> dict[str, Any]:
+    """DLT config for testing purposes."""
+    return _generate_dlt_config()
 
 
 @pytest.fixture

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -86,6 +86,28 @@ TEST_BATCH_FILE_SETTINGS_RECONCILED = frozendict(
 )
 
 
+def generate_cli_arguments(
+    alias_dict: dict[str, list[str]] | frozendict[str, list[str]],
+    *args: dict[str, list[str]] | frozendict[str, list[str]],
+) -> frozendict[str, list[str]]:
+    """Generate the corresponding command line arguments from a list of aliases.
+
+    :param alias_dict: dictionary of arguments and list of valid aliases
+    :type alias_dict: dict[str, list[str]] | frozendict[str, list[str]]
+    :param args: more alias_dicts
+    :type args: dict[str, list[str]] | frozendict[str, list[str]]
+    :return: dictionary of args and list of valid cmd line args
+    :rtype: frozendict[str, list[str]]
+    """
+    all_aliases = {**alias_dict}
+    for a in args:
+        all_aliases = {**all_aliases, **a}
+
+    return frozendict(
+        {k: [f"-{item}" if len(item) == 1 else f"--{item}" for item in v] for k, v in all_aliases.items()}
+    )
+
+
 def make_settings(
     settings_cls: type[CtsSettings],
     dlt_config: dict[str, Any] | None = None,

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,0 +1,127 @@
+"""Shared fixtures for pipelines tests."""
+
+from itertools import batched
+from pathlib import Path
+from typing import Any, Final
+from unittest.mock import MagicMock
+
+import dlt
+import dlt.common.configuration.accessors
+import pytest
+from frozendict import frozendict
+from pydantic_settings import BaseSettings
+
+from cdm_data_loaders.core.fields import (
+    DEV_MODE,
+    INPUT_DIR,
+    LOG_CONFIG_FILE,
+    OUTPUT,
+    START_AT,
+    USE_DESTINATION,
+    USE_OUTPUT_DIR_FOR_PIPELINE_METADATA,
+)
+from cdm_data_loaders.core.settings import (
+    DEFAULT_BATCH_FILE_SETTINGS,
+    DEFAULT_CTS_SETTINGS,
+    CtsSettings,
+)
+from tests.conftest import _generate_dlt_config, TEST_DLT_CONFIG
+
+CASSETTES_DIR = "tests/cassettes"
+
+START_AT_VALUE: Final[int] = 50
+START_AT_STRING: Final[str] = "50"
+TEST_LOG_CONFIG_FILE: Final[str] = "log_conf.json"
+
+DESTINATION_TO_OUTPUT = frozendict(
+    {
+        "local_fs": TEST_DLT_CONFIG["destination.local_fs.bucket_url"],
+        "s3": TEST_DLT_CONFIG["destination.s3.bucket_url"],
+    }
+)
+
+DESTINATION_OUTPUT: Final[str] = DESTINATION_TO_OUTPUT[DEFAULT_CTS_SETTINGS["use_destination"]]
+
+DEFAULT_CTS_SETTINGS_RECONCILED = frozendict(
+    {
+        **DEFAULT_CTS_SETTINGS,
+        OUTPUT: DESTINATION_OUTPUT,
+        "raw_data_dir": f"{DESTINATION_OUTPUT}/raw_data",
+        "pipeline_dir": None,
+    }
+)
+
+DEFAULT_BATCH_FILE_SETTINGS_RECONCILED = frozendict({**DEFAULT_BATCH_FILE_SETTINGS, **DEFAULT_CTS_SETTINGS_RECONCILED})
+
+TEST_CTS_SETTINGS = frozendict(
+    {
+        DEV_MODE: "false",
+        INPUT_DIR: "/dir/path",
+        LOG_CONFIG_FILE: "some/path",
+        OUTPUT: "/some/dir",
+        USE_DESTINATION: "local_fs",
+        USE_OUTPUT_DIR_FOR_PIPELINE_METADATA: "true",
+    }
+)
+
+TEST_CTS_SETTINGS_RECONCILED = frozendict(
+    {
+        **TEST_CTS_SETTINGS,
+        DEV_MODE: False,
+        USE_OUTPUT_DIR_FOR_PIPELINE_METADATA: True,
+        "pipeline_dir": "/some/dir/.dlt_conf",
+        "raw_data_dir": "/some/dir/raw_data",
+    }
+)
+
+TEST_BATCH_FILE_SETTINGS = frozendict(
+    **TEST_CTS_SETTINGS,
+    start_at=START_AT_STRING,
+)
+
+TEST_BATCH_FILE_SETTINGS_RECONCILED = frozendict(
+    {
+        **TEST_CTS_SETTINGS_RECONCILED,
+        START_AT: START_AT_VALUE,
+        "pipeline_dir": "/some/dir/.dlt_conf",
+        "raw_data_dir": "/some/dir/raw_data",
+    }
+)
+
+
+def make_settings(
+    settings_cls: type[CtsSettings],
+    dlt_config: dict[str, Any] | None = None,
+    **kwargs: str | int | Path | dict[str, Any] | dlt.common.configuration.accessors._ConfigAccessor,
+) -> BaseSettings:  # CtsSettings | BatchedFileInputSettings | NcbiRestApiSettings | AtbSettings:
+    """Generate a validated Settings object."""
+    return settings_cls(**{"dlt_config": dlt_config, **kwargs})
+
+
+def make_settings_autofill_config(
+    settings_cls: type[CtsSettings],
+    **kwargs: str | int | Path | dict[str, Any] | bool | dlt.common.configuration.accessors._ConfigAccessor | None,
+) -> (
+    BaseSettings
+):  # CtsSettings | BatchedFileInputSettings | NcbiRestApiSettings | AtbSettings | UniProtSettings | UnirefSettings:
+    """Generate a validated Settings object, supplying the dlt_config if necessary."""
+    if not kwargs:
+        kwargs = {}
+    if "dlt_config" not in kwargs:
+        kwargs["dlt_config"] = _generate_dlt_config()
+    return settings_cls.model_validate(kwargs)
+
+
+def check_settings(
+    settings_object: CtsSettings,
+    expected: dict[str, Any] | frozendict,
+) -> None:
+    """Check that the settings object has the expected values."""
+    assert settings_object.dlt_config is not None
+    assert settings_object.model_dump(exclude={"dlt_config"}) == expected
+
+    # make sure we have both raw_data_dir and pipeline_dir
+    assert "raw_data_dir" in expected
+    assert "pipeline_dir" in expected
+    for attr, value in expected.items():
+        assert getattr(settings_object, attr) == value

--- a/tests/core/conftest.py
+++ b/tests/core/conftest.py
@@ -1,13 +1,10 @@
 """Shared fixtures for pipelines tests."""
 
-from itertools import batched
 from pathlib import Path
 from typing import Any, Final
-from unittest.mock import MagicMock
 
 import dlt
 import dlt.common.configuration.accessors
-import pytest
 from frozendict import frozendict
 from pydantic_settings import BaseSettings
 

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -3,19 +3,20 @@
 import pytest
 
 from cdm_data_loaders.core.fields import generate_aliases
+from tests.core.conftest import generate_cli_arguments
 
 
 @pytest.mark.parametrize(
     ("field_name", "expected_aliases"),
     [
         # field with a short alias
-        ("use_destination", ["-d", "--use_destination", "--use-destination"]),
+        ("use_destination", ["d", "use_destination", "use-destination"]),
         # field with no short alias
-        ("dev_mode", ["--dev_mode", "--dev-mode"]),
+        ("dev_mode", ["dev_mode", "dev-mode"]),
         # field with no underscores, no short aliases - short alias is generated
-        ("verbose", ["-v", "--verbose"]),
+        ("verbose", ["v", "verbose"]),
         # field with underscores, short alias is generated
-        ("non_existent_field", ["-n", "--non_existent_field", "--non-existent-field"]),
+        ("non_existent_field", ["n", "non_existent_field", "non-existent-field"]),
     ],
 )
 def test_generate_aliases(field_name: str, expected_aliases: list[str]) -> None:
@@ -27,15 +28,66 @@ def test_generate_aliases(field_name: str, expected_aliases: list[str]) -> None:
     ("field_name", "expected_aliases"),
     [
         # field with a short alias
-        ("use_destination", ["--use_destination", "--use-destination"]),
+        ("use_destination", ["use_destination", "use-destination"]),
         # field with no short alias
-        ("dev_mode", ["--dev_mode", "--dev-mode"]),
+        ("dev_mode", ["dev_mode", "dev-mode"]),
         # field with no underscores, no short aliases
-        ("verbose", ["--verbose"]),
-        # field with underscores, short alias is generated
-        ("non_existent_field", ["--non_existent_field", "--non-existent-field"]),
+        ("verbose", ["verbose"]),
+        # ifield with underscores, short alias is generated
+        ("non_existent_field", ["non_existent_field", "non-existent-field"]),
     ],
 )
 def test_generate_aliases_no_short_aliases(field_name: str, expected_aliases: list[str]) -> None:
     """Test the generate_aliases function."""
     assert generate_aliases(field_name, short_aliases=False) == expected_aliases
+
+
+def test_generate_cli_arguments() -> None:
+    """Test the generate_cli_arguments function."""
+    aliases = {k: generate_aliases(k) for k in ["use_destination", "dev_mode", "verbose", "non_existent_field"]}
+
+    assert generate_cli_arguments(aliases) == {
+        # field with a short alias
+        "use_destination": ["-d", "--use_destination", "--use-destination"],
+        # field with no short alias
+        "dev_mode": ["--dev_mode", "--dev-mode"],
+        # field with no underscores, no short aliases - short alias is generated
+        "verbose": ["-v", "--verbose"],
+        # field with underscores, short alias is generated
+        "non_existent_field": ["-n", "--non_existent_field", "--non-existent-field"],
+    }
+
+
+def test_generate_cli_arguments_no_short_aliases() -> None:
+    """Test the generate_cli_arguments function, no short aliases."""
+    aliases = {
+        k: generate_aliases(k, short_aliases=False)
+        for k in ["use_destination", "dev_mode", "verbose", "non_existent_field"]
+    }
+
+    assert generate_cli_arguments(aliases) == {
+        # field with a short alias
+        "use_destination": ["--use_destination", "--use-destination"],
+        # field with no short alias
+        "dev_mode": ["--dev_mode", "--dev-mode"],
+        # field with no underscores, no short aliases - short alias is generated
+        "verbose": ["--verbose"],
+        # field with underscores, short alias is generated
+        "non_existent_field": ["--non_existent_field", "--non-existent-field"],
+    }
+
+
+def test_generate_cli_arguments_multiple_args() -> None:
+    """Test the generate_cli_arguments function, multiple dictionaries."""
+    aliases = [{k: generate_aliases(k)} for k in ["use_destination", "dev_mode", "verbose", "non_existent_field"]]
+
+    assert generate_cli_arguments(*aliases) == {
+        # field with a short alias
+        "use_destination": ["-d", "--use_destination", "--use-destination"],
+        # field with no short alias
+        "dev_mode": ["--dev_mode", "--dev-mode"],
+        # field with no underscores, no short aliases - short alias is generated
+        "verbose": ["-v", "--verbose"],
+        # field with underscores, short alias is generated
+        "non_existent_field": ["-n", "--non_existent_field", "--non-existent-field"],
+    }

--- a/tests/core/test_fields.py
+++ b/tests/core/test_fields.py
@@ -1,0 +1,41 @@
+"""Tests for the fields module in cdm_data_loaders.core.fields."""
+
+import pytest
+
+from cdm_data_loaders.core.fields import generate_aliases
+
+
+@pytest.mark.parametrize(
+    ("field_name", "expected_aliases"),
+    [
+        # field with a short alias
+        ("use_destination", ["-d", "--use_destination", "--use-destination"]),
+        # field with no short alias
+        ("dev_mode", ["--dev_mode", "--dev-mode"]),
+        # field with no underscores, no short aliases - short alias is generated
+        ("verbose", ["-v", "--verbose"]),
+        # field with underscores, short alias is generated
+        ("non_existent_field", ["-n", "--non_existent_field", "--non-existent-field"]),
+    ],
+)
+def test_generate_aliases(field_name: str, expected_aliases: list[str]) -> None:
+    """Test the generate_aliases function."""
+    assert generate_aliases(field_name) == expected_aliases
+
+
+@pytest.mark.parametrize(
+    ("field_name", "expected_aliases"),
+    [
+        # field with a short alias
+        ("use_destination", ["--use_destination", "--use-destination"]),
+        # field with no short alias
+        ("dev_mode", ["--dev_mode", "--dev-mode"]),
+        # field with no underscores, no short aliases
+        ("verbose", ["--verbose"]),
+        # field with underscores, short alias is generated
+        ("non_existent_field", ["--non_existent_field", "--non-existent-field"]),
+    ],
+)
+def test_generate_aliases_no_short_aliases(field_name: str, expected_aliases: list[str]) -> None:
+    """Test the generate_aliases function."""
+    assert generate_aliases(field_name, short_aliases=False) == expected_aliases

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -3,11 +3,12 @@
 from typing import Any
 
 import pytest
+from frozendict import frozendict
 from pydantic import ValidationError
 from pydantic_settings import CliApp
 
 from cdm_data_loaders.core.fields import (
-    ARG_ALIASES,
+    ALIASES,
     VALID_DESTINATIONS,
 )
 from cdm_data_loaders.core.settings import (
@@ -24,6 +25,7 @@ from tests.core.conftest import (
     TEST_CTS_SETTINGS,
     TEST_CTS_SETTINGS_RECONCILED,
     check_settings,
+    generate_cli_arguments,
     make_settings,
     make_settings_autofill_config,
 )
@@ -37,6 +39,10 @@ S3 = "is_s3"
 OUT = "output"
 RAW = "raw_data_dir"
 PIPE = "pipeline_dir"
+
+
+# argument aliases for the fields, used for CLI parsing
+ARG_ALIASES: frozendict[str, list[str]] = generate_cli_arguments(ALIASES)
 
 
 # manually specify to avoid recapitulating logic

--- a/tests/core/test_settings.py
+++ b/tests/core/test_settings.py
@@ -6,14 +6,16 @@ import pytest
 from pydantic import ValidationError
 from pydantic_settings import CliApp
 
-from cdm_data_loaders.pipelines.cts_defaults import (
+from cdm_data_loaders.core.fields import (
     ARG_ALIASES,
     VALID_DESTINATIONS,
+)
+from cdm_data_loaders.core.settings import (
     BatchedFileInputSettings,
     CtsSettings,
 )
 from cdm_data_loaders.utils.batcher import MIN_START_AT
-from tests.pipelines.conftest import (
+from tests.core.conftest import (
     DEFAULT_BATCH_FILE_SETTINGS_RECONCILED,
     DEFAULT_CTS_SETTINGS_RECONCILED,
     DESTINATION_TO_OUTPUT,

--- a/tests/pipelines/conftest.py
+++ b/tests/pipelines/conftest.py
@@ -5,123 +5,13 @@ from pathlib import Path
 from typing import Any, Final
 from unittest.mock import MagicMock
 
-import dlt
-import dlt.common.configuration.accessors
 import pytest
-from frozendict import frozendict
 
 from cdm_data_loaders.pipelines import core
-from cdm_data_loaders.pipelines.all_the_bacteria import AtbSettings
-from cdm_data_loaders.pipelines.cts_defaults import (
-    DEFAULT_BATCH_FILE_SETTINGS,
-    DEFAULT_CTS_SETTINGS,
-    BatchedFileInputSettings,
-    CtsSettings,
-)
-from cdm_data_loaders.pipelines.ncbi_rest_api import NcbiSettings
-from cdm_data_loaders.pipelines.uniprot_kb import UniProtSettings
-from cdm_data_loaders.pipelines.uniref import UnirefSettings
-
-CASSETTES_DIR = "tests/cassettes"
 
 START_AT_VALUE: Final[int] = 50
 START_AT_STRING: Final[str] = "50"
 TEST_LOG_CONFIG_FILE: Final[str] = "log_conf.json"
-CONFIG_BUCKET = frozendict({"local_fs": "/output_dir", "s3": "s3://some/s3/bucket"})
-
-TEST_DLT_CONFIG = frozendict(
-    {
-        "destination.local_fs.bucket_url": CONFIG_BUCKET["local_fs"],
-        "destination.local_fs.destination_type": "filesystem",
-        "destination.s3.bucket_url": CONFIG_BUCKET["s3"],
-        "destination.s3.destination_type": "filesystem",
-        "normalize.data_writer.disable_compression": False,
-    }
-)
-
-
-def _generate_dlt_config() -> dict[str, Any]:
-    """Return a fresh DLT config dict (same shape as the conftest fixture)."""
-    return {
-        "destination": {
-            "local_fs": {"bucket_url": CONFIG_BUCKET["local_fs"]},
-            "s3": {"bucket_url": CONFIG_BUCKET["s3"]},
-        },
-        "destination.local_fs.bucket_url": CONFIG_BUCKET["local_fs"],
-        "destination.s3.bucket_url": CONFIG_BUCKET["s3"],
-        "normalize.data_writer.disable_compression": False,
-    }
-
-
-DESTINATION_TO_OUTPUT = frozendict(
-    {
-        "local_fs": TEST_DLT_CONFIG["destination.local_fs.bucket_url"],
-        "s3": TEST_DLT_CONFIG["destination.s3.bucket_url"],
-    }
-)
-
-DESTINATION_OUTPUT: Final[str] = DESTINATION_TO_OUTPUT[DEFAULT_CTS_SETTINGS["use_destination"]]
-
-DEFAULT_CTS_SETTINGS_RECONCILED = frozendict(
-    {
-        **DEFAULT_CTS_SETTINGS,
-        "output": DESTINATION_OUTPUT,
-        "raw_data_dir": f"{DESTINATION_OUTPUT}/raw_data",
-        "pipeline_dir": None,
-    }
-)
-
-DEFAULT_BATCH_FILE_SETTINGS_RECONCILED = frozendict({**DEFAULT_BATCH_FILE_SETTINGS, **DEFAULT_CTS_SETTINGS_RECONCILED})
-
-TEST_CTS_SETTINGS = frozendict(
-    {
-        "dev_mode": "false",
-        "input_dir": "/dir/path",
-        "log_config_file": "some/path",
-        "output": "/some/dir",
-        "use_destination": "local_fs",
-        "use_output_dir_for_pipeline_metadata": "true",
-    }
-)
-
-TEST_CTS_SETTINGS_RECONCILED = frozendict(
-    {
-        **TEST_CTS_SETTINGS,
-        "dev_mode": False,
-        "use_output_dir_for_pipeline_metadata": True,
-        "pipeline_dir": "/some/dir/.dlt_conf",
-        "raw_data_dir": "/some/dir/raw_data",
-    }
-)
-
-TEST_BATCH_FILE_SETTINGS = frozendict(
-    **TEST_CTS_SETTINGS,
-    start_at=START_AT_STRING,
-)
-
-TEST_BATCH_FILE_SETTINGS_RECONCILED = frozendict(
-    {
-        **TEST_CTS_SETTINGS_RECONCILED,
-        "start_at": START_AT_VALUE,
-        "pipeline_dir": "/some/dir/.dlt_conf",
-        "raw_data_dir": "/some/dir/raw_data",
-    }
-)
-
-
-DEFAULT_VCR_CONFIG = frozendict(
-    {
-        "cassette_library_dir": CASSETTES_DIR,
-        "record_mode": "once",  # record on first run, replay thereafter
-        "serializer": "yaml",
-        "match_on": ["method", "scheme", "host", "path", "query"],
-        # strip the NCBI API key from cassettes
-        "filter_query_parameters": ["api_key"],
-        "filter_headers": ["api_key"],
-        "decode_compressed_response": True,
-        "allow_playback_repeats": True,
-    }
-)
 
 
 def make_batcher(files: list[Path], batch_size: int = 5) -> MagicMock:
@@ -130,48 +20,6 @@ def make_batcher(files: list[Path], batch_size: int = 5) -> MagicMock:
     mock_batcher = MagicMock()
     mock_batcher.get_batch.side_effect = [*batches, []]
     return mock_batcher
-
-
-def make_settings(
-    settings_cls: type[CtsSettings],
-    dlt_config: dict[str, Any] | None = None,
-    **kwargs: str | int | Path | dict[str, Any] | dlt.common.configuration.accessors._ConfigAccessor,
-) -> CtsSettings | BatchedFileInputSettings | NcbiSettings | AtbSettings:
-    """Generate a validated Settings object."""
-    return settings_cls(**{"dlt_config": dlt_config, **kwargs})
-
-
-def make_settings_autofill_config(
-    settings_cls: type[CtsSettings],
-    **kwargs: str | int | Path | dict[str, Any] | bool | dlt.common.configuration.accessors._ConfigAccessor | None,
-) -> CtsSettings | BatchedFileInputSettings | NcbiSettings | AtbSettings | UniProtSettings | UnirefSettings:
-    """Generate a validated Settings object, supplying the dlt_config if necessary."""
-    if not kwargs:
-        kwargs = {}
-    if "dlt_config" not in kwargs:
-        kwargs["dlt_config"] = _generate_dlt_config()
-    return settings_cls.model_validate(kwargs)
-
-
-def check_settings(
-    settings_object: CtsSettings,
-    expected: dict[str, Any] | frozendict,
-) -> None:
-    """Check that the settings object has the expected values."""
-    assert settings_object.dlt_config is not None
-    assert settings_object.model_dump(exclude={"dlt_config"}) == expected
-
-    # make sure we have both raw_data_dir and pipeline_dir
-    assert "raw_data_dir" in expected
-    assert "pipeline_dir" in expected
-    for attr, value in expected.items():
-        assert getattr(settings_object, attr) == value
-
-
-@pytest.fixture
-def dlt_config() -> dict[str, Any]:
-    """DLT config for testing purposes."""
-    return _generate_dlt_config()
 
 
 @pytest.fixture

--- a/tests/pipelines/conftest.py
+++ b/tests/pipelines/conftest.py
@@ -6,12 +6,25 @@ from typing import Any, Final
 from unittest.mock import MagicMock
 
 import pytest
+from frozendict import frozendict
 
+from cdm_data_loaders.core.fields import (
+    ALIASES,
+)
 from cdm_data_loaders.pipelines import core
+from cdm_data_loaders.pipelines.all_the_bacteria import ALIASES as ATB_ALIASES
+from cdm_data_loaders.pipelines.ncbi_rest_api import ALIASES as NCBI_REST_API_ALIASES
+from cdm_data_loaders.pipelines.uniref import ALIASES as UNIREF_ALIASES
+from tests.core.conftest import generate_cli_arguments
 
 START_AT_VALUE: Final[int] = 50
 START_AT_STRING: Final[str] = "50"
 TEST_LOG_CONFIG_FILE: Final[str] = "log_conf.json"
+
+
+ARG_ALIASES: frozendict[str, list[str]] = generate_cli_arguments(
+    ALIASES, ATB_ALIASES, UNIREF_ALIASES, NCBI_REST_API_ALIASES
+)
 
 
 def make_batcher(files: list[Path], batch_size: int = 5) -> MagicMock:

--- a/tests/pipelines/test_all_the_bacteria.py
+++ b/tests/pipelines/test_all_the_bacteria.py
@@ -11,6 +11,7 @@ import pytest
 from frozendict import frozendict
 from requests.exceptions import HTTPError
 
+from cdm_data_loaders.core.fields import VALID_DESTINATIONS
 from cdm_data_loaders.pipelines import all_the_bacteria, core
 from cdm_data_loaders.pipelines.all_the_bacteria import (
     ALL_ATB_FILE_NAME,
@@ -23,9 +24,8 @@ from cdm_data_loaders.pipelines.all_the_bacteria import (
     osf_file_downloader,
     run_atb_pipeline,
 )
-from cdm_data_loaders.pipelines.cts_defaults import VALID_DESTINATIONS
 from cdm_data_loaders.utils.download.core import NonRetryableDownloadError
-from tests.pipelines.conftest import CASSETTES_DIR
+from tests.conftest import CASSETTES_DIR
 
 
 @pytest.fixture(autouse=True)

--- a/tests/pipelines/test_core.py
+++ b/tests/pipelines/test_core.py
@@ -13,6 +13,14 @@ import pytest
 from pydantic import ValidationError
 from pydantic_settings import SettingsError
 
+from cdm_data_loaders.core.fields import (
+    DEFAULT_PIPELINE_BATCH_SIZE,
+    VALID_DESTINATIONS,
+)
+from cdm_data_loaders.core.settings import (
+    BatchedFileInputSettings,
+    CtsSettings,
+)
 from cdm_data_loaders.pipelines import core
 from cdm_data_loaders.pipelines.core import (
     NO_MESSAGE,
@@ -24,14 +32,9 @@ from cdm_data_loaders.pipelines.core import (
     stream_xml_file_resource,
     sync_configs,
 )
-from cdm_data_loaders.pipelines.cts_defaults import (
-    DEFAULT_PIPELINE_BATCH_SIZE,
-    VALID_DESTINATIONS,
-    BatchedFileInputSettings,
-    CtsSettings,
-)
-from tests.pipelines.conftest import TEST_CTS_SETTINGS, _generate_dlt_config, make_batcher
-from tests.pipelines.test_cts_defaults import SETTINGS_CLASSES
+from tests.conftest import _generate_dlt_config
+from tests.core.test_settings import SETTINGS_CLASSES, TEST_CTS_SETTINGS
+from tests.pipelines.conftest import make_batcher
 
 
 @pytest.fixture(autouse=True)

--- a/tests/pipelines/test_ncbi_ftp_download.py
+++ b/tests/pipelines/test_ncbi_ftp_download.py
@@ -12,15 +12,15 @@ from moto import mock_aws
 from pydantic import ValidationError
 
 import cdm_data_loaders.utils.s3 as s3_mod
+from cdm_data_loaders.core.fields import INPUT_MOUNT, OUTPUT_MOUNT
 from cdm_data_loaders.ncbi_ftp.assembly import FTP_HOST
-from cdm_data_loaders.pipelines.cts_defaults import INPUT_MOUNT, OUTPUT_MOUNT
 from cdm_data_loaders.pipelines.ncbi_ftp_download import (
     DownloadSettings,
     download_and_stage,
     download_batch,
 )
 from cdm_data_loaders.utils.s3 import reset_s3_client
-from tests.pipelines.conftest import _generate_dlt_config
+from tests.conftest import _generate_dlt_config
 
 _MOCK_STATS = {
     "accession": "GCF_000001215.4",

--- a/tests/pipelines/test_ncbi_ftp_promote.py
+++ b/tests/pipelines/test_ncbi_ftp_promote.py
@@ -15,7 +15,7 @@ from cdm_data_loaders.pipelines.ncbi_ftp_promote import (
     PromoteSettings,
     run_promote,
 )
-from tests.pipelines.conftest import _generate_dlt_config
+from tests.conftest import _generate_dlt_config
 
 _DEFAULT_STAGING_PATH: PurePosixPath = PurePosixPath("staging") / "run1"
 

--- a/tests/pipelines/test_ncbi_rest_api.py
+++ b/tests/pipelines/test_ncbi_rest_api.py
@@ -13,9 +13,9 @@ from pydantic import ValidationError
 from pydantic_settings import CliApp
 from requests import HTTPError
 
+from cdm_data_loaders.core.fields import ARG_ALIASES
 from cdm_data_loaders.pipelines import core
 from cdm_data_loaders.pipelines import ncbi_rest_api as ncbi_module
-from cdm_data_loaders.pipelines.cts_defaults import ARG_ALIASES
 from cdm_data_loaders.pipelines.ncbi_rest_api import (
     ANNOTATION,
     ARG_ALIAS_BATCH_SIZE,
@@ -24,7 +24,7 @@ from cdm_data_loaders.pipelines.ncbi_rest_api import (
     DATASET_NAME,
     ERROR,
     MAX_IDS_PER_QUERY,
-    NcbiSettings,
+    NcbiRestApiSettings,
     assemble_assembly_reports,
     assembly_list,
     cli,
@@ -35,8 +35,10 @@ from cdm_data_loaders.pipelines.ncbi_rest_api import (
     run_ncbi_pipeline,
     set_settings,
 )
-from tests.pipelines.conftest import (
+from tests.conftest import (
     DEFAULT_VCR_CONFIG,
+)
+from tests.core.conftest import (
     TEST_CTS_SETTINGS,
     TEST_CTS_SETTINGS_RECONCILED,
     check_settings,
@@ -107,14 +109,14 @@ def assembly_ids(valid_assembly_ids: list[str], invalid_assembly_id: str) -> lis
 
 
 @pytest.fixture(scope="module")
-def test_settings() -> NcbiSettings:
+def test_settings() -> NcbiRestApiSettings:
     """Generate a test settings class."""
-    return make_settings_autofill_config(NcbiSettings)  # type: ignore[reportReturnType]
+    return make_settings_autofill_config(NcbiRestApiSettings)  # type: ignore[reportReturnType]
 
 
-def make_settings(**kwargs: str | int | bool) -> NcbiSettings:
-    """Generate a validated NcbiSettings object."""
-    return NcbiSettings.model_validate(kwargs)
+def make_settings(**kwargs: str | int | bool) -> NcbiRestApiSettings:
+    """Generate a validated NcbiRestApiSettings object."""
+    return NcbiRestApiSettings.model_validate(kwargs)
 
 
 @pytest.fixture(autouse=True)
@@ -127,7 +129,7 @@ def reset_settings(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(ncbi_module, "PIPELINE_SETTINGS", None)
 
 
-def test_get_set_settings(test_settings: NcbiSettings) -> None:
+def test_get_set_settings(test_settings: NcbiRestApiSettings) -> None:
     """Test setting and retrieval of settings."""
     assert ncbi_module.PIPELINE_SETTINGS is None
     with pytest.raises(RuntimeError, match="Pipeline settings have not been initialised"):
@@ -154,9 +156,9 @@ def test_get_set_settings(test_settings: NcbiSettings) -> None:
 def test_settings_valid_batch_size(batch_size: int | str | None, parsed_batch_size: int) -> None:
     """Ensure that a valid batch size is correctly parsed."""
     if batch_size is None:
-        settings: NcbiSettings = make_settings_autofill_config(NcbiSettings)  # type: ignore[reportReturnType]
+        settings: NcbiRestApiSettings = make_settings_autofill_config(NcbiRestApiSettings)  # type: ignore[reportReturnType]
     else:
-        settings: NcbiSettings = make_settings_autofill_config(NcbiSettings, batch_size=batch_size)  # type: ignore[reportReturnType]
+        settings: NcbiRestApiSettings = make_settings_autofill_config(NcbiRestApiSettings, batch_size=batch_size)  # type: ignore[reportReturnType]
     assert settings.batch_size == parsed_batch_size
 
 
@@ -176,10 +178,10 @@ def test_cli_invalid_batch_size_via_cli_raises(bad_batch_size: str, message: str
     """Ensure that an invalid batch size passed via CLI raises an error."""
     if use_cliapp:
         with pytest.raises(ValidationError, match=message):
-            CliApp.run(NcbiSettings, cli_args=["--batch-size", bad_batch_size])
+            CliApp.run(NcbiRestApiSettings, cli_args=["--batch-size", bad_batch_size])
     else:
         with pytest.raises(ValidationError, match=message):
-            make_settings_autofill_config(NcbiSettings, batch_size=bad_batch_size)
+            make_settings_autofill_config(NcbiRestApiSettings, batch_size=bad_batch_size)
 
 
 @pytest.mark.parametrize(
@@ -196,11 +198,11 @@ def test_cli_invalid_batch_size_via_cli_raises(bad_batch_size: str, message: str
 )
 def test_cli_valid_query_type(query_type: str | None, parsed_query_type: str | None) -> None:
     """Ensure that a valid batch size is correctly parsed."""
-    settings: NcbiSettings = make_settings_autofill_config(NcbiSettings, query_type=query_type)  # type: ignore[reportReturnType]
+    settings: NcbiRestApiSettings = make_settings_autofill_config(NcbiRestApiSettings, query_type=query_type)  # type: ignore[reportReturnType]
     assert settings.query_type == parsed_query_type
 
     if query_type is None:
-        alt_settings: NcbiSettings = make_settings_autofill_config(NcbiSettings)  # type: ignore[reportReturnType]
+        alt_settings: NcbiRestApiSettings = make_settings_autofill_config(NcbiRestApiSettings)  # type: ignore[reportReturnType]
         assert alt_settings.query_type == parsed_query_type
 
 
@@ -220,10 +222,10 @@ def test_cli_invalid_query_type(query_type: str, use_cliapp: bool) -> None:
     """Ensure that an invalid batch size passed via CLI raises an error."""
     if use_cliapp:
         with pytest.raises(ValidationError, match=STRING_MATCH_MESSAGE):
-            CliApp.run(NcbiSettings, cli_args=["--query-type", query_type])
+            CliApp.run(NcbiRestApiSettings, cli_args=["--query-type", query_type])
     else:
         with pytest.raises(ValidationError, match=STRING_MATCH_MESSAGE):
-            make_settings_autofill_config(NcbiSettings, query_type=query_type)
+            make_settings_autofill_config(NcbiRestApiSettings, query_type=query_type)
 
 
 @pytest.mark.parametrize(
@@ -232,7 +234,7 @@ def test_cli_invalid_query_type(query_type: str, use_cliapp: bool) -> None:
 )
 def test_settings_all_params_set(settings: frozendict, reconciled: frozendict) -> None:
     """Ensure that settings are set correctly when all args are specified."""
-    s = make_settings_autofill_config(NcbiSettings, **settings)
+    s = make_settings_autofill_config(NcbiRestApiSettings, **settings)
     check_settings(s, reconciled)
 
 
@@ -258,9 +260,9 @@ def test_cli_all_variants(
     use_output_dir_for_pipeline_metadata: str,
     dlt_config: dict[str, Any],
 ) -> None:
-    """Test all the variants of the NcbiSettings fields."""
+    """Test all the variants of the NcbiRestApiSettings fields."""
     s = CliApp.run(
-        NcbiSettings,
+        NcbiRestApiSettings,
         dlt_config=dlt_config,
         cli_args=[
             query_type,
@@ -285,12 +287,12 @@ def test_cli_all_variants(
 
 
 def test_cli_passes_settings_class_to_run_cli() -> None:
-    """Ensure that cli() calls run_cli with NcbiSettings as the settings class."""
+    """Ensure that cli() calls run_cli with NcbiRestApiSettings as the settings class."""
     with patch.object(ncbi_module, "run_cli") as mock_run_cli:
         cli()
 
     mock_run_cli.assert_called_once()
-    assert mock_run_cli.call_args[0] == (NcbiSettings, run_ncbi_pipeline)
+    assert mock_run_cli.call_args[0] == (NcbiRestApiSettings, run_ncbi_pipeline)
 
 
 def test_cli_calls_run_ncbi_pipeline(monkeypatch: pytest.MonkeyPatch, dlt_config: dict[str, Any]) -> None:
@@ -299,7 +301,7 @@ def test_cli_calls_run_ncbi_pipeline(monkeypatch: pytest.MonkeyPatch, dlt_config
     mock_settings_cls = MagicMock(return_value=mock_settings_instance)
     mock_run_ncbi_pipeline = MagicMock()
 
-    monkeypatch.setattr(ncbi_module, "NcbiSettings", mock_settings_cls)
+    monkeypatch.setattr(ncbi_module, "NcbiRestApiSettings", mock_settings_cls)
     monkeypatch.setattr(ncbi_module, "run_ncbi_pipeline", mock_run_ncbi_pipeline)
 
     cli()
@@ -330,7 +332,9 @@ def check_annotation_report(annotation_report: list[dict[str, Any]] | None, asse
 
 def test_assembly_list_resource() -> None:
     """Test that the assembly list resource yields the expected assembly IDs."""
-    settings: NcbiSettings = make_settings_autofill_config(NcbiSettings, input_dir="tests/data/ncbi_rest_api/input")  # type: ignore[reportAssignmentType]
+    settings: NcbiRestApiSettings = make_settings_autofill_config(
+        NcbiRestApiSettings, input_dir="tests/data/ncbi_rest_api/input"
+    )  # type: ignore[reportAssignmentType]
     set_settings(settings)
 
     ass_list = list(assembly_list())
@@ -366,7 +370,7 @@ def test_run_ncbi_pipeline_sets_core_run_pipeline_args_correctly(
     if use_pipeline_dir is not None:
         base_settings["use_output_dir_for_pipeline_metadata"] = use_pipeline_dir
 
-    settings: NcbiSettings = make_settings_autofill_config(NcbiSettings, **base_settings)  # type: ignore[reportAssignmentType]
+    settings: NcbiRestApiSettings = make_settings_autofill_config(NcbiRestApiSettings, **base_settings)  # type: ignore[reportAssignmentType]
 
     check_settings(
         settings,
@@ -455,14 +459,14 @@ def test_get_annotation_report_invalid_id() -> None:
     assert get_annotation_report(INVALID_ID) is None
 
 
-def test_get_assembly_reports_empty_id_list(test_settings: NcbiSettings) -> None:
+def test_get_assembly_reports_empty_id_list(test_settings: NcbiRestApiSettings) -> None:
     """Ensure that getting reports for an empty list returns nothing."""
     set_settings(test_settings)
     assert get_assembly_reports([]) == {}
 
 
 @pytest.mark.vcr
-def test_get_assembly_reports(test_settings: NcbiSettings) -> None:
+def test_get_assembly_reports(test_settings: NcbiRestApiSettings) -> None:
     """Test the retrieval of annotation and dataset reports."""
     set_settings(test_settings)
     assembly_reports = get_assembly_reports(ALL_IDS)
@@ -479,7 +483,7 @@ def test_get_assembly_reports(test_settings: NcbiSettings) -> None:
 @pytest.mark.parametrize("query_type", [None, DATASET, ANNOTATION])
 def test_get_assembly_reports_mock_subs(query_type: str | None, monkeypatch: pytest.MonkeyPatch) -> None:
     """Ensure that the correct subs are called and the correct subs are not called with the query_type parameter."""
-    settings: NcbiSettings = make_settings_autofill_config(NcbiSettings, query_type=query_type)  # type: ignore[reportAssignmentType]
+    settings: NcbiRestApiSettings = make_settings_autofill_config(NcbiRestApiSettings, query_type=query_type)  # type: ignore[reportAssignmentType]
     set_settings(settings)
     mock_get_annotation_report = MagicMock(return_value={"this": "that"})
     mock_get_dataset_reports = MagicMock(return_value=dict.fromkeys(ALL_IDS, "blob"))
@@ -558,7 +562,7 @@ RECORDED_ERRORS = {
 @mock.patch("tenacity.nap.time.sleep", MagicMock())
 @pytest.mark.default_cassette("test_get_assembly_reports_annotation_report_errors.yaml")
 @pytest.mark.vcr
-def test_get_assembly_reports_annotation_report_errors(test_settings: NcbiSettings) -> None:
+def test_get_assembly_reports_annotation_report_errors(test_settings: NcbiRestApiSettings) -> None:
     """Test the retrieval of assembly data when errors occur fetching annotation reports."""
     set_settings(test_settings)
     original_get_annotation_report = get_annotation_report
@@ -598,7 +602,7 @@ def test_get_assembly_reports_annotation_report_errors(test_settings: NcbiSettin
 
 @mock.patch("tenacity.nap.time.sleep", MagicMock())
 @pytest.mark.vcr
-def test_get_assembly_reports_dataset_report_errors(test_settings: NcbiSettings) -> None:
+def test_get_assembly_reports_dataset_report_errors(test_settings: NcbiRestApiSettings) -> None:
     """Test the retrieval of assembly data when an error occurs fetching dataset reports."""
     set_settings(test_settings)
     assembly_reports = get_assembly_reports(ALL_IDS)
@@ -615,7 +619,7 @@ def test_get_assembly_reports_dataset_report_errors(test_settings: NcbiSettings)
 
 @mock.patch("tenacity.nap.time.sleep", MagicMock())
 @pytest.mark.vcr
-def test_get_assembly_reports_total_wipeout(test_settings: NcbiSettings) -> None:
+def test_get_assembly_reports_total_wipeout(test_settings: NcbiRestApiSettings) -> None:
     """Test the retrieval of assembly data when all queries fail."""
     set_settings(test_settings)
     original_get_annotation_report = get_annotation_report
@@ -656,8 +660,8 @@ def test_get_assembly_reports_total_wipeout(test_settings: NcbiSettings) -> None
 @pytest.mark.vcr
 def test_get_assembly_report_parser_with_cassette(assembly_ids: list[str], tmp_path: Path) -> None:
     with patch("dlt.mark"):
-        settings: NcbiSettings = make_settings_autofill_config(
-            NcbiSettings, input_dir="tests/data/ncbi_rest_api/input", output=str(tmp_path)
+        settings: NcbiRestApiSettings = make_settings_autofill_config(
+            NcbiRestApiSettings, input_dir="tests/data/ncbi_rest_api/input", output=str(tmp_path)
         )  # type: ignore[reportAssignmentType]
         run_ncbi_pipeline(settings)
 

--- a/tests/pipelines/test_ncbi_rest_api.py
+++ b/tests/pipelines/test_ncbi_rest_api.py
@@ -13,13 +13,10 @@ from pydantic import ValidationError
 from pydantic_settings import CliApp
 from requests import HTTPError
 
-from cdm_data_loaders.core.fields import ARG_ALIASES
 from cdm_data_loaders.pipelines import core
 from cdm_data_loaders.pipelines import ncbi_rest_api as ncbi_module
 from cdm_data_loaders.pipelines.ncbi_rest_api import (
     ANNOTATION,
-    ARG_ALIAS_BATCH_SIZE,
-    ARG_ALIAS_QUERY_TYPE,
     DATASET,
     DATASET_NAME,
     ERROR,
@@ -44,6 +41,7 @@ from tests.core.conftest import (
     check_settings,
     make_settings_autofill_config,
 )
+from tests.pipelines.conftest import ARG_ALIASES
 
 
 @pytest.fixture(autouse=True)
@@ -238,8 +236,8 @@ def test_settings_all_params_set(settings: frozendict, reconciled: frozendict) -
     check_settings(s, reconciled)
 
 
-@pytest.mark.parametrize("query_type", ARG_ALIAS_QUERY_TYPE)
-@pytest.mark.parametrize("batch_size", ARG_ALIAS_BATCH_SIZE)
+@pytest.mark.parametrize("query_type", ARG_ALIASES["query_type"])
+@pytest.mark.parametrize("batch_size", ARG_ALIASES["batch_size"])
 @pytest.mark.parametrize("dev_mode", ARG_ALIASES["dev_mode"])
 @pytest.mark.parametrize("input_dir", ARG_ALIASES["input_dir"])
 @pytest.mark.parametrize("log_config_file", ARG_ALIASES["log_config_file"])

--- a/tests/pipelines/test_uniprot.py
+++ b/tests/pipelines/test_uniprot.py
@@ -10,7 +10,6 @@ import pytest
 from frozendict import frozendict
 from pydantic_settings import CliApp
 
-from cdm_data_loaders.core.fields import ARG_ALIASES
 from cdm_data_loaders.parsers.uniprot.uniprot_kb import ENTRY_XML_TAG
 from cdm_data_loaders.pipelines import core
 from cdm_data_loaders.pipelines import uniprot_kb as uniprot_module
@@ -28,6 +27,7 @@ from tests.core.conftest import (
     make_settings_autofill_config,
 )
 from tests.pipelines.conftest import (
+    ARG_ALIASES,
     make_batcher,
 )
 

--- a/tests/pipelines/test_uniprot.py
+++ b/tests/pipelines/test_uniprot.py
@@ -10,10 +10,10 @@ import pytest
 from frozendict import frozendict
 from pydantic_settings import CliApp
 
+from cdm_data_loaders.core.fields import ARG_ALIASES
 from cdm_data_loaders.parsers.uniprot.uniprot_kb import ENTRY_XML_TAG
 from cdm_data_loaders.pipelines import core
 from cdm_data_loaders.pipelines import uniprot_kb as uniprot_module
-from cdm_data_loaders.pipelines.cts_defaults import ARG_ALIASES
 from cdm_data_loaders.pipelines.uniprot_kb import (
     UNIPROT_LOG_INTERVAL,
     UniProtSettings,
@@ -21,12 +21,14 @@ from cdm_data_loaders.pipelines.uniprot_kb import (
     parse_uniprot,
     run_uniprot_pipeline,
 )
-from tests.pipelines.conftest import (
+from tests.core.conftest import (
     TEST_BATCH_FILE_SETTINGS,
     TEST_BATCH_FILE_SETTINGS_RECONCILED,
     check_settings,
-    make_batcher,
     make_settings_autofill_config,
+)
+from tests.pipelines.conftest import (
+    make_batcher,
 )
 
 # TODO: add a test to ensure that parse_uniprot_entry is called with the appropriate args. Requires mocking the file batcher and stream_xml_file_resource functions.

--- a/tests/pipelines/test_uniref.py
+++ b/tests/pipelines/test_uniref.py
@@ -11,13 +11,11 @@ from frozendict import frozendict
 from pydantic import ValidationError
 from pydantic_settings import CliApp
 
-from cdm_data_loaders.core.fields import ARG_ALIASES
 from cdm_data_loaders.parsers.uniprot.uniref import ENTRY_XML_TAG, UNIREF_VARIANTS
 from cdm_data_loaders.pipelines import core
 from cdm_data_loaders.pipelines import uniref as uniref_module
 from cdm_data_loaders.pipelines.uniref import (
     UNIREF_LOG_INTERVAL,
-    UNIREF_VARIANT_ALIASES,
     UnirefSettings,
     cli,
     parse_uniref,
@@ -30,6 +28,7 @@ from tests.core.conftest import (
     make_settings_autofill_config,
 )
 from tests.pipelines.conftest import (
+    ARG_ALIASES,
     make_batcher,
 )
 
@@ -80,7 +79,7 @@ def test_settings_valid_variants_accepted(variant: str) -> None:
 
 
 @pytest.mark.parametrize("value", UNIREF_VARIANTS)
-@pytest.mark.parametrize("uniref_variant", UNIREF_VARIANT_ALIASES)
+@pytest.mark.parametrize("uniref_variant", ARG_ALIASES["uniref_variant"])
 def test_cli_valid_variants_accepted(uniref_variant: str, dlt_config: dict[str, Any], value: str) -> None:
     """Ensure that each valid uniref_variant value is accepted without error when passed via CLI."""
     s = CliApp.run(UnirefSettings, dlt_config=dlt_config, cli_args=[uniref_variant, value])
@@ -99,7 +98,7 @@ def test_invalid_variant_raises(value: str) -> None:
 
 
 @pytest.mark.parametrize("value", ["25", "75", "uniref50", "", "ALL"])
-@pytest.mark.parametrize("uniref_variant", UNIREF_VARIANT_ALIASES)
+@pytest.mark.parametrize("uniref_variant", ARG_ALIASES["uniref_variant"])
 def test_cli_invalid_variant_via_cli_raises(value: str, uniref_variant: str, dlt_config: dict[str, Any]) -> None:
     """Ensure that an invalid uniref_variant passed via CLI raises an error."""
     # with pytest.raises(ValidationError, match="Value error, uniref_variant must be one of"):
@@ -129,7 +128,7 @@ def test_cli_missing_required_uniref_variant_raises(dlt_config: dict[str, Any]) 
 
 
 @pytest.mark.parametrize("value", ["25", "75", "uniref50", "", "ALL"])
-@pytest.mark.parametrize("uniref_variant", UNIREF_VARIANT_ALIASES)
+@pytest.mark.parametrize("uniref_variant", ARG_ALIASES["uniref_variant"])
 def test_cli_invalid_variant_and_destination_via_cli_raises(
     value: str, uniref_variant: str, dlt_config: dict[str, Any]
 ) -> None:
@@ -163,7 +162,7 @@ def test_make_settings_all_params_set() -> None:
 @pytest.mark.parametrize("log_config_file", ARG_ALIASES["log_config_file"])
 @pytest.mark.parametrize("output", ARG_ALIASES["output"])
 @pytest.mark.parametrize("start_at", ARG_ALIASES["start_at"])
-@pytest.mark.parametrize("uniref_variant", UNIREF_VARIANT_ALIASES)
+@pytest.mark.parametrize("uniref_variant", ARG_ALIASES["uniref_variant"])
 @pytest.mark.parametrize("use_destination", ARG_ALIASES["use_destination"])
 @pytest.mark.parametrize(
     "use_output_dir_for_pipeline_metadata",

--- a/tests/pipelines/test_uniref.py
+++ b/tests/pipelines/test_uniref.py
@@ -11,10 +11,10 @@ from frozendict import frozendict
 from pydantic import ValidationError
 from pydantic_settings import CliApp
 
+from cdm_data_loaders.core.fields import ARG_ALIASES
 from cdm_data_loaders.parsers.uniprot.uniref import ENTRY_XML_TAG, UNIREF_VARIANTS
 from cdm_data_loaders.pipelines import core
 from cdm_data_loaders.pipelines import uniref as uniref_module
-from cdm_data_loaders.pipelines.cts_defaults import ARG_ALIASES
 from cdm_data_loaders.pipelines.uniref import (
     UNIREF_LOG_INTERVAL,
     UNIREF_VARIANT_ALIASES,
@@ -23,12 +23,14 @@ from cdm_data_loaders.pipelines.uniref import (
     parse_uniref,
     run_uniref_pipeline,
 )
-from tests.pipelines.conftest import (
+from tests.core.conftest import (
     TEST_BATCH_FILE_SETTINGS,
     TEST_BATCH_FILE_SETTINGS_RECONCILED,
     check_settings,
-    make_batcher,
     make_settings_autofill_config,
+)
+from tests.pipelines.conftest import (
+    make_batcher,
 )
 
 # TODO: add a test to ensure that parse_uniref_entry is called with the appropriate args. Requires mocking the file batcher and stream_xml_file_resource functions.


### PR DESCRIPTION
# Description of PR purpose/changes

The `pipelines` directory was starting to get cluttered and confusing, so this PR moves the settings-related file over to the `cdm_data_loaders.core` namespace.

# Testing Instructions
* Details for how to test the PR:
- [ ] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [ ] My submission follows the [AI Covenant](/AI_COVENANT.md) principles
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] I have run Ruff `format` to format my code
- [ ] I have run Ruff `check` and fixed any errors that it uncovered

# Updating Version and Release Notes (if applicable)

- [ ] [Version has been bumped](https://semver.org/) for each release.
- [ ] [README](/README.md) has been updated for each release.
