### PR TITLE
Add PDB manifest pipeline

### DIFF
--- a/.github/workflows/trivy.yaml
+++ b/.github/workflows/trivy.yaml
@@ -49,7 +49,7 @@ jobs:
                   template: "@/contrib/sarif.tpl"
                   output: "trivy-results.sarif"
                   severity: "CRITICAL,HIGH"
-                  timeout: 15m
+                  timeout: 25m
 
             - name: Upload Trivy scan results to GitHub Security tab
               uses: github/codeql-action/upload-sarif@v4

--- a/docs/pdb_e2e_walkthrough.md
+++ b/docs/pdb_e2e_walkthrough.md
@@ -1,0 +1,90 @@
+# PDB Pipelines - End-to-End Transfer Walkthrough
+
+## Workflow Overview
+
+Semi-automated PDB transfers involve three distinct pipelines run sequentially:
+* `manifest-generation`: Triggered manually in the Lakehouse.
+    - Downloads current PDB holdings files
+    - Optionally bootstraps current Lakehouse PDB snapshot (if previous snapshot was not saved)
+    - Compares current PDB holdings to Lakehouse PDB snapshot to generate:
+        * `transfer_manifest.txt`: New and updated PDB records to download
+        * `updated_manifest.txt`: Lakehouse records to archive before promoting new downloads
+        * `removed_manifest.txt`: Lakehouse records to archive (will not be replaced with new download)
+        * `missing_dates.txt`: Current PDB holdings for which a last-modified date was not included. (Manual review)
+* `download`: cdm-task-service containerized pipeline.
+    - Downloads records in `transfer_manifest.txt` to staging folder
+    - (possibly verifies file contents against JSONSchema - TBD)
+* `promote`: Triggered manually in the Lakehouse.
+    - Archives PDB records in `updated_manifest.txt` and `removed_manifest.txt`
+    - Promotes staged new downloads to PDB Lakehouse destination
+    - Writes frictionless file descriptors for newly promoted PDB records
+
+### Note for local testing
+
+It is possible to test the end-to-end workflow with a local containerized CEPH test store.
+To start the container:
+```sh
+docker run -d \
+  --name ceph \
+  -p 9000:8080 \
+  -p 9001:8443 \
+  -e RGW_PORT=8080 \
+  -e RGW_ACCESS_KEY=test_access_key \
+  -e RGW_SECRET_KEY=test_access_secret \
+  ghcr.io/kbasetest/ceph-rgw-test-image:0.1.5
+```
+Then, set CEPH credentials as environment variables:
+
+```sh
+export AWS_ENDPOINT_URL=http://localhost:9000
+export AWS_ACCESS_KEY_ID=test_access_key
+export AWS_SECRET_ACCESS_KEY=test_access_secret
+```
+
+Finally, create the standard staging and destination buckets in the test store:
+
+```sh
+uv run python scripts/s3_local.py mb s3://cdm-lake
+uv run python scripts/s3_local.py mb s3://cts
+```
+
+### Package Build
+
+The `cdm-data-loaders` package must be present locally. If you haven't already build it, follow these steps:
+
+```sh
+cd cdm-data-loaders
+uv sync
+source .venv/bin/activate
+uv pip install -e .
+```
+
+## Manifest Generation
+
+Manifest generation is triggered by calling the `pdb_manifest` cli tool. At minimum, you must provide a path
+to the folder the manifests should be written to. If that folder doesn't exist, it will be created:
+
+```sh
+uv run pdb_manifest --output-path out
+```
+
+This will trigger the manifest generation and save the manifest files to `./out/`.
+
+### `pdb_manifest` CLI Tool options
+
+* `--help`: Show full usage (includes some options that are ignored by `pdb_manifest`).
+* `--output-path {path}`: **(Required)** Path to the local folder where manifest files are saved. Created automatically if it does not exist.
+* `--destination-bucket {str}`: Specify a non-standard S3 bucket for the current Lakehouse (or test store) records.
+* `--destination-prefix {str}`: Specify a non-standard S3 key prefix for the current Lakehouse (or test store) records. Must contain `raw_data/`.
+* `--snapshot {str}`: Specify a non-standard path (relative to the `destination-prefix`) for the current snapshot file.
+* `--bootstrap {date}`: Bootstrap a snapshot file using the current Lakehouse (or test store) state, assigning the specified ISO 8601 date as the last-modified date for all records (e.g. `2024-01-01`).
+* `--skip-diff True`: Disable reading of the snapshot file. All current records in the PDB holdings file will be included in the `transfer_manifest.txt`.
+* `--regex {str}` / `-r {str}`: Optionally provide a regex filter expression. Only PDB record ids that pass the filter will be included in manifest files.
+
+## Download
+
+_Coming Soon!_
+
+## Promote
+
+_Coming Soon!_

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,7 @@ all_the_bacteria = "cdm_data_loaders.pipelines.all_the_bacteria:cli"
 ncbi_ftp_promote = "cdm_data_loaders.pipelines.ncbi_ftp_promote:cli"
 ncbi_ftp_sync = "cdm_data_loaders.pipelines.ncbi_ftp_download:cli"
 ncbi_rest_api = "cdm_data_loaders.pipelines.ncbi_rest_api:cli"
+pdb_manifest = "cdm_data_loaders.pipelines.pdb_manifest:cli"
 uniprot = "cdm_data_loaders.pipelines.uniprot_kb:cli"
 uniref = "cdm_data_loaders.pipelines.uniref:cli"
 

--- a/src/cdm_data_loaders/parsers/pdb_holdings_file.py
+++ b/src/cdm_data_loaders/parsers/pdb_holdings_file.py
@@ -1,0 +1,45 @@
+"""
+PDB holdings file parser.
+
+Holdings json files apply one of two schemas:
+
+* ID-only: dict[str, dict[Any]] keyed on PDB IDs with values of empty dicts
+* ID/Date: dict[str, str] keyed on PDB IDs with ISO-8601 date string values, e.g., ``"2024-01-15"``
+
+PDB IDs in both schemas are in "extended format" with ``"pdb_"`` followed by 8 lowercase alpha numeric
+characters, e.g., ``"pdb_00001abc"``. Classic ID, which only contained 4 alphanumeric characters
+after the ``"pdb_"`` prefix are lowercased and zero-padded in extended format:
+
+``"PDB_1ABC"`` (classic) = ``"pdb_00001abc"`` (extended)
+"""
+
+import json
+from typing import Any
+
+from cdm_data_loaders.pdb.constants import HoldingsFile, HoldingsFileSchemas, PDBRecord
+
+
+def parse_holdings_file(holdings: HoldingsFile, data: bytes) -> dict[str, PDBRecord]:
+    """Parse a PDB holdings file and return data as a dict keyed on PDB ID.
+
+    :param holdings: holdings file type information
+    :param data: file data
+    :return: parsed PDB record info as a dict keyed on PDB ID
+    """
+    json_data = json.loads(data)
+    if not isinstance(json_data, dict):
+        msg = "Holdings file expected to contain a JSON dict"
+        raise TypeError(msg)
+    return _parse_pdb_record(holdings, json_data)
+
+
+def _parse_pdb_record(holdings: HoldingsFile, records: dict[str, Any]) -> dict[str, PDBRecord]:
+    """Parse a key-value pair from a holdings file entry into a PDBRecord."""
+    if holdings.schema == HoldingsFileSchemas.ID_DATE:
+        # extract data as a dict of id/updated-date pairs
+        return {key.lower(): PDBRecord(id=key.lower(), last_modified=val) for key, val in records.items()}
+    if holdings.schema == HoldingsFileSchemas.ID_ONLY:
+        # extract keys (ids) from data
+        return {key.lower(): PDBRecord(id=key.lower()) for key in records}
+    msg = f"Invalid holdings file schema: {holdings.schema}"
+    raise ValueError(msg)

--- a/src/cdm_data_loaders/pdb/constants.py
+++ b/src/cdm_data_loaders/pdb/constants.py
@@ -1,0 +1,79 @@
+"""Constants, enums, classes, and globals used in PDB piplines."""
+
+import re
+from dataclasses import dataclass
+from enum import StrEnum, auto
+from pathlib import Path, PurePosixPath
+
+DEFAULT_DESTINATION_BUCKET: PurePosixPath = PurePosixPath("cdm-lake")
+DEFAULT_DESTINATION_PREFIX: PurePosixPath = PurePosixPath("tenant-general-warehouse/refdata/datasets/pdb")
+DEFAULT_HOLDINGS_SNAPSHOT: PurePosixPath = PurePosixPath("current_holdings_snapshot.json.gz")
+
+HOLDINGS_BASE_URL = PurePosixPath("files-beta.rcsb.org/pub/wwpdb/pdb/holdings")
+
+
+class HoldingsFileTypes(StrEnum):
+    """Types of holdings files used by PDB."""
+
+    CURRENT = auto()
+    LAST_MODIFIED = auto()
+    REMOVED = auto()
+
+
+class HoldingsFileSchemas(StrEnum):
+    """Schema for extracted holdings file data."""
+
+    ID_ONLY = auto()
+    ID_DATE = auto()
+
+
+@dataclass(frozen=True)
+class HoldingsFile:
+    """Filename and schema for a holdings file."""
+
+    filename: Path
+    schema: HoldingsFileSchemas
+
+
+@dataclass(frozen=True)
+class ManifestData:
+    """Data needed to build the manifest files."""
+
+    new: list[str]
+    updated: list[str]
+    removed: list[str]
+    missing_dates: list[str]
+
+
+HOLDINGS_FILES: dict[HoldingsFileTypes, HoldingsFile] = {
+    HoldingsFileTypes.CURRENT: HoldingsFile(
+        filename=Path("current_file_holdings.json.gz"),
+        schema=HoldingsFileSchemas.ID_ONLY,
+    ),
+    HoldingsFileTypes.LAST_MODIFIED: HoldingsFile(
+        filename=Path("released_structures_last_modified_dates.json.gz"),
+        schema=HoldingsFileSchemas.ID_DATE,
+    ),
+    HoldingsFileTypes.REMOVED: HoldingsFile(
+        filename=Path("all_removed_entries.json.gz"),
+        schema=HoldingsFileSchemas.ID_ONLY,
+    ),
+}
+
+# Extended PDB ID: "pdb_" followed by exactly 8 lower-case alphanumeric characters.
+# Classic PDB IDs are [0-9A-Z]{4}; in extended format they are zero-padded to 8
+# chars and lowercased, giving [0-9a-z]{8}
+PDB_ID_RE = re.compile(r"^pdb_[0-9a-z]{8}$", re.IGNORECASE)
+PDB_ID_SEARCH_RE = re.compile(r"pdb_[0-9a-z]{8}", re.IGNORECASE)
+
+
+@dataclass
+class PDBRecord:
+    """A single PDB entry as represented in the holdings inventory.
+
+    :param id: extended PDB ID, e.g., ``"pdb_00001abc"``
+    :param last_modified: ISO-8601 date of last modification, e.g. ``"2024-01-15"``
+    """
+
+    id: str
+    last_modified: str = ""

--- a/src/cdm_data_loaders/pdb/constants.py
+++ b/src/cdm_data_loaders/pdb/constants.py
@@ -6,10 +6,10 @@ from enum import StrEnum, auto
 from pathlib import Path, PurePosixPath
 
 DEFAULT_DESTINATION_BUCKET: PurePosixPath = PurePosixPath("cdm-lake")
-DEFAULT_DESTINATION_PREFIX: PurePosixPath = PurePosixPath("tenant-general-warehouse/refdata/datasets/pdb")
+DEFAULT_DESTINATION_PREFIX: PurePosixPath = PurePosixPath("tenant-general-warehouse") / "refdata" / "datasets" / "pdb"
 DEFAULT_HOLDINGS_SNAPSHOT: PurePosixPath = PurePosixPath("current_holdings_snapshot.json.gz")
 
-HOLDINGS_BASE_URL = PurePosixPath("files-beta.rcsb.org/pub/wwpdb/pdb/holdings")
+HOLDINGS_BASE_URL = PurePosixPath("files-beta.rcsb.org") / "pub" / "wwpdb" / "pdb" / "holdings"
 
 
 class HoldingsFileTypes(StrEnum):

--- a/src/cdm_data_loaders/pipelines/pdb_manifest.py
+++ b/src/cdm_data_loaders/pipelines/pdb_manifest.py
@@ -19,14 +19,15 @@ import gzip
 import json
 import re
 import tempfile
-from datetime import UTC, datetime
+from datetime import UTC, date, datetime
 from logging import Logger, getLogger
 from pathlib import Path, PurePosixPath
 from typing import Any
 from urllib.request import urlopen
 
+from botocore.exceptions import ClientError
 from pydantic import AliasChoices, Field
-from pydantic_settings import SettingsConfigDict
+from pydantic_settings import CliImplicitFlag, SettingsConfigDict
 
 from cdm_data_loaders.core.settings import DEFAULT_SETTINGS_CONFIG_DICT, CtsSettings
 from cdm_data_loaders.pdb.constants import (
@@ -42,6 +43,7 @@ from cdm_data_loaders.pdb.constants import (
     ManifestData,
     PDBRecord,
 )
+from cdm_data_loaders.pipelines.core import run_cli
 from cdm_data_loaders.utils.s3 import get_s3_client
 
 logger: Logger = getLogger(__name__)
@@ -67,24 +69,24 @@ class PdbManfestSettings(CtsSettings):
         description="File path relative to destination bucket/prefix for current holdings snapshot file",
         validation_alias=AliasChoices("snapshot"),
     )
-    bootstrap_date: datetime | None = Field(
+    bootstrap_date: date | None = Field(
         default=None,
         description="If a date is provided, the current PDB Lakehouse records will be used to generate a synthetic snapshot file with last-modified date set to this value for each record",
         validation_alias=AliasChoices("bootstrap"),
     )
-    skip_diff: bool = Field(
+    skip_diff: CliImplicitFlag[bool] = Field(
         default=False,
         description="If set, prevents reading of snapshot data. All current PDB records will be include in manifest",
         validation_alias=AliasChoices("skip-diff", "skip_diff"),
     )
     output_path: Path = Field(
         description="Local path to save generated manfiest files to",
-        validation_alias=AliasChoices("o", "output-path", "output_path"),
+        validation_alias=AliasChoices("output-path", "output_path"),
     )
     regex_filter: str | None = Field(
         default=None,
         description="RegEx string to filter records. Only PDB ids that pass the RegEx search will be included in manifest files.",
-        validation_alias=AliasChoices("r", "regex"),
+        validation_alias=AliasChoices("regex", "r"),
     )
 
 
@@ -93,6 +95,7 @@ def run_manifest_generation(config: PdbManfestSettings) -> None:
 
     "param config: validated pipeline settings
     """
+    config.output_path.mkdir(parents=True, exist_ok=True)
     snapshot: dict[str, PDBRecord] = {}
     if config.bootstrap_date:
         snapshot = _generate_snapshot_from_s3_state(
@@ -130,6 +133,20 @@ def run_manifest_generation(config: PdbManfestSettings) -> None:
     )
     _save_manifest_files(manifest_data, config.output_path)
     _save_summary_file(manifest_data, config.regex_filter, config.output_path)
+
+
+def cli() -> None:
+    """CLI interface for the PDB manifest generation pipeline."""
+    run_cli(PdbManfestSettings, run_manifest_generation)
+
+
+if __name__ == "__main__":
+    cli()
+
+
+# ------------------------
+# Private helper functions
+# ------------------------
 
 
 def _download_holdings_files(
@@ -202,7 +219,7 @@ def _extract_id_from_s3_key(key: str) -> str | None:
 def _generate_snapshot_from_s3_state(
     bucket: PurePosixPath,
     key_prefix: PurePosixPath,
-    date: datetime,
+    date: date,
 ) -> dict[str, PDBRecord]:
     """Bootstraps a holdings snapshot file based on the current store state."""
     s3 = get_s3_client()
@@ -274,6 +291,12 @@ def _download_holdings_snapshot(
     try:
         s3.download_file(Bucket=str(bucket), Key=str(key), Filename=str(tmp_path))
         return _load_holdings_snapshot(tmp_path)
+    except ClientError:
+        msg = (
+            f"PDB Snapshot file s3://{bucket / key} not found. Rerun with --skip-diff to download all current "
+            "records, or --bootstrap to generate a snapshot file from the current S3 store state."
+        )
+        raise ValueError(msg) from None
     finally:
         Path(tmp_path).unlink()
 

--- a/src/cdm_data_loaders/pipelines/pdb_manifest.py
+++ b/src/cdm_data_loaders/pipelines/pdb_manifest.py
@@ -1,0 +1,311 @@
+"""Generate a transfer manifest based on current PDB holdings files.
+
+Project documentation: https://www.rcsb.org/
+
+Batch downloading via rsync from: "rsync-beta.rcsb.org:32382
+
+Steps:
+- Downloads the current PDB holdings files
+- (Optional) Loads the set of holdings files from the last transfer OR bootsraps a set of holdings files from the current S3 store state
+- Produces a set of transfer manifest files:
+    * ``transfer_manifest.txt`` - PDB IDs to download (new and updated)
+    * ``removed_manifest.txt``  - PDB IDs to archive
+    * ``updated_manifest.txt``  - PDB IDs being replaced (download new; archive old)
+    * ``missing_dates.txt``     - PDB IDs with missing last-modified dates in the current holdings files
+    * ``summary.json``          - manifest generation statistics
+"""
+
+import gzip
+import json
+import re
+import tempfile
+from datetime import UTC, datetime
+from logging import Logger, getLogger
+from pathlib import Path, PurePosixPath
+from typing import Any
+from urllib.request import urlopen
+
+from pydantic import AliasChoices, Field
+from pydantic_settings import SettingsConfigDict
+
+from cdm_data_loaders.core.settings import DEFAULT_SETTINGS_CONFIG_DICT, CtsSettings
+from cdm_data_loaders.pdb.constants import (
+    DEFAULT_DESTINATION_BUCKET,
+    DEFAULT_DESTINATION_PREFIX,
+    DEFAULT_HOLDINGS_SNAPSHOT,
+    HOLDINGS_BASE_URL,
+    HOLDINGS_FILES,
+    PDB_ID_SEARCH_RE,
+    HoldingsFile,
+    HoldingsFileSchemas,
+    HoldingsFileTypes,
+    ManifestData,
+    PDBRecord,
+)
+from cdm_data_loaders.utils.s3 import get_s3_client
+
+logger: Logger = getLogger(__name__)
+
+
+class PdbManfestSettings(CtsSettings):
+    """Configuration for running the PDB manifest-generation pipeline."""
+
+    model_config = SettingsConfigDict(**DEFAULT_SETTINGS_CONFIG_DICT, cli_prog_name="pdb_manifest")
+
+    destination_bucket: PurePosixPath = Field(
+        default=DEFAULT_DESTINATION_BUCKET,
+        description="Bucket holding current PDB records",
+        validation_alias=AliasChoices("destination-bucket", "destination_bucket"),
+    )
+    destination_prefix: PurePosixPath = Field(
+        default=DEFAULT_DESTINATION_PREFIX,
+        description="Path to folder in the destination bucket where PDB records exist. Must contain `raw_data/` folder",
+        validation_alias=AliasChoices("destination-prefix", "destination_prefix"),
+    )
+    holdings_snapshot_path: PurePosixPath = Field(
+        default=DEFAULT_HOLDINGS_SNAPSHOT,
+        description="File path relative to destination bucket/prefix for current holdings snapshot file",
+        validation_alias=AliasChoices("snapshot"),
+    )
+    bootstrap_date: datetime | None = Field(
+        default=None,
+        description="If a date is provided, the current PDB Lakehouse records will be used to generate a synthetic snapshot file with last-modified date set to this value for each record",
+        validation_alias=AliasChoices("bootstrap"),
+    )
+    skip_diff: bool = Field(
+        default=False,
+        description="If set, prevents reading of snapshot data. All current PDB records will be include in manifest",
+        validation_alias=AliasChoices("skip-diff", "skip_diff"),
+    )
+    output_path: Path = Field(
+        description="Local path to save generated manfiest files to",
+        validation_alias=AliasChoices("o", "output-path", "output_path"),
+    )
+    regex_filter: str | None = Field(
+        default=None,
+        description="RegEx string to filter records. Only PDB ids that pass the RegEx search will be included in manifest files.",
+        validation_alias=AliasChoices("r", "regex"),
+    )
+
+
+def run_manifest_generation(config: PdbManfestSettings) -> None:
+    """Main CTS entry point for PDB manifest generation.
+
+    "param config: validated pipeline settings
+    """
+    snapshot: dict[str, PDBRecord] = {}
+    if config.bootstrap_date:
+        snapshot = _generate_snapshot_from_s3_state(
+            config.destination_bucket,
+            config.destination_prefix,
+            config.bootstrap_date,
+        )
+    elif not config.skip_diff:
+        snapshot = _download_holdings_snapshot(
+            bucket=config.destination_bucket,
+            key=config.destination_prefix / config.holdings_snapshot_path,
+        )
+    raw_data = _download_holdings_files()
+    if config.regex_filter:
+        regex = re.compile(config.regex_filter)
+
+        def apply_regex_filter(data: dict[str, PDBRecord]) -> dict[str, PDBRecord]:
+            return {key: val for key, val in data.items() if regex.search(key)}
+
+        raw_data[HoldingsFileTypes.CURRENT] = apply_regex_filter(raw_data[HoldingsFileTypes.CURRENT])
+        raw_data[HoldingsFileTypes.LAST_MODIFIED] = apply_regex_filter(raw_data[HoldingsFileTypes.LAST_MODIFIED])
+        raw_data[HoldingsFileTypes.REMOVED] = apply_regex_filter(raw_data[HoldingsFileTypes.REMOVED])
+        snapshot = apply_regex_filter(snapshot)
+    manifest_data = _generate_manifest_data(
+        current=raw_data[HoldingsFileTypes.CURRENT],
+        removed=set(raw_data[HoldingsFileTypes.REMOVED].keys()),
+        previous=snapshot,
+        missing_dates=list(
+            raw_data[HoldingsFileTypes.CURRENT].keys() - raw_data[HoldingsFileTypes.LAST_MODIFIED].keys()
+        ),
+    )
+    _save_manifest_files(manifest_data, config.output_path)
+    _save_summary_file(manifest_data, config.regex_filter, config.output_path)
+
+
+def _download_holdings_files(
+    base_url: PurePosixPath = HOLDINGS_BASE_URL,
+) -> dict[HoldingsFileTypes, dict[str, PDBRecord]]:
+    """Download the set of holdings files.
+
+    Returns a dict keyed on filename with the JSON contents of each holdings file.
+    :param base_url: base URL for the folder containing the holdings files
+    :return: dict of holdings JSON objects
+    """
+    result: dict[HoldingsFileTypes, Any] = {}
+    for key, holdings in HOLDINGS_FILES.items():
+        url = f"https://{base_url / holdings.filename}"
+        msg = f"Downloading PDB holdings file: {url}"
+        logger.info(msg)
+        with urlopen(url) as response:  # noqa: S310
+            compressed = response.read()
+        data = json.loads(gzip.decompress(compressed))
+        if not isinstance(data, dict):
+            msg = "Holdings file expected to contain a JSON dict"
+            raise TypeError(msg)
+        result[key] = _parse_pdb_record(holdings, data)
+        msg = f"Downloaded {holdings.filename} ({len(compressed)} bytes compressed)"
+        logger.info(msg)
+    return result
+
+
+def _parse_pdb_record(holdings: HoldingsFile, records: dict[str, Any]) -> dict[str, PDBRecord]:
+    """Parse a key-value pair from a holdings file entry into a PDBRecord."""
+    if holdings.schema == HoldingsFileSchemas.ID_DATE:
+        # extract data as a dict of id/updated-date pairs
+        return {key.lower(): PDBRecord(id=key.lower(), last_modified=val) for key, val in records.items()}
+    if holdings.schema == HoldingsFileSchemas.ID_ONLY:
+        # extract keys (ids) from data
+        return {key.lower(): PDBRecord(id=key.lower()) for key in records}
+    msg = f"Invalid holdings file schema: {holdings.schema}"
+    raise ValueError(msg)
+
+
+def _generate_manifest_data(
+    current: dict[str, PDBRecord],
+    removed: set[str],
+    *,
+    previous: dict[str, PDBRecord] | None = None,
+    missing_dates: list[str] | None = None,
+) -> ManifestData:
+    """Generates a set of manifest data."""
+    previous = previous or {}
+    missing_dates = missing_dates or []
+    return ManifestData(
+        new=list(current.keys() - previous.keys()),
+        updated=[
+            key
+            for key, val in current.items()
+            if (prev_rec := previous.get(key)) is not None
+            and val.last_modified
+            and ((not prev_rec.last_modified) or val.last_modified > prev_rec.last_modified)
+        ],
+        removed=sorted((removed & previous.keys()) | (previous.keys() - current.keys())),
+        missing_dates=missing_dates,
+    )
+
+
+def _extract_id_from_s3_key(key: str) -> str | None:
+    m = PDB_ID_SEARCH_RE.search(key)
+    return m.group(0).lower() if m else None
+
+
+def _generate_snapshot_from_s3_state(
+    bucket: PurePosixPath,
+    key_prefix: PurePosixPath,
+    date: datetime,
+) -> dict[str, PDBRecord]:
+    """Bootstraps a holdings snapshot file based on the current store state."""
+    s3 = get_s3_client()
+    paginator = s3.get_paginator("list_objects_v2")
+    results: dict[str, PDBRecord] = {}
+
+    for page in paginator.paginate(Bucket=str(bucket), Prefix=str(key_prefix)):
+        for obj in page.get("Contents", []):
+            pdb_id = _extract_id_from_s3_key(obj["Key"])
+            if pdb_id and pdb_id not in results:
+                results[pdb_id] = PDBRecord(id=pdb_id, last_modified=date.isoformat())
+
+    msg = f"Scanned S3 store: found {len(results)} unique PDB records"
+    logger.info(msg)
+    return results
+
+
+# File I/O
+
+
+def _save_holdings_snapshot(
+    records: dict[str, PDBRecord],
+    output_path: Path,
+) -> None:
+    """Save a PDB holdings snapshot as a gzipped JSON file.
+
+    :param records: map of PDB ID to PDBRecord
+    :param output_path: path to write to (should end in ``.json.gz``)
+    """
+    payload = {
+        rec.id: {
+            "last_modified": rec.last_modified,
+        }
+        for rec in records.values()
+    }
+    data = json.dumps(payload).encode()
+    with gzip.open(output_path, "wb") as f:
+        f.write(data)
+    msg = f"Saved holdings snapshot ({len(records)} entries) to {output_path}"
+    logger.info(msg)
+
+
+def _load_holdings_snapshot(
+    path: Path,
+) -> dict[str, PDBRecord]:
+    """Loads holdings snapshot data from a local file."""
+    with gzip.open(path, "rb") as f:
+        payload: dict[str, Any] = json.loads(f.read())
+    records: dict[str, PDBRecord] = {
+        key: PDBRecord(
+            id=key,
+            last_modified=val.get("last_modified", ""),
+        )
+        for key, val in payload.items()
+    }
+    msg = f"Loaded PDB holdings snapshot: {len(records)} entries from {path}"
+    logger.info(msg)
+    return records
+
+
+def _download_holdings_snapshot(
+    bucket: PurePosixPath,
+    key: PurePosixPath,
+) -> dict[str, PDBRecord]:
+    """Download and parse a holdings snapshot file from S3."""
+    s3 = get_s3_client()
+    with tempfile.NamedTemporaryFile(suffix=".json.gz", delete=False) as tmp:
+        tmp_path = Path(tmp.name)
+    try:
+        s3.download_file(Bucket=str(bucket), Key=str(key), Filename=str(tmp_path))
+        return _load_holdings_snapshot(tmp_path)
+    finally:
+        Path(tmp_path).unlink()
+
+
+def _save_manifest_files(data: ManifestData, output_path: Path) -> None:
+    """Saves manifest data to files."""
+
+    def save_file(filename: str, ids: list[str]) -> None:
+        file = output_path / filename
+        with file.open("w") as f:
+            f.writelines(pdb_id + "\n" for pdb_id in ids)
+        msg = f"Wrote {len(ids)} entries to manifest: {filename}"
+        logger.info(msg)
+
+    save_file("transfer_manifest.txt", data.new + data.updated)
+    save_file("updated_manifest.txt", data.updated)
+    save_file("removed_manifest.txt", data.removed)
+    save_file("missing_dates.txt", data.missing_dates)
+
+
+def _save_summary_file(data: ManifestData, regex_filter: str | None, output_path: Path) -> None:
+    """Saves a summary of the manifest generation to a JSON file."""
+    summary: dict[str, Any] = {
+        "generated_at": datetime.now(UTC).isoformat(),
+        **({"regex_filter": regex_filter} if regex_filter is not None else {}),
+        "saved_to": str(output_path),
+        "new": len(data.new),
+        "updated": len(data.updated),
+        "removed": len(data.removed),
+        "missing_dates": len(data.missing_dates),
+    }
+    file = output_path / "summary.json"
+    with file.open("w") as f:
+        f.write(json.dumps(summary, indent=2))
+    msg = (
+        f"Manifest summary: {len(data.new)} new; {len(data.updated)} updated; "
+        f"{len(data.removed)} removed; {len(data.missing_dates)} missing dates"
+    )
+    logger.info(msg)

--- a/src/cdm_data_loaders/pipelines/pdb_manifest.py
+++ b/src/cdm_data_loaders/pipelines/pdb_manifest.py
@@ -116,8 +116,12 @@ def run_manifest_generation(config: PdbManfestSettings) -> None:
         raw_data[HoldingsFileTypes.LAST_MODIFIED] = apply_regex_filter(raw_data[HoldingsFileTypes.LAST_MODIFIED])
         raw_data[HoldingsFileTypes.REMOVED] = apply_regex_filter(raw_data[HoldingsFileTypes.REMOVED])
         snapshot = apply_regex_filter(snapshot)
+    current_with_dates = {
+        pdb_id: raw_data[HoldingsFileTypes.LAST_MODIFIED].get(pdb_id, rec)
+        for pdb_id, rec in raw_data[HoldingsFileTypes.CURRENT].items()
+    }
     manifest_data = _generate_manifest_data(
-        current=raw_data[HoldingsFileTypes.CURRENT],
+        current=current_with_dates,
         removed=set(raw_data[HoldingsFileTypes.REMOVED].keys()),
         previous=snapshot,
         missing_dates=list(

--- a/src/cdm_data_loaders/pipelines/pdb_manifest.py
+++ b/src/cdm_data_loaders/pipelines/pdb_manifest.py
@@ -30,6 +30,7 @@ from pydantic import AliasChoices, Field
 from pydantic_settings import CliImplicitFlag, SettingsConfigDict
 
 from cdm_data_loaders.core.settings import DEFAULT_SETTINGS_CONFIG_DICT, CtsSettings
+from cdm_data_loaders.parsers.pdb_holdings_file import parse_holdings_file
 from cdm_data_loaders.pdb.constants import (
     DEFAULT_DESTINATION_BUCKET,
     DEFAULT_DESTINATION_PREFIX,
@@ -37,8 +38,6 @@ from cdm_data_loaders.pdb.constants import (
     HOLDINGS_BASE_URL,
     HOLDINGS_FILES,
     PDB_ID_SEARCH_RE,
-    HoldingsFile,
-    HoldingsFileSchemas,
     HoldingsFileTypes,
     ManifestData,
     PDBRecord,
@@ -165,26 +164,10 @@ def _download_holdings_files(
         logger.info(msg)
         with urlopen(url) as response:  # noqa: S310
             compressed = response.read()
-        data = json.loads(gzip.decompress(compressed))
-        if not isinstance(data, dict):
-            msg = "Holdings file expected to contain a JSON dict"
-            raise TypeError(msg)
-        result[key] = _parse_pdb_record(holdings, data)
+        result[key] = parse_holdings_file(holdings, gzip.decompress(compressed))
         msg = f"Downloaded {holdings.filename} ({len(compressed)} bytes compressed)"
         logger.info(msg)
     return result
-
-
-def _parse_pdb_record(holdings: HoldingsFile, records: dict[str, Any]) -> dict[str, PDBRecord]:
-    """Parse a key-value pair from a holdings file entry into a PDBRecord."""
-    if holdings.schema == HoldingsFileSchemas.ID_DATE:
-        # extract data as a dict of id/updated-date pairs
-        return {key.lower(): PDBRecord(id=key.lower(), last_modified=val) for key, val in records.items()}
-    if holdings.schema == HoldingsFileSchemas.ID_ONLY:
-        # extract keys (ids) from data
-        return {key.lower(): PDBRecord(id=key.lower()) for key in records}
-    msg = f"Invalid holdings file schema: {holdings.schema}"
-    raise ValueError(msg)
 
 
 def _generate_manifest_data(

--- a/src/cdm_data_loaders/pipelines/pdb_manifest.py
+++ b/src/cdm_data_loaders/pipelines/pdb_manifest.py
@@ -2,11 +2,11 @@
 
 Project documentation: https://www.rcsb.org/
 
-Batch downloading via rsync from: "rsync-beta.rcsb.org:32382
+Batch downloading via rsync from: rsync-beta.rcsb.org:32382
 
 Steps:
 - Downloads the current PDB holdings files
-- (Optional) Loads the set of holdings files from the last transfer OR bootsraps a set of holdings files from the current S3 store state
+- (Optional) Loads the set of holdings files from the last transfer OR bootstraps a set of holdings files from the current S3 store state
 - Produces a set of transfer manifest files:
     * ``transfer_manifest.txt`` - PDB IDs to download (new and updated)
     * ``removed_manifest.txt``  - PDB IDs to archive

--- a/tests/integration/test_pdb_manifest_pipeline.py
+++ b/tests/integration/test_pdb_manifest_pipeline.py
@@ -19,6 +19,7 @@ import pytest
 
 import cdm_data_loaders.pipelines.pdb_manifest as pdb_manifest_mod
 from cdm_data_loaders.pdb.constants import (
+    DEFAULT_DESTINATION_PREFIX,
     HoldingsFileTypes,
     PDBRecord,
 )
@@ -32,7 +33,7 @@ from cdm_data_loaders.pipelines.pdb_manifest import (
 )
 
 # A prefix under which we seed fake PDB objects in CEPH
-_PDB_KEY_PREFIX = PurePosixPath("tenant-general-warehouse/refdata/datasets/pdb/raw_data")
+_PDB_KEY_PREFIX = DEFAULT_DESTINATION_PREFIX / "raw_data"
 
 # A handful of fake extended PDB IDs used across tests
 _FAKE_IDS = [
@@ -134,7 +135,7 @@ class TestSnapshotCeph:
             "pdb_00001abc": PDBRecord(id="pdb_00001abc", last_modified="2024-01-15"),
             "pdb_00001def": PDBRecord(id="pdb_00001def", last_modified="2023-06-30"),
         }
-        snapshot_key = PurePosixPath("snapshots/current_holdings_snapshot.json.gz")
+        snapshot_key = PurePosixPath("snapshots") / "current_holdings_snapshot.json.gz"
         local_file = tmp_path / "snapshot.json.gz"
 
         # Save locally then upload to CEPH
@@ -159,7 +160,7 @@ class TestSnapshotCeph:
         tmp_path: Path,
     ) -> None:
         """Tests round-trip saving/loading of empty snapshot to S3 store."""
-        snapshot_key = PurePosixPath("snapshots/empty_snapshot.json.gz")
+        snapshot_key = PurePosixPath("snapshots") / "empty_snapshot.json.gz"
         local_file = tmp_path / "empty.json.gz"
         _save_holdings_snapshot({}, local_file)
         pdb_ceph_client.upload_file(

--- a/tests/integration/test_pdb_manifest_pipeline.py
+++ b/tests/integration/test_pdb_manifest_pipeline.py
@@ -11,7 +11,7 @@ from collections.abc import Generator
 from datetime import date
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
-from typing import cast
+from typing import ClassVar, cast
 from unittest.mock import patch
 
 import botocore.client
@@ -413,3 +413,225 @@ class TestRunManifestGenerationE2E:
         assert self._read_manifest(tmp_path, "updated_manifest.txt") == []
         assert self._read_manifest(tmp_path, "removed_manifest.txt") == []
         assert sorted(self._read_manifest(tmp_path, "missing_dates.txt")) == sorted(expected_missing)
+
+
+# ---------------------------------------------------------------------------
+# Round-trip: generate snapshot from S3 state then run manifest generation
+# ---------------------------------------------------------------------------
+
+# Snapshot filename used by the round-trip tests (distinct from the other E2E tests).
+_ROUNDTRIP_SNAPSHOT_FILENAME = PurePosixPath("roundtrip_snapshot.json.gz")
+
+# IDs seeded into CEPH for the round-trip tests.
+_ROUNDTRIP_IDS: list[str] = ["pdb_00001abc", "pdb_00001def", "pdb_aaaaaaaa"]
+
+
+@pytest.mark.requires_ceph
+@pytest.mark.slow_test
+class TestSnapshotManifestRoundTripCeph:
+    """Generate a snapshot from the live S3 store state, then drive manifest generation.
+
+    These tests verify the full contract between ``_generate_snapshot_from_s3_state``,
+    ``_save_holdings_snapshot``, ``_download_holdings_snapshot``, and
+    ``run_manifest_generation``.  PDB HTTP calls are mocked; all S3 interactions
+    use the real CEPH test store via ``pdb_ceph_client``.
+    """
+
+    # A date well in the past so we can easily manufacture "newer" dates in holdings.
+    _BOOTSTRAP_DATE: ClassVar[date] = date(2020, 1, 1)
+    _NEWER_DATE: ClassVar[str] = "2024-06-15"
+
+    # ---------------------------------------------------------------------------
+    # Helpers
+    # ---------------------------------------------------------------------------
+
+    def _make_config(
+        self,
+        test_bucket: PurePosixPath,
+        output_path: Path,
+        **kwargs: object,
+    ) -> PdbManfestSettings:
+        defaults: dict = {
+            "bootstrap_date": None,
+            "skip_diff": False,
+            "regex_filter": None,
+            "destination_bucket": test_bucket,
+            "destination_prefix": _PDB_KEY_PREFIX,
+            "holdings_snapshot_path": _ROUNDTRIP_SNAPSHOT_FILENAME,
+            "output_path": output_path,
+        }
+        defaults.update(kwargs)
+        return cast("PdbManfestSettings", SimpleNamespace(**defaults))
+
+    def _build_and_upload_snapshot(
+        self,
+        s3: botocore.client.BaseClient,
+        bucket: PurePosixPath,
+        snap_date: date,
+        local_path: Path,
+    ) -> dict[str, PDBRecord]:
+        """Scan the CEPH store, save a snapshot locally, and upload it.
+
+        Returns the generated snapshot dict so callers can inspect its contents.
+        The snapshot is uploaded to the key read by ``_download_holdings_snapshot``
+        when using the config produced by ``_make_config``.
+        """
+        snapshot = _generate_snapshot_from_s3_state(
+            bucket=bucket,
+            key_prefix=_PDB_KEY_PREFIX,
+            date=snap_date,
+        )
+        _save_holdings_snapshot(snapshot, local_path)
+        s3.upload_file(
+            Filename=str(local_path),
+            Bucket=str(bucket),
+            Key=str(_PDB_KEY_PREFIX / _ROUNDTRIP_SNAPSHOT_FILENAME),
+        )
+        return snapshot
+
+    def _mock_holdings(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        current: dict[str, PDBRecord],
+        last_modified: dict[str, PDBRecord] | None = None,
+        removed: dict[str, PDBRecord] | None = None,
+    ) -> None:
+        monkeypatch.setattr(
+            pdb_manifest_mod,
+            "_download_holdings_files",
+            lambda: {
+                HoldingsFileTypes.CURRENT: dict(current),
+                HoldingsFileTypes.LAST_MODIFIED: dict(last_modified or {}),
+                HoldingsFileTypes.REMOVED: dict(removed or {}),
+            },
+        )
+
+    def _read_manifest(self, output_path: Path, filename: str) -> list[str]:
+        return (output_path / filename).read_text().splitlines()
+
+    # ---------------------------------------------------------------------------
+    # Tests
+    # ---------------------------------------------------------------------------
+
+    def test_no_changes_when_store_matches_holdings(
+        self,
+        pdb_ceph_client: botocore.client.BaseClient,
+        test_bucket: PurePosixPath,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """When the snapshot exactly matches the current holdings, all manifests are empty."""
+        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _ROUNDTRIP_IDS)
+        self._build_and_upload_snapshot(pdb_ceph_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap.json.gz")
+
+        # Holdings current = same IDs; last-modified dates match the bootstrap date.
+        current = {id_: PDBRecord(id=id_) for id_ in _ROUNDTRIP_IDS}
+        last_modified = {
+            id_: PDBRecord(id=id_, last_modified=self._BOOTSTRAP_DATE.isoformat()) for id_ in _ROUNDTRIP_IDS
+        }
+        self._mock_holdings(monkeypatch, current, last_modified)
+
+        run_manifest_generation(self._make_config(test_bucket, tmp_path / "out"))
+
+        assert self._read_manifest(tmp_path / "out", "transfer_manifest.txt") == []
+        assert self._read_manifest(tmp_path / "out", "updated_manifest.txt") == []
+        assert self._read_manifest(tmp_path / "out", "removed_manifest.txt") == []
+        assert self._read_manifest(tmp_path / "out", "missing_dates.txt") == []
+
+    def test_records_removed_from_store_reappear_in_transfer_manifest(
+        self,
+        pdb_ceph_client: botocore.client.BaseClient,
+        test_bucket: PurePosixPath,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """IDs dropped from the S3 store between runs re-emerge as new in transfer_manifest.
+
+        Workflow:
+        1. Seed all IDs; generate snapshot. expect no changes on first run.
+        2. Delete some IDs from the store; regenerate snapshot, expect deleted IDs
+           are absent from the new snapshot but still present in the mocked
+           holdings: they appear as *new* in ``transfer_manifest.txt``.
+        """
+        removed_ids = ["pdb_00001def", "pdb_aaaaaaaa"]
+        current = {id_: PDBRecord(id=id_) for id_ in _ROUNDTRIP_IDS}
+        last_modified = {
+            id_: PDBRecord(id=id_, last_modified=self._BOOTSTRAP_DATE.isoformat()) for id_ in _ROUNDTRIP_IDS
+        }
+        self._mock_holdings(monkeypatch, current, last_modified)
+
+        # First run: baseline:nothing should appear in any manifest
+        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _ROUNDTRIP_IDS)
+        self._build_and_upload_snapshot(pdb_ceph_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap1.json.gz")
+        run_manifest_generation(self._make_config(test_bucket, tmp_path / "run1"))
+        assert self._read_manifest(tmp_path / "run1", "transfer_manifest.txt") == []
+
+        # Remove some records from the store
+        for pdb_id in removed_ids:
+            key = str(_PDB_KEY_PREFIX / pdb_id / f"{pdb_id}_model.cif.gz")
+            pdb_ceph_client.delete_object(Bucket=str(test_bucket), Key=key)
+
+        # Second run: removed IDs are absent from new snapshot: should appear in transfer_manifest.txt
+        self._build_and_upload_snapshot(pdb_ceph_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap2.json.gz")
+        run_manifest_generation(self._make_config(test_bucket, tmp_path / "run2"))
+
+        transfer = sorted(self._read_manifest(tmp_path / "run2", "transfer_manifest.txt"))
+        assert transfer == sorted(removed_ids)
+        assert self._read_manifest(tmp_path / "run2", "updated_manifest.txt") == []
+        assert self._read_manifest(tmp_path / "run2", "removed_manifest.txt") == []
+
+    def test_holdings_newer_date_triggers_updated_manifest(
+        self,
+        pdb_ceph_client: botocore.client.BaseClient,
+        test_bucket: PurePosixPath,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """Records whose holdings last-modified date is newer than the snapshot appear in updated_manifest."""
+        ids = ["pdb_00001abc", "pdb_00001def"]
+        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, ids)
+        self._build_and_upload_snapshot(pdb_ceph_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap.json.gz")
+
+        # pdb_00001abc has a newer date in holdings: should appear in updated
+        # pdb_00001def has the same date as the snapshot: should not appear in updated
+        current = {id_: PDBRecord(id=id_) for id_ in ids}
+        last_modified = {
+            "pdb_00001abc": PDBRecord(id="pdb_00001abc", last_modified=self._NEWER_DATE),
+            "pdb_00001def": PDBRecord(id="pdb_00001def", last_modified=self._BOOTSTRAP_DATE.isoformat()),
+        }
+        self._mock_holdings(monkeypatch, current, last_modified)
+
+        run_manifest_generation(self._make_config(test_bucket, tmp_path / "out"))
+
+        assert self._read_manifest(tmp_path / "out", "updated_manifest.txt") == ["pdb_00001abc"]
+        transfer = self._read_manifest(tmp_path / "out", "transfer_manifest.txt")
+        assert "pdb_00001abc" in transfer
+        assert "pdb_00001def" not in transfer
+
+    def test_id_absent_from_holdings_appears_in_removed_manifest(
+        self,
+        pdb_ceph_client: botocore.client.BaseClient,
+        test_bucket: PurePosixPath,
+        tmp_path: Path,
+        monkeypatch: pytest.MonkeyPatch,
+    ) -> None:
+        """An ID present in the snapshot but absent from current holdings appears in removed_manifest."""
+        kept_in_holdings = ["pdb_00001abc", "pdb_00001def"]
+        dropped_from_holdings = ["pdb_aaaaaaaa"]
+
+        # Seed all IDs so the snapshot contains all three.
+        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _ROUNDTRIP_IDS)
+        self._build_and_upload_snapshot(pdb_ceph_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap.json.gz")
+
+        # Holdings no longer lists pdb_aaaaaaaa as current.
+        current = {id_: PDBRecord(id=id_) for id_ in kept_in_holdings}
+        last_modified = {
+            id_: PDBRecord(id=id_, last_modified=self._BOOTSTRAP_DATE.isoformat()) for id_ in kept_in_holdings
+        }
+        self._mock_holdings(monkeypatch, current, last_modified)
+
+        run_manifest_generation(self._make_config(test_bucket, tmp_path / "out"))
+
+        assert self._read_manifest(tmp_path / "out", "removed_manifest.txt") == dropped_from_holdings
+        assert self._read_manifest(tmp_path / "out", "transfer_manifest.txt") == []
+        assert self._read_manifest(tmp_path / "out", "updated_manifest.txt") == []

--- a/tests/integration/test_pdb_manifest_pipeline.py
+++ b/tests/integration/test_pdb_manifest_pipeline.py
@@ -10,6 +10,8 @@ a running CEPH test store and are marked ``requires_ceph`` + ``slow_test``.
 from collections.abc import Generator
 from datetime import UTC, datetime
 from pathlib import Path, PurePosixPath
+from types import SimpleNamespace
+from typing import cast
 from unittest.mock import patch
 
 import botocore.client
@@ -21,10 +23,12 @@ from cdm_data_loaders.pdb.constants import (
     PDBRecord,
 )
 from cdm_data_loaders.pipelines.pdb_manifest import (
+    PdbManfestSettings,
     _download_holdings_files,
     _download_holdings_snapshot,
     _generate_snapshot_from_s3_state,
     _save_holdings_snapshot,
+    run_manifest_generation,
 )
 
 # A prefix under which we seed fake PDB objects in CEPH
@@ -39,7 +43,7 @@ _FAKE_IDS = [
 
 
 # ---------------------------------------------------------------------------
-# Local fixture — patch pdb_manifest's get_s3_client to use CEPH client
+# Local fixture - patch pdb_manifest's get_s3_client to use CEPH client
 # ---------------------------------------------------------------------------
 
 
@@ -231,3 +235,180 @@ class TestGenerateSnapshotFromS3State:
         )
 
         assert list(result.keys()).count(pdb_id) == 1
+
+
+# ---------------------------------------------------------------------------
+# Full pipeline end-to-end tests
+# ---------------------------------------------------------------------------
+
+# Holdings data shared across E2E tests.
+# pdb_aaaaaaaa is intentionally absent from LAST_MODIFIED; should show up in missing_dates.
+_E2E_CURRENT: dict[str, PDBRecord] = {
+    "pdb_00001abc": PDBRecord(id="pdb_00001abc"),
+    "pdb_00001def": PDBRecord(id="pdb_00001def"),
+    "pdb_aaaaaaaa": PDBRecord(id="pdb_aaaaaaaa"),
+}
+_E2E_LAST_MODIFIED: dict[str, PDBRecord] = {
+    "pdb_00001abc": PDBRecord(id="pdb_00001abc", last_modified="2024-01-15"),
+    "pdb_00001def": PDBRecord(id="pdb_00001def", last_modified="2024-02-20"),
+}
+_E2E_REMOVED: dict[str, PDBRecord] = {}
+
+_SNAPSHOT_PREFIX = PurePosixPath("e2e-pdb-test")
+_SNAPSHOT_FILENAME = PurePosixPath("current_snapshot.json.gz")
+
+
+@pytest.mark.requires_ceph
+@pytest.mark.slow_test
+class TestRunManifestGenerationE2E:
+    """End-to-end tests for run_manifest_generation.
+
+    PDB HTTP downloads are mocked; S3 interactions use the real CEPH store.
+    """
+
+    @pytest.fixture(autouse=True)
+    def _mock_holdings_download(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Replace live PDB downloads with controlled in-memory data."""
+        mock_raw = {
+            HoldingsFileTypes.CURRENT: dict(_E2E_CURRENT),
+            HoldingsFileTypes.LAST_MODIFIED: dict(_E2E_LAST_MODIFIED),
+            HoldingsFileTypes.REMOVED: dict(_E2E_REMOVED),
+        }
+        monkeypatch.setattr(pdb_manifest_mod, "_download_holdings_files", lambda: mock_raw)
+
+    def _make_config(
+        self,
+        test_bucket: PurePosixPath,
+        tmp_path: Path,
+        **kwargs: object,
+    ) -> PdbManfestSettings:
+        defaults: dict = {
+            "bootstrap_date": None,
+            "skip_diff": False,
+            "regex_filter": None,
+            "destination_bucket": test_bucket,
+            "destination_prefix": _PDB_KEY_PREFIX,
+            "holdings_snapshot_path": _SNAPSHOT_FILENAME,
+            "output_path": tmp_path,
+        }
+        defaults.update(kwargs)
+        return cast("PdbManfestSettings", SimpleNamespace(**defaults))
+
+    def _read_manifest(self, tmp_path: Path, filename: str) -> list[str]:
+        return (tmp_path / filename).read_text().splitlines()
+
+    @pytest.mark.usefixtures("pdb_ceph_client")
+    def test_skip_diff_all_current_records_are_new(
+        self,
+        test_bucket: PurePosixPath,
+        tmp_path: Path,
+    ) -> None:
+        """With skip_diff=True, every current ID appears as new in the transfer manifest."""
+        config = self._make_config(test_bucket, tmp_path, skip_diff=True)
+        run_manifest_generation(config)
+
+        transfer = sorted(self._read_manifest(tmp_path, "transfer_manifest.txt"))
+        assert transfer == sorted(_E2E_CURRENT.keys())
+        assert self._read_manifest(tmp_path, "updated_manifest.txt") == []
+        assert self._read_manifest(tmp_path, "removed_manifest.txt") == []
+        assert self._read_manifest(tmp_path, "missing_dates.txt") == ["pdb_aaaaaaaa"]
+
+    def test_bootstrap_date_uses_s3_state_as_previous(
+        self,
+        pdb_ceph_client: botocore.client.BaseClient,
+        test_bucket: PurePosixPath,
+        tmp_path: Path,
+    ) -> None:
+        """With bootstrap_date, the S3 store determines the previous snapshot."""
+        # pdb_00001def: in S3, bootstrap date older than current: updated.
+        # pdb_00009999: in S3 but not in current holdings: removed.
+        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, ["pdb_00001def", "pdb_00009999"])
+        bootstrap_date = datetime(2020, 1, 1, tzinfo=UTC)
+
+        config = self._make_config(test_bucket, tmp_path, bootstrap_date=bootstrap_date)
+        run_manifest_generation(config)
+
+        # pdb_00001abc and pdb_aaaaaaaa are not in the store: new
+        transfer = self._read_manifest(tmp_path, "transfer_manifest.txt")
+        assert "pdb_00001abc" in transfer
+        assert "pdb_00001def" in transfer  # also in transfer (updated IDs included)
+        assert "pdb_aaaaaaaa" in transfer
+
+        assert self._read_manifest(tmp_path, "updated_manifest.txt") == ["pdb_00001def"]
+        assert self._read_manifest(tmp_path, "removed_manifest.txt") == ["pdb_00009999"]
+        assert self._read_manifest(tmp_path, "missing_dates.txt") == ["pdb_aaaaaaaa"]
+
+    def test_with_existing_snapshot_incremental_diff(
+        self,
+        pdb_ceph_client: botocore.client.BaseClient,
+        test_bucket: PurePosixPath,
+        tmp_path: Path,
+    ) -> None:
+        """An S3 snapshot drives incremental diffing; only changed records appear."""
+        # pdb_00001def: in snapshot with older date: updated.
+        # pdb_00009999: in snapshot but not in current holdings: removed.
+        previous = {
+            "pdb_00001def": PDBRecord(id="pdb_00001def", last_modified="2023-06-01"),
+            "pdb_00009999": PDBRecord(id="pdb_00009999", last_modified="2022-01-01"),
+        }
+        local_snapshot = tmp_path / "input_snapshot.json.gz"
+        _save_holdings_snapshot(previous, local_snapshot)
+        snapshot_key = _SNAPSHOT_PREFIX / _SNAPSHOT_FILENAME
+        pdb_ceph_client.upload_file(
+            Filename=str(local_snapshot),
+            Bucket=str(test_bucket),
+            Key=str(snapshot_key),
+        )
+
+        config = self._make_config(
+            test_bucket,
+            tmp_path,
+            destination_prefix=_SNAPSHOT_PREFIX,
+        )
+        run_manifest_generation(config)
+
+        # pdb_00001abc and pdb_aaaaaaaa were not in snapshot: new
+        transfer = self._read_manifest(tmp_path, "transfer_manifest.txt")
+        assert "pdb_00001abc" in transfer
+        assert "pdb_00001def" in transfer  # also in transfer (updated IDs included)
+        assert "pdb_aaaaaaaa" in transfer
+
+        assert self._read_manifest(tmp_path, "updated_manifest.txt") == ["pdb_00001def"]
+        assert self._read_manifest(tmp_path, "removed_manifest.txt") == ["pdb_00009999"]
+        assert self._read_manifest(tmp_path, "missing_dates.txt") == ["pdb_aaaaaaaa"]
+
+    @pytest.mark.usefixtures("pdb_ceph_client")
+    @pytest.mark.parametrize(
+        ("regex_filter", "expected_transfer", "expected_missing"),
+        [
+            pytest.param(
+                "pdb_00001",
+                ["pdb_00001abc", "pdb_00001def"],
+                [],
+                id="prefix-filter",
+            ),
+            pytest.param(
+                "pdb_aaa",
+                ["pdb_aaaaaaaa"],
+                ["pdb_aaaaaaaa"],
+                id="single-match-still-missing-date",
+            ),
+        ],
+    )
+    def test_regex_filter(
+        self,
+        test_bucket: PurePosixPath,
+        tmp_path: Path,
+        regex_filter: str,
+        expected_transfer: list[str],
+        expected_missing: list[str],
+    ) -> None:
+        """Regex filter restricts which IDs appear across all output manifest files."""
+        config = self._make_config(test_bucket, tmp_path, skip_diff=True, regex_filter=regex_filter)
+        run_manifest_generation(config)
+
+        transfer = sorted(self._read_manifest(tmp_path, "transfer_manifest.txt"))
+        assert transfer == sorted(expected_transfer)
+        assert self._read_manifest(tmp_path, "updated_manifest.txt") == []
+        assert self._read_manifest(tmp_path, "removed_manifest.txt") == []
+        assert sorted(self._read_manifest(tmp_path, "missing_dates.txt")) == sorted(expected_missing)

--- a/tests/integration/test_pdb_manifest_pipeline.py
+++ b/tests/integration/test_pdb_manifest_pipeline.py
@@ -8,7 +8,7 @@ a running CEPH test store and are marked ``requires_ceph`` + ``slow_test``.
 """
 
 from collections.abc import Generator
-from datetime import UTC, datetime
+from datetime import date
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 from typing import cast
@@ -188,7 +188,7 @@ class TestGenerateSnapshotFromS3State:
     ) -> None:
         """Tests bootstrapped snapshot includes in-store ids."""
         _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _FAKE_IDS)
-        bootstrap_date = datetime(2024, 1, 1, tzinfo=UTC)
+        bootstrap_date = date(2024, 1, 1)
 
         result = _generate_snapshot_from_s3_state(
             bucket=test_bucket,
@@ -205,7 +205,7 @@ class TestGenerateSnapshotFromS3State:
     ) -> None:
         """Ensures the provided snapshot date is properly set."""
         _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _FAKE_IDS)
-        bootstrap_date = datetime(2024, 1, 1, tzinfo=UTC)
+        bootstrap_date = date(2024, 1, 1)
 
         result = _generate_snapshot_from_s3_state(
             bucket=test_bucket,
@@ -231,7 +231,7 @@ class TestGenerateSnapshotFromS3State:
         result = _generate_snapshot_from_s3_state(
             bucket=test_bucket,
             key_prefix=_PDB_KEY_PREFIX,
-            date=datetime(2024, 6, 1, tzinfo=UTC),
+            date=date(2024, 6, 1),
         )
 
         assert list(result.keys()).count(pdb_id) == 1
@@ -323,7 +323,7 @@ class TestRunManifestGenerationE2E:
         # pdb_00001def: in S3, bootstrap date older than current: updated.
         # pdb_00009999: in S3 but not in current holdings: removed.
         _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, ["pdb_00001def", "pdb_00009999"])
-        bootstrap_date = datetime(2020, 1, 1, tzinfo=UTC)
+        bootstrap_date = date(2020, 1, 1)
 
         config = self._make_config(test_bucket, tmp_path, bootstrap_date=bootstrap_date)
         run_manifest_generation(config)

--- a/tests/integration/test_pdb_manifest_pipeline.py
+++ b/tests/integration/test_pdb_manifest_pipeline.py
@@ -1,0 +1,233 @@
+"""Integration tests for the PDB manifest-generating pipeline.
+
+Tests in ``TestDownloadHoldingsFilesLive`` hit the real RCSB PDB holdings
+service and are marked ``slow_test`` + ``external_request``.
+
+Tests in ``TestSnapshotCeph`` and ``TestGenerateSnapshotFromS3State`` require
+a running CEPH test store and are marked ``requires_ceph`` + ``slow_test``.
+"""
+
+from collections.abc import Generator
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from unittest.mock import patch
+
+import botocore.client
+import pytest
+
+import cdm_data_loaders.pipelines.pdb_manifest as pdb_manifest_mod
+from cdm_data_loaders.pdb.constants import (
+    HoldingsFileTypes,
+    PDBRecord,
+)
+from cdm_data_loaders.pipelines.pdb_manifest import (
+    _download_holdings_files,
+    _download_holdings_snapshot,
+    _generate_snapshot_from_s3_state,
+    _save_holdings_snapshot,
+)
+
+# A prefix under which we seed fake PDB objects in CEPH
+_PDB_KEY_PREFIX = PurePosixPath("tenant-general-warehouse/refdata/datasets/pdb/raw_data")
+
+# A handful of fake extended PDB IDs used across tests
+_FAKE_IDS = [
+    "pdb_00001abc",
+    "pdb_00001def",
+    "pdb_aaaaaaaa",
+]
+
+
+# ---------------------------------------------------------------------------
+# Local fixture — patch pdb_manifest's get_s3_client to use CEPH client
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+def pdb_ceph_client(
+    ceph_s3_client: botocore.client.BaseClient,
+) -> Generator[botocore.client.BaseClient]:
+    """Extend ceph_s3_client by also patching get_s3_client inside pdb_manifest."""
+    with patch.object(pdb_manifest_mod, "get_s3_client", return_value=ceph_s3_client):
+        yield ceph_s3_client
+
+
+def _seed_fake_pdb_objects(
+    s3: botocore.client.BaseClient,
+    bucket: PurePosixPath,
+    pdb_ids: list[str],
+    prefix: PurePosixPath = _PDB_KEY_PREFIX,
+) -> None:
+    """Upload a minimal placeholder object for each PDB ID into CEPH."""
+    for pdb_id in pdb_ids:
+        key = str(prefix / pdb_id / f"{pdb_id}_model.cif.gz")
+        s3.put_object(Bucket=str(bucket), Key=key, Body=b"placeholder")
+
+
+# ---------------------------------------------------------------------------
+# Live PDB service tests
+# ---------------------------------------------------------------------------
+
+type HoldingsFiles = dict[HoldingsFileTypes, dict[str, PDBRecord]]
+
+
+@pytest.fixture(scope="module")
+def holdings_files() -> HoldingsFiles:
+    """Download the holdings files."""
+    return _download_holdings_files()
+
+
+@pytest.mark.slow_test
+@pytest.mark.external_request
+class TestDownloadHoldingsFilesLive:
+    """Download real PDB holdings files from the RCSB server."""
+
+    def test_returns_all_three_holding_types(self, holdings_files: HoldingsFiles) -> None:
+        """Ensures all three holdings files are downloaded."""
+        assert HoldingsFileTypes.CURRENT in holdings_files
+        assert HoldingsFileTypes.LAST_MODIFIED in holdings_files
+        assert HoldingsFileTypes.REMOVED in holdings_files
+
+    def test_current_holdings_are_non_empty(self, holdings_files: HoldingsFiles) -> None:
+        """Ensures records exist is each holdings file."""
+        assert len(holdings_files[HoldingsFileTypes.CURRENT]) > 0
+        assert len(holdings_files[HoldingsFileTypes.LAST_MODIFIED]) > 0
+        assert len(holdings_files[HoldingsFileTypes.REMOVED]) > 0
+
+    def test_all_records_have_lowercase_ids(self, holdings_files: HoldingsFiles) -> None:
+        """Ensures PDB IDs are properly lower-cased."""
+        for file_type, records in holdings_files.items():
+            for pdb_id, rec in records.items():
+                assert pdb_id == pdb_id.lower(), f"{file_type}: key '{pdb_id}' is not lowercase"
+                assert rec.id == rec.id.lower(), f"{file_type}: record.id '{rec.id}' is not lowercase"
+
+    def test_last_modified_records_have_dates(self, holdings_files: HoldingsFiles) -> None:
+        """Ensure last-modified holdings file has dates included."""
+        dates = holdings_files[HoldingsFileTypes.LAST_MODIFIED]
+        assert len(dates) > 0
+        sample = next(iter(dates.values()))
+        assert sample.last_modified != ""
+
+
+# ---------------------------------------------------------------------------
+# CEPH snapshot round-trip tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_ceph
+@pytest.mark.slow_test
+class TestSnapshotCeph:
+    """Save a holdings snapshot to CEPH and retrieve it via _download_holdings_snapshot."""
+
+    def test_save_and_download_snapshot(
+        self,
+        pdb_ceph_client: botocore.client.BaseClient,
+        test_bucket: PurePosixPath,
+        tmp_path: Path,
+    ) -> None:
+        """Tests round-trip saving/loading of snapshot to S3 store."""
+        records = {
+            "pdb_00001abc": PDBRecord(id="pdb_00001abc", last_modified="2024-01-15"),
+            "pdb_00001def": PDBRecord(id="pdb_00001def", last_modified="2023-06-30"),
+        }
+        snapshot_key = PurePosixPath("snapshots/current_holdings_snapshot.json.gz")
+        local_file = tmp_path / "snapshot.json.gz"
+
+        # Save locally then upload to CEPH
+        _save_holdings_snapshot(records, local_file)
+        pdb_ceph_client.upload_file(
+            Filename=str(local_file),
+            Bucket=str(test_bucket),
+            Key=str(snapshot_key),
+        )
+
+        # Download and verify round-trip
+        downloaded = _download_holdings_snapshot(
+            bucket=test_bucket,
+            key=snapshot_key,
+        )
+        assert downloaded == records
+
+    def test_empty_snapshot_round_trip(
+        self,
+        pdb_ceph_client: botocore.client.BaseClient,
+        test_bucket: PurePosixPath,
+        tmp_path: Path,
+    ) -> None:
+        """Tests round-trip saving/loading of empty snapshot to S3 store."""
+        snapshot_key = PurePosixPath("snapshots/empty_snapshot.json.gz")
+        local_file = tmp_path / "empty.json.gz"
+        _save_holdings_snapshot({}, local_file)
+        pdb_ceph_client.upload_file(
+            Filename=str(local_file),
+            Bucket=str(test_bucket),
+            Key=str(snapshot_key),
+        )
+        downloaded = _download_holdings_snapshot(bucket=test_bucket, key=snapshot_key)
+        assert downloaded == {}
+
+
+# ---------------------------------------------------------------------------
+# CEPH snapshot-from-S3-state tests
+# ---------------------------------------------------------------------------
+
+
+@pytest.mark.requires_ceph
+@pytest.mark.slow_test
+class TestGenerateSnapshotFromS3State:
+    """Bootstrap a holdings snapshot by scanning objects in CEPH."""
+
+    def test_finds_all_seeded_ids(
+        self,
+        pdb_ceph_client: botocore.client.BaseClient,
+        test_bucket: PurePosixPath,
+    ) -> None:
+        """Tests bootstrapped snapshot includes in-store ids."""
+        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _FAKE_IDS)
+        bootstrap_date = datetime(2024, 1, 1, tzinfo=UTC)
+
+        result = _generate_snapshot_from_s3_state(
+            bucket=test_bucket,
+            key_prefix=_PDB_KEY_PREFIX,
+            date=bootstrap_date,
+        )
+
+        assert set(result.keys()) == set(_FAKE_IDS)
+
+    def test_all_records_use_bootstrap_date(
+        self,
+        pdb_ceph_client: botocore.client.BaseClient,
+        test_bucket: PurePosixPath,
+    ) -> None:
+        """Ensures the provided snapshot date is properly set."""
+        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _FAKE_IDS)
+        bootstrap_date = datetime(2024, 1, 1, tzinfo=UTC)
+
+        result = _generate_snapshot_from_s3_state(
+            bucket=test_bucket,
+            key_prefix=_PDB_KEY_PREFIX,
+            date=bootstrap_date,
+        )
+
+        expected_date = bootstrap_date.isoformat()
+        for pdb_id, rec in result.items():
+            assert rec.last_modified == expected_date, f"{pdb_id} has unexpected date {rec.last_modified}"
+
+    def test_deduplicates_multiple_objects_per_id(
+        self,
+        pdb_ceph_client: botocore.client.BaseClient,
+        test_bucket: PurePosixPath,
+    ) -> None:
+        """Multiple S3 objects sharing the same PDB ID produce a single snapshot entry."""
+        pdb_id = "pdb_00001abc"
+        for suffix in ("model.cif.gz", "data.cif.gz", "info.json"):
+            key = str(_PDB_KEY_PREFIX / pdb_id / f"{pdb_id}_{suffix}")
+            pdb_ceph_client.put_object(Bucket=str(test_bucket), Key=key, Body=b"x")
+
+        result = _generate_snapshot_from_s3_state(
+            bucket=test_bucket,
+            key_prefix=_PDB_KEY_PREFIX,
+            date=datetime(2024, 6, 1, tzinfo=UTC),
+        )
+
+        assert list(result.keys()).count(pdb_id) == 1

--- a/tests/parsers/test_pdb_holdings_file.py
+++ b/tests/parsers/test_pdb_holdings_file.py
@@ -1,0 +1,124 @@
+"""
+Tests of the PDB holdings file parser.
+"""
+
+import json
+from pathlib import Path
+
+import pytest
+
+from cdm_data_loaders.parsers.pdb_holdings_file import _parse_pdb_record, parse_holdings_file
+from cdm_data_loaders.pdb.constants import HoldingsFile, HoldingsFileSchemas, PDBRecord
+
+_HOLDINGS_ID_ONLY = HoldingsFile(filename=Path("dummy.json.gz"), schema=HoldingsFileSchemas.ID_ONLY)
+_HOLDINGS_ID_DATE = HoldingsFile(filename=Path("dummy.json.gz"), schema=HoldingsFileSchemas.ID_DATE)
+_HOLDINGS_BAD = HoldingsFile(filename=Path("dummy.json.gz"), schema="bad_schema")  # type: ignore[arg-type]
+
+# ---------------------------------------------------------------------------
+# parse_holdings_file
+# ---------------------------------------------------------------------------
+
+
+class TestParseHoldingsFile:
+    """Tests for parse_holdings_file()."""
+
+    @pytest.mark.parametrize(
+        ("file", "data", "expected_records"),
+        [
+            pytest.param(
+                HoldingsFile(
+                    filename=Path("current_file_holdings.json.gz"),
+                    schema=HoldingsFileSchemas.ID_ONLY,
+                ),
+                json.dumps({"PDB_00001ABC": {}, "PDB_00001DEF": {}}).encode("utf-8"),
+                {"pdb_00001abc": "", "pdb_00001def": ""},
+            ),
+            pytest.param(
+                HoldingsFile(
+                    filename=Path("released_structures_last_modified_dates.json.gz"),
+                    schema=HoldingsFileSchemas.ID_DATE,
+                ),
+                json.dumps({"PDB_00001ABC": "2024-01-15"}).encode("utf-8"),
+                {"pdb_00001abc": "2024-01-15"},
+            ),
+            pytest.param(
+                HoldingsFile(
+                    filename=Path("all_removed_entries.json.gz"),
+                    schema=HoldingsFileSchemas.ID_ONLY,
+                ),
+                json.dumps({"PDB_00009999": {}}).encode("utf-8"),
+                {"pdb_00009999": ""},
+            ),
+        ],
+    )
+    def test_downloads_and_parses_all_three_files(
+        self, file: HoldingsFile, data: bytes, expected_records: dict[str, str | None]
+    ) -> None:
+        """Tests that each holdings file type is properly loaded."""
+        result = parse_holdings_file(file, data)
+        for key, date in expected_records.items():
+            assert key in result
+            assert result[key].id == key
+            assert result[key].last_modified == date
+
+    def test_non_dict_response_raises_type_error(self) -> None:
+        """Ensures invalid JSON data raises TypeError."""
+        file = HoldingsFile(
+            filename=Path("invalid.json.gz"),
+            schema=HoldingsFileSchemas.ID_ONLY,
+        )
+        data = json.dumps(["not", "a", "dict"]).encode("utf-8")
+        with pytest.raises(TypeError, match="expected to contain a JSON dict"):
+            parse_holdings_file(file, data)
+
+
+# ---------------------------------------------------------------------------
+# _parse_pdb_record
+# ---------------------------------------------------------------------------
+
+
+class TestParsePdbRecord:
+    """Parameterized cases for testing _parse_pdb_record()."""
+
+    @pytest.mark.parametrize(
+        ("holdings", "raw", "expected"),
+        [
+            pytest.param(
+                _HOLDINGS_ID_ONLY,
+                {"PDB_00001ABC": {"status": "RELEASED"}, "PDB_00001DEF": {}},
+                {"pdb_00001abc": PDBRecord(id="pdb_00001abc"), "pdb_00001def": PDBRecord(id="pdb_00001def")},
+                id="id-only-extracts-keys",
+            ),
+            pytest.param(
+                _HOLDINGS_ID_ONLY,
+                {"PDB_AAAAAAAA": {}},
+                {"pdb_aaaaaaaa": PDBRecord(id="pdb_aaaaaaaa")},
+                id="id-only-normalizes-case",
+            ),
+            pytest.param(_HOLDINGS_ID_ONLY, {}, {}, id="id-only-empty"),
+            pytest.param(
+                _HOLDINGS_ID_DATE,
+                {"PDB_00001ABC": "2024-01-15", "PDB_00001DEF": "2024-02-20"},
+                {
+                    "pdb_00001abc": PDBRecord(id="pdb_00001abc", last_modified="2024-01-15"),
+                    "pdb_00001def": PDBRecord(id="pdb_00001def", last_modified="2024-02-20"),
+                },
+                id="id-date-extracts-key-and-date",
+            ),
+            pytest.param(
+                _HOLDINGS_ID_DATE,
+                {"PDB_AAAAAAAA": "2024-03-01"},
+                {"pdb_aaaaaaaa": PDBRecord(id="pdb_aaaaaaaa", last_modified="2024-03-01")},
+                id="id-date-normalizes-case",
+            ),
+            pytest.param(_HOLDINGS_ID_DATE, {}, {}, id="id-date-empty"),
+        ],
+    )
+    def test_parse_pdb_record(self, holdings: HoldingsFile, raw: dict, expected: dict) -> None:
+        """Tests parsed output is as expected."""
+        assert _parse_pdb_record(holdings, raw) == expected
+
+    def test_invalid_schema_raises_value_error(self) -> None:
+        """Ensures ValueError is raised when an invalid schema is specified."""
+        with pytest.raises(ValueError, match="Invalid holdings file schema"):
+            _parse_pdb_record(_HOLDINGS_BAD, {"PDB_00001ABC": {}})

--- a/tests/pipelines/test_pdb_manifest.py
+++ b/tests/pipelines/test_pdb_manifest.py
@@ -2,11 +2,15 @@
 
 import gzip
 import json
-from pathlib import Path
+from datetime import UTC, datetime
+from pathlib import Path, PurePosixPath
+from types import SimpleNamespace
+from typing import ClassVar, cast
 from unittest.mock import MagicMock, patch
 
 import pytest
 
+import cdm_data_loaders.pipelines.pdb_manifest as pdb_manifest_mod
 from cdm_data_loaders.pdb.constants import (
     HoldingsFile,
     HoldingsFileSchemas,
@@ -15,6 +19,7 @@ from cdm_data_loaders.pdb.constants import (
     PDBRecord,
 )
 from cdm_data_loaders.pipelines.pdb_manifest import (
+    PdbManfestSettings,
     _download_holdings_files,
     _extract_id_from_s3_key,
     _generate_manifest_data,
@@ -23,6 +28,7 @@ from cdm_data_loaders.pipelines.pdb_manifest import (
     _save_holdings_snapshot,
     _save_manifest_files,
     _save_summary_file,
+    run_manifest_generation,
 )
 
 # ---------------------------------------------------------------------------
@@ -459,3 +465,138 @@ class TestSaveSummaryFile:
             assert key not in summary
         assert "generated_at" in summary
         assert isinstance(summary["saved_to"], str)
+
+
+# ---------------------------------------------------------------------------
+# run_manifest_generation
+# ---------------------------------------------------------------------------
+
+
+class TestRunManifestGeneration:
+    """Unit tests for the run_manifest_generation orchestration.
+
+    All HTTP and S3 calls are mocked so no external services are required.
+    """
+
+    # Controlled holdings data: pdb_aaaaaaaa is intentionally absent from
+    # LAST_MODIFIED to exercise the missing-dates path.
+    _CURRENT: ClassVar[dict[str, PDBRecord]] = {
+        "pdb_00001abc": PDBRecord(id="pdb_00001abc"),
+        "pdb_00001def": PDBRecord(id="pdb_00001def"),
+        "pdb_aaaaaaaa": PDBRecord(id="pdb_aaaaaaaa"),
+    }
+    _LAST_MODIFIED: ClassVar[dict[str, PDBRecord]] = {
+        "pdb_00001abc": PDBRecord(id="pdb_00001abc", last_modified="2024-01-15"),
+        "pdb_00001def": PDBRecord(id="pdb_00001def", last_modified="2024-02-20"),
+    }
+    _REMOVED: ClassVar[dict[str, PDBRecord]] = {}
+
+    @pytest.fixture(autouse=True)
+    def _patch_holdings_download(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        """Replace HTTP downloads with controlled in-memory data."""
+        mock_raw = {
+            HoldingsFileTypes.CURRENT: dict(self._CURRENT),
+            HoldingsFileTypes.LAST_MODIFIED: dict(self._LAST_MODIFIED),
+            HoldingsFileTypes.REMOVED: dict(self._REMOVED),
+        }
+        monkeypatch.setattr(pdb_manifest_mod, "_download_holdings_files", lambda: mock_raw)
+
+    def _make_config(self, tmp_path: Path, **kwargs: object) -> PdbManfestSettings:
+        defaults: dict = {
+            "bootstrap_date": None,
+            "skip_diff": False,
+            "regex_filter": None,
+            "destination_bucket": PurePosixPath("test-bucket"),
+            "destination_prefix": PurePosixPath("test/prefix"),
+            "holdings_snapshot_path": PurePosixPath("snapshot.json.gz"),
+            "output_path": tmp_path,
+        }
+        defaults.update(kwargs)
+        return cast("PdbManfestSettings", SimpleNamespace(**defaults))
+
+    def _read_manifest(self, tmp_path: Path, filename: str) -> list[str]:
+        return (tmp_path / filename).read_text().splitlines()
+
+    def test_skip_diff_all_records_are_new(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """With skip_diff=True no snapshot is loaded and every current ID is new."""
+        mock_dl = MagicMock()
+        monkeypatch.setattr(pdb_manifest_mod, "_download_holdings_snapshot", mock_dl)
+
+        run_manifest_generation(self._make_config(tmp_path, skip_diff=True))
+
+        mock_dl.assert_not_called()
+        transfer = self._read_manifest(tmp_path, "transfer_manifest.txt")
+        assert sorted(transfer) == sorted(self._CURRENT.keys())
+        assert self._read_manifest(tmp_path, "updated_manifest.txt") == []
+        assert self._read_manifest(tmp_path, "removed_manifest.txt") == []
+
+    def test_bootstrap_date_calls_generate_snapshot(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """With bootstrap_date set, _generate_snapshot_from_s3_state is invoked."""
+        mock_gen = MagicMock(return_value={})
+        monkeypatch.setattr(pdb_manifest_mod, "_generate_snapshot_from_s3_state", mock_gen)
+
+        bootstrap_date = datetime(2020, 1, 1, tzinfo=UTC)
+        run_manifest_generation(self._make_config(tmp_path, bootstrap_date=bootstrap_date))
+
+        mock_gen.assert_called_once_with(
+            PurePosixPath("test-bucket"),
+            PurePosixPath("test/prefix"),
+            bootstrap_date,
+        )
+
+    def test_normal_mode_downloads_snapshot(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """Without skip_diff or bootstrap_date, _download_holdings_snapshot is invoked."""
+        mock_dl = MagicMock(return_value={})
+        monkeypatch.setattr(pdb_manifest_mod, "_download_holdings_snapshot", mock_dl)
+
+        run_manifest_generation(self._make_config(tmp_path))
+
+        mock_dl.assert_called_once_with(
+            bucket=PurePosixPath("test-bucket"),
+            key=PurePosixPath("test/prefix/snapshot.json.gz"),
+        )
+
+    @pytest.mark.parametrize(
+        ("regex_filter", "expected_ids"),
+        [
+            pytest.param("pdb_00001", ["pdb_00001abc", "pdb_00001def"], id="prefix-match"),
+            pytest.param("pdb_aaa", ["pdb_aaaaaaaa"], id="single-match"),
+            pytest.param("pdb_xxxxx", [], id="no-match"),
+        ],
+    )
+    def test_regex_filter_limits_transfer_manifest(
+        self,
+        monkeypatch: pytest.MonkeyPatch,
+        tmp_path: Path,
+        regex_filter: str,
+        expected_ids: list[str],
+    ) -> None:
+        """Regex filter restricts which IDs appear in the output manifests."""
+        monkeypatch.setattr(pdb_manifest_mod, "_download_holdings_snapshot", MagicMock(return_value={}))
+
+        run_manifest_generation(self._make_config(tmp_path, skip_diff=True, regex_filter=regex_filter))
+
+        transfer = self._read_manifest(tmp_path, "transfer_manifest.txt")
+        assert sorted(transfer) == sorted(expected_ids)
+
+    def test_missing_dates_computed_as_current_minus_last_modified(
+        self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path
+    ) -> None:
+        """IDs present in CURRENT but absent from LAST_MODIFIED appear in missing_dates.txt."""
+        monkeypatch.setattr(pdb_manifest_mod, "_download_holdings_snapshot", MagicMock(return_value={}))
+
+        run_manifest_generation(self._make_config(tmp_path, skip_diff=True))
+
+        missing = self._read_manifest(tmp_path, "missing_dates.txt")
+        assert missing == ["pdb_aaaaaaaa"]
+
+    def test_summary_file_written(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """A summary.json is written with correct counts."""
+        monkeypatch.setattr(pdb_manifest_mod, "_download_holdings_snapshot", MagicMock(return_value={}))
+
+        run_manifest_generation(self._make_config(tmp_path, skip_diff=True))
+
+        summary = json.loads((tmp_path / "summary.json").read_text())
+        total = summary["new"] + summary["updated"]
+        assert total == len(self._CURRENT)
+        assert summary["missing_dates"] == 1

--- a/tests/pipelines/test_pdb_manifest.py
+++ b/tests/pipelines/test_pdb_manifest.py
@@ -540,7 +540,7 @@ class TestRunManifestGeneration:
 
         mock_gen.assert_called_once_with(
             PurePosixPath("test-bucket"),
-            PurePosixPath("test/prefix"),
+            PurePosixPath("test") / "prefix",
             bootstrap_date,
         )
 
@@ -553,7 +553,7 @@ class TestRunManifestGeneration:
 
         mock_dl.assert_called_once_with(
             bucket=PurePosixPath("test-bucket"),
-            key=PurePosixPath("test/prefix/snapshot.json.gz"),
+            key=PurePosixPath("test") / "prefix" / "snapshot.json.gz",
         )
 
     @pytest.mark.parametrize(

--- a/tests/pipelines/test_pdb_manifest.py
+++ b/tests/pipelines/test_pdb_manifest.py
@@ -29,7 +29,6 @@ from cdm_data_loaders.pipelines.pdb_manifest import (
     _generate_manifest_data,
     _generate_snapshot_from_s3_state,
     _load_holdings_snapshot,
-    _parse_pdb_record,
     _save_holdings_snapshot,
     _save_manifest_files,
     _save_summary_file,
@@ -64,58 +63,6 @@ def _make_gzipped_response(data: dict | list[str]) -> MagicMock:
     resp.__enter__ = lambda s: s
     resp.__exit__ = MagicMock(return_value=False)
     return resp
-
-
-# ---------------------------------------------------------------------------
-# _parse_pdb_record
-# ---------------------------------------------------------------------------
-
-
-class TestParsePdbRecord:
-    """Parameterized cases for testing _parse_pdb_record()."""
-
-    @pytest.mark.parametrize(
-        ("holdings", "raw", "expected"),
-        [
-            pytest.param(
-                _HOLDINGS_ID_ONLY,
-                {"PDB_00001ABC": {"status": "RELEASED"}, "PDB_00001DEF": {}},
-                {"pdb_00001abc": PDBRecord(id="pdb_00001abc"), "pdb_00001def": PDBRecord(id="pdb_00001def")},
-                id="id-only-extracts-keys",
-            ),
-            pytest.param(
-                _HOLDINGS_ID_ONLY,
-                {"PDB_AAAAAAAA": {}},
-                {"pdb_aaaaaaaa": PDBRecord(id="pdb_aaaaaaaa")},
-                id="id-only-normalizes-case",
-            ),
-            pytest.param(_HOLDINGS_ID_ONLY, {}, {}, id="id-only-empty"),
-            pytest.param(
-                _HOLDINGS_ID_DATE,
-                {"PDB_00001ABC": "2024-01-15", "PDB_00001DEF": "2024-02-20"},
-                {
-                    "pdb_00001abc": PDBRecord(id="pdb_00001abc", last_modified="2024-01-15"),
-                    "pdb_00001def": PDBRecord(id="pdb_00001def", last_modified="2024-02-20"),
-                },
-                id="id-date-extracts-key-and-date",
-            ),
-            pytest.param(
-                _HOLDINGS_ID_DATE,
-                {"PDB_AAAAAAAA": "2024-03-01"},
-                {"pdb_aaaaaaaa": PDBRecord(id="pdb_aaaaaaaa", last_modified="2024-03-01")},
-                id="id-date-normalizes-case",
-            ),
-            pytest.param(_HOLDINGS_ID_DATE, {}, {}, id="id-date-empty"),
-        ],
-    )
-    def test_parse_pdb_record(self, holdings: HoldingsFile, raw: dict, expected: dict) -> None:
-        """Tests parsed output is as expected."""
-        assert _parse_pdb_record(holdings, raw) == expected
-
-    def test_invalid_schema_raises_value_error(self) -> None:
-        """Ensures ValueError is raised when an invalid schema is specified."""
-        with pytest.raises(ValueError, match="Invalid holdings file schema"):
-            _parse_pdb_record(_HOLDINGS_BAD, {"PDB_00001ABC": {}})
 
 
 # ---------------------------------------------------------------------------
@@ -577,17 +524,6 @@ class TestDownloadHoldingsFiles:
         assert "pdb_00001def" in result[HoldingsFileTypes.CURRENT]
         assert result[HoldingsFileTypes.LAST_MODIFIED]["pdb_00001abc"].last_modified == "2024-01-15"
         assert "pdb_00009999" in result[HoldingsFileTypes.REMOVED]
-
-    def test_non_dict_response_raises_type_error(self) -> None:
-        """Ensures invalid JSON data raises TypeError."""
-        with (
-            patch(
-                "cdm_data_loaders.pipelines.pdb_manifest.urlopen",
-                return_value=_make_gzipped_response(["not", "a", "dict"]),
-            ),
-            pytest.raises(TypeError, match="expected to contain a JSON dict"),
-        ):
-            _download_holdings_files()
 
 
 # ---------------------------------------------------------------------------

--- a/tests/pipelines/test_pdb_manifest.py
+++ b/tests/pipelines/test_pdb_manifest.py
@@ -2,7 +2,7 @@
 
 import gzip
 import json
-from datetime import UTC, datetime
+from datetime import date
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 from typing import ClassVar, cast
@@ -535,7 +535,7 @@ class TestRunManifestGeneration:
         mock_gen = MagicMock(return_value={})
         monkeypatch.setattr(pdb_manifest_mod, "_generate_snapshot_from_s3_state", mock_gen)
 
-        bootstrap_date = datetime(2020, 1, 1, tzinfo=UTC)
+        bootstrap_date = date(2020, 1, 1)
         run_manifest_generation(self._make_config(tmp_path, bootstrap_date=bootstrap_date))
 
         mock_gen.assert_called_once_with(
@@ -600,3 +600,15 @@ class TestRunManifestGeneration:
         total = summary["new"] + summary["updated"]
         assert total == len(self._CURRENT)
         assert summary["missing_dates"] == 1
+
+    def test_output_directory_created_when_missing(self, monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+        """run_manifest_generation creates output_path and its parents when they don't exist."""
+        monkeypatch.setattr(pdb_manifest_mod, "_download_holdings_snapshot", MagicMock(return_value={}))
+
+        output_path = tmp_path / "nested" / "output"
+        assert not output_path.exists()
+
+        run_manifest_generation(self._make_config(tmp_path, skip_diff=True, output_path=output_path))
+
+        assert output_path.is_dir()
+        assert (output_path / "transfer_manifest.txt").exists()

--- a/tests/pipelines/test_pdb_manifest.py
+++ b/tests/pipelines/test_pdb_manifest.py
@@ -15,8 +15,6 @@ from botocore.exceptions import ClientError
 
 import cdm_data_loaders.pipelines.pdb_manifest as pdb_manifest_mod
 from cdm_data_loaders.pdb.constants import (
-    HoldingsFile,
-    HoldingsFileSchemas,
     HoldingsFileTypes,
     ManifestData,
     PDBRecord,
@@ -38,10 +36,6 @@ from cdm_data_loaders.pipelines.pdb_manifest import (
 # ---------------------------------------------------------------------------
 # Shared test data
 # ---------------------------------------------------------------------------
-
-_HOLDINGS_ID_ONLY = HoldingsFile(filename=Path("dummy.json.gz"), schema=HoldingsFileSchemas.ID_ONLY)
-_HOLDINGS_ID_DATE = HoldingsFile(filename=Path("dummy.json.gz"), schema=HoldingsFileSchemas.ID_DATE)
-_HOLDINGS_BAD = HoldingsFile(filename=Path("dummy.json.gz"), schema="bad_schema")  # type: ignore[arg-type]
 
 _ID_A = "pdb_00001abc"
 _ID_B = "pdb_00001def"

--- a/tests/pipelines/test_pdb_manifest.py
+++ b/tests/pipelines/test_pdb_manifest.py
@@ -1,0 +1,461 @@
+"""Unit tests for the PDB manifest-generating pipeline."""
+
+import gzip
+import json
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from cdm_data_loaders.pdb.constants import (
+    HoldingsFile,
+    HoldingsFileSchemas,
+    HoldingsFileTypes,
+    ManifestData,
+    PDBRecord,
+)
+from cdm_data_loaders.pipelines.pdb_manifest import (
+    _download_holdings_files,
+    _extract_id_from_s3_key,
+    _generate_manifest_data,
+    _load_holdings_snapshot,
+    _parse_pdb_record,
+    _save_holdings_snapshot,
+    _save_manifest_files,
+    _save_summary_file,
+)
+
+# ---------------------------------------------------------------------------
+# Shared test data
+# ---------------------------------------------------------------------------
+
+_HOLDINGS_ID_ONLY = HoldingsFile(filename=Path("dummy.json.gz"), schema=HoldingsFileSchemas.ID_ONLY)
+_HOLDINGS_ID_DATE = HoldingsFile(filename=Path("dummy.json.gz"), schema=HoldingsFileSchemas.ID_DATE)
+_HOLDINGS_BAD = HoldingsFile(filename=Path("dummy.json.gz"), schema="bad_schema")  # type: ignore[arg-type]
+
+_ID_A = "pdb_00001abc"
+_ID_B = "pdb_00001def"
+_ID_C = "pdb_aaaaaaaa"
+_ID_D = "pdb_03942abd"
+
+_DATE_OLD = "2023-01-01"
+_DATE_NEW = "2024-06-15"
+
+_MANIFEST_ONE_OF_EACH = ManifestData(new=[_ID_A], updated=[_ID_B], removed=[_ID_C], missing_dates=[_ID_D])
+_MANIFEST_THREE_NEW = ManifestData(new=[_ID_A, _ID_B, _ID_C], updated=[], removed=[], missing_dates=[])
+
+
+def _make_gzipped_response(data: dict | list[str]) -> MagicMock:
+    """Return a mock context-manager response yielding gzipped JSON bytes."""
+    compressed = gzip.compress(json.dumps(data).encode())
+    resp = MagicMock()
+    resp.read.return_value = compressed
+    resp.__enter__ = lambda s: s
+    resp.__exit__ = MagicMock(return_value=False)
+    return resp
+
+
+# ---------------------------------------------------------------------------
+# _parse_pdb_record
+# ---------------------------------------------------------------------------
+
+
+class TestParsePdbRecord:
+    """Parameterized cases for testing _parse_pdb_record()."""
+
+    @pytest.mark.parametrize(
+        ("holdings", "raw", "expected"),
+        [
+            pytest.param(
+                _HOLDINGS_ID_ONLY,
+                {"PDB_00001ABC": {"status": "RELEASED"}, "PDB_00001DEF": {}},
+                {"pdb_00001abc": PDBRecord(id="pdb_00001abc"), "pdb_00001def": PDBRecord(id="pdb_00001def")},
+                id="id-only-extracts-keys",
+            ),
+            pytest.param(
+                _HOLDINGS_ID_ONLY,
+                {"PDB_AAAAAAAA": {}},
+                {"pdb_aaaaaaaa": PDBRecord(id="pdb_aaaaaaaa")},
+                id="id-only-normalizes-case",
+            ),
+            pytest.param(_HOLDINGS_ID_ONLY, {}, {}, id="id-only-empty"),
+            pytest.param(
+                _HOLDINGS_ID_DATE,
+                {"PDB_00001ABC": "2024-01-15", "PDB_00001DEF": "2024-02-20"},
+                {
+                    "pdb_00001abc": PDBRecord(id="pdb_00001abc", last_modified="2024-01-15"),
+                    "pdb_00001def": PDBRecord(id="pdb_00001def", last_modified="2024-02-20"),
+                },
+                id="id-date-extracts-key-and-date",
+            ),
+            pytest.param(
+                _HOLDINGS_ID_DATE,
+                {"PDB_AAAAAAAA": "2024-03-01"},
+                {"pdb_aaaaaaaa": PDBRecord(id="pdb_aaaaaaaa", last_modified="2024-03-01")},
+                id="id-date-normalizes-case",
+            ),
+            pytest.param(_HOLDINGS_ID_DATE, {}, {}, id="id-date-empty"),
+        ],
+    )
+    def test_parse_pdb_record(self, holdings: HoldingsFile, raw: dict, expected: dict) -> None:
+        """Tests parsed output is as expected."""
+        assert _parse_pdb_record(holdings, raw) == expected
+
+    def test_invalid_schema_raises_value_error(self) -> None:
+        """Ensures ValueError is raised when an invalid schema is specified."""
+        with pytest.raises(ValueError, match="Invalid holdings file schema"):
+            _parse_pdb_record(_HOLDINGS_BAD, {"PDB_00001ABC": {}})
+
+
+# ---------------------------------------------------------------------------
+# _generate_manifest_data
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateManifestData:
+    """Test for _generate_manifest_data()."""
+
+    @pytest.mark.parametrize(
+        ("current", "previous", "expected_new"),
+        [
+            pytest.param(
+                {
+                    _ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_NEW),
+                    _ID_B: PDBRecord(id=_ID_B, last_modified=_DATE_NEW),
+                },
+                {},
+                [_ID_A, _ID_B],
+                id="all-new-no-previous",
+            ),
+            pytest.param(
+                {_ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_NEW)},
+                {_ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_OLD)},
+                [],
+                id="already-in-previous",
+            ),
+        ],
+    )
+    def test_new_field(
+        self,
+        current: dict[str, PDBRecord],
+        previous: dict[str, PDBRecord],
+        expected_new: list[str],
+    ) -> None:
+        """Tests new records are properly determined."""
+        result = _generate_manifest_data(current, removed=set(), previous=previous)
+        assert sorted(result.new) == sorted(expected_new)
+
+    @pytest.mark.parametrize(
+        ("current", "previous", "expect_in_updated"),
+        [
+            pytest.param(
+                {_ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_NEW)},
+                {_ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_OLD)},
+                True,
+                id="newer-date",
+            ),
+            pytest.param(
+                {_ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_NEW)},
+                {_ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_NEW)},
+                False,
+                id="same-date",
+            ),
+            pytest.param(
+                {_ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_OLD)},
+                {_ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_NEW)},
+                False,
+                id="older-date",
+            ),
+            pytest.param(
+                {_ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_NEW)},
+                {_ID_A: PDBRecord(id=_ID_A, last_modified="")},
+                True,
+                id="prev-no-date",
+            ),
+            pytest.param(
+                {_ID_A: PDBRecord(id=_ID_A, last_modified="")},
+                {_ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_OLD)},
+                False,
+                id="current-no-date",
+            ),
+        ],
+    )
+    def test_updated_field(
+        self,
+        current: dict[str, PDBRecord],
+        previous: dict[str, PDBRecord],
+        expect_in_updated: bool,
+    ) -> None:
+        """Ensures various combinations of specified and unspecified dates are handled."""
+        result = _generate_manifest_data(current, removed=set(), previous=previous)
+        assert (_ID_A in result.updated) is expect_in_updated
+
+    @pytest.mark.parametrize(
+        ("current", "removed_set", "previous", "expected_removed"),
+        [
+            pytest.param(
+                {_ID_A: PDBRecord(id=_ID_A)},
+                set(),
+                {_ID_A: PDBRecord(id=_ID_A), _ID_B: PDBRecord(id=_ID_B)},
+                [_ID_B],
+                id="vanished-from-current",
+            ),
+            pytest.param(
+                {_ID_A: PDBRecord(id=_ID_A)},
+                {_ID_B},
+                {_ID_A: PDBRecord(id=_ID_A), _ID_B: PDBRecord(id=_ID_B)},
+                [_ID_B],
+                id="explicit-removed-in-previous",
+            ),
+            pytest.param(
+                {_ID_A: PDBRecord(id=_ID_A)},
+                {_ID_C},
+                {_ID_A: PDBRecord(id=_ID_A)},
+                [],
+                id="explicit-removed-not-in-previous",
+            ),
+            pytest.param(
+                {},
+                set(),
+                {_ID_B: PDBRecord(id=_ID_B), _ID_A: PDBRecord(id=_ID_A)},
+                sorted([_ID_A, _ID_B]),
+                id="all-removed-sorted",
+            ),
+        ],
+    )
+    def test_removed_field(
+        self,
+        current: dict[str, PDBRecord],
+        removed_set: set[str],
+        previous: dict[str, PDBRecord],
+        expected_removed: list[str],
+    ) -> None:
+        """Ensures removed records are correctly determined based on holdings files and previous state."""
+        result = _generate_manifest_data(current, removed=removed_set, previous=previous)
+        assert result.removed == expected_removed
+
+    def test_missing_dates_propagated(self) -> None:
+        """Ensures missing dates are properly set."""
+        result = _generate_manifest_data({}, removed=set(), missing_dates=[_ID_A, _ID_B])
+        assert result.missing_dates == [_ID_A, _ID_B]
+
+    def test_new_and_updated_are_disjoint(self) -> None:
+        """An entry cannot be both new and updated."""
+        current = {
+            _ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_NEW),  # new (not in previous)
+            _ID_B: PDBRecord(id=_ID_B, last_modified=_DATE_NEW),  # updated (in previous, newer date)
+        }
+        previous = {_ID_B: PDBRecord(id=_ID_B, last_modified=_DATE_OLD)}
+        result = _generate_manifest_data(current, removed=set(), previous=previous)
+        assert set(result.new) & set(result.updated) == set()
+
+
+# ---------------------------------------------------------------------------
+# _extract_id_from_s3_key
+# ---------------------------------------------------------------------------
+
+
+class TestExtractIdFromS3Key:
+    """Tests for _extract_id_from_s3_key()."""
+
+    @pytest.mark.parametrize(
+        ("key", "expected"),
+        [
+            pytest.param(
+                "tenant-general-warehouse/pdb/raw_data/pdb_00001abc/file.cif.gz",
+                "pdb_00001abc",
+                id="nested-path",
+            ),
+            pytest.param("some/unrelated/path.txt", None, id="no-match"),
+            pytest.param("data/PDB_00001ABC/file.cif", "pdb_00001abc", id="uppercase-normalized"),
+            pytest.param(
+                "pdb_00001abc/subdir/pdb_00001def/file",
+                "pdb_00001abc",
+                id="first-match-returned",
+            ),
+        ],
+    )
+    def test_extract_id(self, key: str, expected: str | None) -> None:
+        """Ensures ids are properly extracted when present."""
+        assert _extract_id_from_s3_key(key) == expected
+
+
+# ---------------------------------------------------------------------------
+# _save_holdings_snapshot / _load_holdings_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestHoldingsSnapshotRoundTrip:
+    """Tests for IO of snapshop data."""
+
+    @pytest.mark.parametrize(
+        "records",
+        [
+            pytest.param(
+                {
+                    _ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_NEW),
+                    _ID_B: PDBRecord(id=_ID_B, last_modified=_DATE_OLD),
+                },
+                id="two-records",
+            ),
+            pytest.param({}, id="empty"),
+        ],
+    )
+    def test_round_trip(self, tmp_path: Path, records: dict[str, PDBRecord]) -> None:
+        """Tests save/load of snapshot data."""
+        path = tmp_path / "snapshot.json.gz"
+        _save_holdings_snapshot(records, path)
+        assert _load_holdings_snapshot(path) == records
+
+    def test_missing_last_modified_defaults_to_empty_string(self, tmp_path: Path) -> None:
+        """Snapshot entries with no last_modified field are loaded with empty string."""
+        payload = {_ID_A: PDBRecord(id=_ID_A)}  # no "last_modified" key
+        path = tmp_path / "partial.json.gz"
+        _save_holdings_snapshot(payload, path)
+        assert _load_holdings_snapshot(path)[_ID_A].last_modified == ""
+
+
+# ---------------------------------------------------------------------------
+# _download_holdings_files
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadHoldingsFiles:
+    """Tests for _download_holdings_files()."""
+
+    def test_downloads_and_parses_all_three_files(self) -> None:
+        """Tests that each holdings file type is properly loaded."""
+        raw_current = {"PDB_00001ABC": {}, "PDB_00001DEF": {}}
+        raw_dates = {"PDB_00001ABC": "2024-01-15"}
+        raw_removed = {"PDB_00009999": {}}
+
+        responses = [
+            _make_gzipped_response(raw_current),
+            _make_gzipped_response(raw_dates),
+            _make_gzipped_response(raw_removed),
+        ]
+
+        with patch("cdm_data_loaders.pipelines.pdb_manifest.urlopen", side_effect=responses):
+            result = _download_holdings_files()
+
+        assert HoldingsFileTypes.CURRENT in result
+        assert HoldingsFileTypes.LAST_MODIFIED in result
+        assert HoldingsFileTypes.REMOVED in result
+        assert "pdb_00001abc" in result[HoldingsFileTypes.CURRENT]
+        assert "pdb_00001def" in result[HoldingsFileTypes.CURRENT]
+        assert result[HoldingsFileTypes.LAST_MODIFIED]["pdb_00001abc"].last_modified == "2024-01-15"
+        assert "pdb_00009999" in result[HoldingsFileTypes.REMOVED]
+
+    def test_non_dict_response_raises_type_error(self) -> None:
+        """Ensures invalid JSON data raises TypeError."""
+        with (
+            patch(
+                "cdm_data_loaders.pipelines.pdb_manifest.urlopen",
+                return_value=_make_gzipped_response(["not", "a", "dict"]),
+            ),
+            pytest.raises(TypeError, match="expected to contain a JSON dict"),
+        ):
+            _download_holdings_files()
+
+
+# ---------------------------------------------------------------------------
+# _save_manifest_files
+# ---------------------------------------------------------------------------
+
+
+class TestSaveManifestFiles:
+    """Tests for _save_manifest_files()."""
+
+    @pytest.mark.parametrize(
+        ("data", "filename", "expected_lines"),
+        [
+            pytest.param(
+                _MANIFEST_ONE_OF_EACH,
+                "transfer_manifest.txt",
+                [_ID_A, _ID_B],
+                id="transfer-contains-new-and-updated",
+            ),
+            pytest.param(
+                _MANIFEST_ONE_OF_EACH,
+                "updated_manifest.txt",
+                [_ID_B],
+                id="updated-contains-only-updated",
+            ),
+            pytest.param(
+                _MANIFEST_ONE_OF_EACH,
+                "removed_manifest.txt",
+                [_ID_C],
+                id="removed-contains-only-removed",
+            ),
+            pytest.param(
+                _MANIFEST_ONE_OF_EACH,
+                "missing_dates.txt",
+                [_ID_D],
+                id="missing-dates-empty",
+            ),
+            pytest.param(
+                _MANIFEST_THREE_NEW,
+                "transfer_manifest.txt",
+                [_ID_A, _ID_B, _ID_C],
+                id="each-id-on-its-own-line",
+            ),
+        ],
+    )
+    def test_file_contents(self, tmp_path: Path, data: ManifestData, filename: str, expected_lines: list[str]) -> None:
+        """Ensures manifest file contents are correct."""
+        _save_manifest_files(data, tmp_path)
+        lines = (tmp_path / filename).read_text().splitlines()
+        assert sorted(lines) == sorted(expected_lines)
+
+
+# ---------------------------------------------------------------------------
+# _save_summary_file
+# ---------------------------------------------------------------------------
+
+
+class TestSaveSummaryFile:
+    """Tests for _save_summary_file()."""
+
+    @pytest.mark.parametrize(
+        ("data", "regex_filter", "expected_values", "absent_keys"),
+        [
+            pytest.param(
+                ManifestData(new=[_ID_A, _ID_B], updated=[_ID_C], removed=[], missing_dates=[_ID_A]),
+                None,
+                {"new": 2, "updated": 1, "removed": 0, "missing_dates": 1},
+                ["regex_filter"],
+                id="counts-correct-no-filter",
+            ),
+            pytest.param(
+                ManifestData(new=[], updated=[], removed=[], missing_dates=[]),
+                "pdb_0000",
+                {"regex_filter": "pdb_0000"},
+                [],
+                id="regex-filter-included",
+            ),
+            pytest.param(
+                ManifestData(new=[], updated=[], removed=[], missing_dates=[]),
+                None,
+                {},
+                ["regex_filter"],
+                id="regex-filter-omitted",
+            ),
+        ],
+    )
+    def test_summary_file(
+        self,
+        tmp_path: Path,
+        data: ManifestData,
+        regex_filter: str | None,
+        expected_values: dict,
+        absent_keys: list[str],
+    ) -> None:
+        """Ensure metrics are output in summary file."""
+        _save_summary_file(data, regex_filter, tmp_path)
+        summary = json.loads((tmp_path / "summary.json").read_text())
+        for key, val in expected_values.items():
+            assert summary[key] == val
+        for key in absent_keys:
+            assert key not in summary
+        assert "generated_at" in summary
+        assert isinstance(summary["saved_to"], str)

--- a/tests/pipelines/test_pdb_manifest.py
+++ b/tests/pipelines/test_pdb_manifest.py
@@ -2,13 +2,16 @@
 
 import gzip
 import json
+import tempfile
+from collections.abc import Callable
 from datetime import date
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
-from typing import ClassVar, cast
-from unittest.mock import MagicMock, patch
+from typing import IO, ClassVar, cast
+from unittest.mock import ANY, MagicMock, patch
 
 import pytest
+from botocore.exceptions import ClientError
 
 import cdm_data_loaders.pipelines.pdb_manifest as pdb_manifest_mod
 from cdm_data_loaders.pdb.constants import (
@@ -21,8 +24,10 @@ from cdm_data_loaders.pdb.constants import (
 from cdm_data_loaders.pipelines.pdb_manifest import (
     PdbManfestSettings,
     _download_holdings_files,
+    _download_holdings_snapshot,
     _extract_id_from_s3_key,
     _generate_manifest_data,
+    _generate_snapshot_from_s3_state,
     _load_holdings_snapshot,
     _parse_pdb_record,
     _save_holdings_snapshot,
@@ -319,6 +324,227 @@ class TestHoldingsSnapshotRoundTrip:
         path = tmp_path / "partial.json.gz"
         _save_holdings_snapshot(payload, path)
         assert _load_holdings_snapshot(path)[_ID_A].last_modified == ""
+
+
+# ---------------------------------------------------------------------------
+# _generate_snapshot_from_s3_state
+# ---------------------------------------------------------------------------
+
+
+class TestGenerateSnapshotFromS3StateUnit:
+    """Unit tests for _generate_snapshot_from_s3_state() with a mocked S3 client."""
+
+    def _build_mock_s3(self, pages: list[list[str]]) -> MagicMock:
+        """Return a mock S3 client whose paginator yields one page per list of key strings."""
+        mock_s3 = MagicMock()
+        paginator = MagicMock()
+        mock_s3.get_paginator.return_value = paginator
+        page_dicts = [{"Contents": [{"Key": k} for k in keys]} if keys else {} for keys in pages]
+        paginator.paginate.return_value = page_dicts
+        return mock_s3
+
+    def test_empty_store_returns_empty_dict(self) -> None:
+        """Empty S3 store produces an empty snapshot."""
+        mock_s3 = self._build_mock_s3([[]])
+        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+            result = _generate_snapshot_from_s3_state(
+                PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
+            )
+        assert result == {}
+
+    def test_returns_record_for_each_valid_key(self) -> None:
+        """Objects with extractable PDB IDs produce one record per ID."""
+        keys = [
+            "prefix/pdb_00001abc/pdb_00001abc_model.cif.gz",
+            "prefix/pdb_00001def/pdb_00001def_data.cif.gz",
+        ]
+        mock_s3 = self._build_mock_s3([keys])
+        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+            result = _generate_snapshot_from_s3_state(
+                PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
+            )
+        assert set(result.keys()) == {"pdb_00001abc", "pdb_00001def"}
+
+    def test_sets_provided_date_on_all_records(self) -> None:
+        """The bootstrap date is written to every record's last_modified field."""
+        keys = [
+            "prefix/pdb_00001abc/model.cif.gz",
+            "prefix/pdb_00001def/model.cif.gz",
+        ]
+        mock_s3 = self._build_mock_s3([keys])
+        bootstrap = date(2023, 6, 15)
+        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+            result = _generate_snapshot_from_s3_state(PurePosixPath("bucket"), PurePosixPath("prefix"), bootstrap)
+        for rec in result.values():
+            assert rec.last_modified == bootstrap.isoformat()
+
+    def test_deduplicates_multiple_objects_per_pdb_id(self) -> None:
+        """Multiple S3 objects sharing a PDB ID produce exactly one snapshot entry."""
+        pdb_id = "pdb_00001abc"
+        keys = [
+            f"prefix/{pdb_id}/{pdb_id}_model.cif.gz",
+            f"prefix/{pdb_id}/{pdb_id}_data.cif.gz",
+            f"prefix/{pdb_id}/{pdb_id}_info.json",
+        ]
+        mock_s3 = self._build_mock_s3([keys])
+        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+            result = _generate_snapshot_from_s3_state(
+                PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
+            )
+        assert len(result) == 1
+        assert pdb_id in result
+
+    def test_skips_keys_without_valid_pdb_id(self) -> None:
+        """Keys that contain no recognisable PDB ID are silently ignored."""
+        keys = [
+            "some/unrelated/path.txt",
+            "prefix/logs/error.log",
+            "prefix/pdb_00001abc/model.cif.gz",  # the only valid one
+        ]
+        mock_s3 = self._build_mock_s3([keys])
+        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+            result = _generate_snapshot_from_s3_state(
+                PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
+            )
+        assert set(result.keys()) == {"pdb_00001abc"}
+
+    def test_aggregates_records_across_multiple_pages(self) -> None:
+        """Records distributed across paginator pages are all collected."""
+        mock_s3 = self._build_mock_s3(
+            [
+                ["prefix/pdb_00001abc/model.cif.gz"],
+                ["prefix/pdb_00001def/model.cif.gz"],
+                ["prefix/pdb_aaaaaaaa/model.cif.gz"],
+            ]
+        )
+        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+            result = _generate_snapshot_from_s3_state(
+                PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
+            )
+        assert set(result.keys()) == {"pdb_00001abc", "pdb_00001def", "pdb_aaaaaaaa"}
+
+    def test_paginator_called_with_correct_bucket_and_prefix(self) -> None:
+        """list_objects_v2 paginator receives the exact bucket name and prefix."""
+        mock_s3 = self._build_mock_s3([[]])
+        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+            _generate_snapshot_from_s3_state(PurePosixPath("my-bucket"), PurePosixPath("a/b/c"), date(2024, 1, 1))
+        mock_s3.get_paginator.assert_called_once_with("list_objects_v2")
+        mock_s3.get_paginator.return_value.paginate.assert_called_once_with(Bucket="my-bucket", Prefix="a/b/c")
+
+    def test_page_with_no_contents_key_is_handled_gracefully(self) -> None:
+        """A paginator page with no 'Contents' key doesn't raise and contributes no records."""
+        mock_s3 = self._build_mock_s3(
+            [
+                [],  # renders as {} (no Contents key)
+                ["prefix/pdb_00001abc/model.cif.gz"],
+            ]
+        )
+        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+            result = _generate_snapshot_from_s3_state(
+                PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
+            )
+        assert set(result.keys()) == {"pdb_00001abc"}
+
+
+# ---------------------------------------------------------------------------
+# _download_holdings_snapshot
+# ---------------------------------------------------------------------------
+
+
+class TestDownloadHoldingsSnapshotUnit:
+    """Unit tests for _download_holdings_snapshot() with a mocked S3 client."""
+
+    _RECORDS: ClassVar[dict[str, PDBRecord]] = {
+        _ID_A: PDBRecord(id=_ID_A, last_modified=_DATE_NEW),
+        _ID_B: PDBRecord(id=_ID_B, last_modified=_DATE_OLD),
+    }
+
+    def _writing_side_effect(self, records: dict[str, PDBRecord]) -> Callable[..., None]:
+        """Return a download_file side_effect that writes a valid snapshot to Filename."""
+
+        def _effect(**kwargs: str) -> None:
+            _save_holdings_snapshot(records, Path(kwargs["Filename"]))
+
+        return _effect
+
+    def test_returns_parsed_snapshot_on_success(self) -> None:
+        """A successful download returns the correctly deserialised snapshot dict."""
+        mock_s3 = MagicMock()
+        mock_s3.download_file.side_effect = self._writing_side_effect(self._RECORDS)
+        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+            result = _download_holdings_snapshot(PurePosixPath("bucket"), PurePosixPath("path/snapshot.json.gz"))
+        assert result == self._RECORDS
+
+    def test_calls_download_file_with_correct_bucket_and_key(self) -> None:
+        """download_file is invoked with the exact bucket and key passed to the function."""
+        mock_s3 = MagicMock()
+        mock_s3.download_file.side_effect = self._writing_side_effect({})
+        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+            _download_holdings_snapshot(PurePosixPath("my-bucket"), PurePosixPath("some/key.json.gz"))
+        mock_s3.download_file.assert_called_once_with(Bucket="my-bucket", Key="some/key.json.gz", Filename=ANY)
+
+    def test_client_error_raises_value_error(self) -> None:
+        """A ClientError from S3 is converted into a descriptive ValueError."""
+        mock_s3 = MagicMock()
+        mock_s3.download_file.side_effect = ClientError(
+            {"Error": {"Code": "NoSuchKey", "Message": "Not found"}}, "GetObject"
+        )
+        with (
+            patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3),
+            pytest.raises(ValueError, match="not found"),
+        ):
+            _download_holdings_snapshot(PurePosixPath("bucket"), PurePosixPath("missing/key.json.gz"))
+
+    def test_error_message_includes_bucket_and_key(self) -> None:
+        """The ValueError message contains both the bucket name and the key path."""
+        mock_s3 = MagicMock()
+        mock_s3.download_file.side_effect = ClientError({"Error": {"Code": "NoSuchKey", "Message": ""}}, "GetObject")
+        with (
+            patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3),
+            pytest.raises(ValueError, match="Snapshot file") as exc_info,
+        ):
+            _download_holdings_snapshot(PurePosixPath("my-bucket"), PurePosixPath("path/to/snap.json.gz"))
+        msg = str(exc_info.value)
+        assert "my-bucket" in msg
+        assert "path/to/snap.json.gz" in msg
+
+    def test_temp_file_is_cleaned_up_on_success(self) -> None:
+        """The temporary download file is deleted after a successful call."""
+        captured: list[str] = []
+        mock_s3 = MagicMock()
+
+        def write_and_capture(**kwargs: str) -> None:
+            _save_holdings_snapshot({}, Path(kwargs["Filename"]))
+            captured.append(kwargs["Filename"])
+
+        mock_s3.download_file.side_effect = write_and_capture
+        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+            _download_holdings_snapshot(PurePosixPath("b"), PurePosixPath("k.json.gz"))
+
+        assert captured, "download_file was never called"
+        assert not Path(captured[0]).exists(), f"Temp file {captured[0]} was not cleaned up"
+
+    def test_temp_file_is_cleaned_up_on_error(self) -> None:
+        """The temporary download file is deleted even when a ClientError is raised."""
+        captured: list[Path] = []
+        real_ntf = tempfile.NamedTemporaryFile
+
+        def recording_ntf(**kwargs: object) -> IO[bytes]:
+            handle = real_ntf(**kwargs)  # type: ignore[arg-type]
+            captured.append(Path(handle.name))
+            return handle
+
+        mock_s3 = MagicMock()
+        mock_s3.download_file.side_effect = ClientError({"Error": {"Code": "NoSuchKey", "Message": ""}}, "GetObject")
+        with (
+            patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3),
+            patch("cdm_data_loaders.pipelines.pdb_manifest.tempfile.NamedTemporaryFile", side_effect=recording_ntf),
+            pytest.raises(ValueError, match="not found"),
+        ):
+            _download_holdings_snapshot(PurePosixPath("b"), PurePosixPath("k.json.gz"))
+
+        assert captured, "NamedTemporaryFile was never called"
+        assert not captured[0].exists(), f"Temp file {captured[0]} was not cleaned up after error"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
# Description of PR purpose/changes

This PR adds a pipeline for generating PDB manifest files. Future PRs will introduce download and promote pipelines for PDB that consume the manifest files.

I included walk-through instructions in `docs/` that can be followed for testing or in production. (The download and promote steps are stubbed out for now.)

@ialarmedalien - I just followed the same approach for organizing manifest data across several text files that I used for NCBI. If as part of the refactor of NCBI steps you were planning on updating the manifest data file schemas, let me know and I can make those changes here also.

# Testing Instructions

Unit and integration tests for the new code are added to the tests suite. You can also follow the instructions in `docs/pdb_e2e_walkthrough.md` for end-to-end testing using a local containerized CEPH test store.

- [x] Tests pass locally and in GitHub Actions

# Dev Checklist:

- [x] My submission follows the [AI Covenant](/AI_COVENANT.md) principles
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] I have run Ruff `format` to format my code
- [x] I have run Ruff `check` and fixed any errors that it uncovered
