### PR TITLE
Move utils.s3 to utils.file_transfer.s3.*

### DIFF
--- a/docs/ncbi_ftp_e2e_walkthrough.md
+++ b/docs/ncbi_ftp_e2e_walkthrough.md
@@ -152,7 +152,7 @@ the S3 client **before** running the cells that use them.  Insert a new cell
 after Cell 1 (Imports) with:
 
 ```python
-from cdm_data_loaders.utils.s3 import get_s3_client, reset_s3_client
+from cdm_data_loaders.utils.file_transfer.s3.client import get_s3_client, reset_s3_client
 
 reset_s3_client()
 get_s3_client({

--- a/notebooks/ncbi_ftp_download.ipynb
+++ b/notebooks/ncbi_ftp_download.ipynb
@@ -117,7 +117,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cdm_data_loaders.utils.s3 import get_s3_client, reset_s3_client\n",
+    "from cdm_data_loaders.utils.file_transfer.s3.client import get_s3_client, reset_s3_client\n",
     "\n",
     "# Provide S3 credentials (use for local testing against CEPH test container)\n",
     "PROVIDE_CREDENTIALS = False  # Set to False to rely on environment credentials (e.g. IAM role)\n",

--- a/notebooks/ncbi_ftp_manifest.ipynb
+++ b/notebooks/ncbi_ftp_manifest.ipynb
@@ -62,7 +62,7 @@
     "    write_transfer_manifest,\n",
     "    write_updated_manifest,\n",
     ")\n",
-    "from cdm_data_loaders.utils.s3 import get_s3_client, split_s3_path"
+    "from cdm_data_loaders.utils.file_transfer.s3.client import get_s3_client, reset_s3_client, split_s3_path"
    ]
   },
   {
@@ -72,8 +72,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from cdm_data_loaders.utils.s3 import reset_s3_client\n",
-    "\n",
     "# Provide S3 credentials (use for local testing against CEPH test container)\n",
     "PROVIDE_CREDENTIALS = False  # Set to False to rely on environment credentials (e.g. IAM role)\n",
     "if PROVIDE_CREDENTIALS:\n",

--- a/scripts/s3_local.py
+++ b/scripts/s3_local.py
@@ -20,12 +20,12 @@ Environment variables (with defaults for the walkthrough):
 import os
 import sys
 
-from cdm_data_loaders.utils import s3
+from cdm_data_loaders.utils.file_transfer.s3 import cli, client
 
 
 def _client() -> None:
-    s3.reset_s3_client()
-    _ = s3.get_s3_client(
+    client.reset_s3_client()
+    _ = client.get_s3_client(
         {
             "endpoint_url": os.environ.get("AWS_ENDPOINT_URL", "http://localhost:9000"),
             "aws_access_key_id": os.environ.get("AWS_ACCESS_KEY_ID", "test_access_key"),
@@ -36,7 +36,7 @@ def _client() -> None:
 
 # dispatch
 
-COMMANDS = {"mb": s3.cmd_mb, "cp": s3.cmd_cp, "ls": s3.cmd_ls, "head": s3.cmd_head}
+COMMANDS = {"mb": cli.cmd_mb, "cp": cli.cmd_cp, "ls": cli.cmd_ls, "head": cli.cmd_head}
 
 
 def main() -> None:

--- a/src/cdm_data_loaders/ncbi_ftp/manifest.py
+++ b/src/cdm_data_loaders/ncbi_ftp/manifest.py
@@ -29,8 +29,8 @@ from cdm_data_loaders.ncbi_ftp.assembly import (
     parse_md5_checksums_file,
 )
 from cdm_data_loaders.ncbi_ftp.constants import ACCESSION_PARTS_REGEX, ASSEMBLY_PATH_REGEX
+from cdm_data_loaders.utils.file_transfer.s3.object_utils import head_object, list_matching_objects
 from cdm_data_loaders.utils.ftp_client import FTP, connect_ftp, ftp_noop_keepalive, ftp_retrieve_text
-from cdm_data_loaders.utils.s3 import head_object, list_matching_objects
 
 logger: Logger = getLogger(__name__)
 

--- a/src/cdm_data_loaders/ncbi_ftp/metadata.py
+++ b/src/cdm_data_loaders/ncbi_ftp/metadata.py
@@ -25,7 +25,8 @@ from typing import Any, TypedDict
 
 from frictionless import Package
 
-from cdm_data_loaders.utils.s3 import copy_object, get_s3_client
+from cdm_data_loaders.utils.file_transfer.s3 import client
+from cdm_data_loaders.utils.file_transfer.s3.object_utils import copy_object
 
 logger: Logger = getLogger(__name__)
 
@@ -199,7 +200,7 @@ def upload_descriptor(
         logger.debug("[dry-run] would upload descriptor: s3://%s/%s", bucket, key)
         return key
 
-    s3 = get_s3_client()
+    s3_client = client.get_s3_client()
     body = json.dumps(descriptor, indent=2).encode()
 
     with tempfile.NamedTemporaryFile(suffix=".json", delete=False) as tmp:
@@ -207,7 +208,7 @@ def upload_descriptor(
         tmp.write(body)
 
     try:
-        s3.upload_file(Filename=tmp_path, Bucket=str(bucket), Key=str(key))
+        s3_client.upload_file(Filename=tmp_path, Bucket=str(bucket), Key=str(key))
         logger.debug("Uploaded descriptor: s3://%s/%s", bucket, key)
     finally:
         Path(tmp_path).unlink()
@@ -244,10 +245,10 @@ def archive_descriptor(  # noqa: PLR0913
         logger.debug("[dry-run] would archive descriptor: s3://%s/%s -> %s", bucket, source_key, archive_key)
         return True
 
-    s3 = get_s3_client()
+    s3_client = client.get_s3_client()
     try:
-        s3.head_object(Bucket=str(bucket), Key=str(source_key))
-    except s3.exceptions.NoSuchKey:
+        s3_client.head_object(Bucket=str(bucket), Key=str(source_key))
+    except s3_client.exceptions.NoSuchKey:
         logger.warning("Descriptor not found, skipping archive: s3://%s/%s", bucket, source_key)
         return False
     except Exception as e:

--- a/src/cdm_data_loaders/ncbi_ftp/promote.py
+++ b/src/cdm_data_loaders/ncbi_ftp/promote.py
@@ -25,10 +25,10 @@ from cdm_data_loaders.ncbi_ftp.metadata import (
     create_descriptor,
     upload_descriptor,
 )
-from cdm_data_loaders.utils.s3 import (
+from cdm_data_loaders.utils.file_transfer.s3 import client
+from cdm_data_loaders.utils.file_transfer.s3.object_utils import (
     copy_object,
     delete_objects,
-    get_s3_client,
     list_matching_objects,
     object_exists,
     upload_file,
@@ -174,7 +174,7 @@ def _promote_file(  # noqa: PLR0913
     :param sidecars: set of S3 keys for sidecar files (to check for MD5 metadata)
     :return: ``(resource_dict, staged_key)`` on success; raises on failure.
     """
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     rel_path = staged_key.relative_to(staging_prefix)
     final_key = lakehouse_key_prefix / rel_path
     final_key_path = PurePosixPath(final_key)
@@ -560,7 +560,7 @@ def _trim_manifest(
     :param staging_bucket: S3 bucket containing the transfer manifest
     :param promoted_accessions: set of accessions that were successfully promoted
     """
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
 
     with tempfile.NamedTemporaryFile(mode="w", delete=False, suffix=".txt") as tmp:
         tmp_path = tmp.name

--- a/src/cdm_data_loaders/parsers/uniprot/idmapping.py
+++ b/src/cdm_data_loaders/parsers/uniprot/idmapping.py
@@ -36,7 +36,7 @@ from pyspark.sql.types import StringType, StructField
 from cdm_data_loaders.core.constants import CDM_LAKE_S3, INVALID_DATA_FIELD_NAME
 from cdm_data_loaders.core.pipeline_run import PipelineRun
 from cdm_data_loaders.readers.dsv import read
-from cdm_data_loaders.utils.s3 import list_matching_objects
+from cdm_data_loaders.utils.file_transfer.s3.object_utils import list_matching_objects
 from cdm_data_loaders.utils.spark import APPEND, set_up_workspace, write_table
 from cdm_data_loaders.validation.dataframe_validator import DataFrameValidator, Validator
 from cdm_data_loaders.validation.df_nullable_fields import validate as check_nullable_fields

--- a/src/cdm_data_loaders/pipelines/ncbi_ftp_download.py
+++ b/src/cdm_data_loaders/pipelines/ncbi_ftp_download.py
@@ -30,8 +30,9 @@ from cdm_data_loaders.ncbi_ftp.assembly import (
     parse_assembly_path,
 )
 from cdm_data_loaders.pipelines.core import run_cli
+from cdm_data_loaders.utils.file_transfer.s3.client import get_s3_client
+from cdm_data_loaders.utils.file_transfer.s3.object_utils import upload_file
 from cdm_data_loaders.utils.ftp_client import ThreadLocalFTP
-from cdm_data_loaders.utils.s3 import get_s3_client, upload_file
 
 logger: Logger = getLogger(__name__)
 

--- a/src/cdm_data_loaders/pipelines/pdb_manifest.py
+++ b/src/cdm_data_loaders/pipelines/pdb_manifest.py
@@ -43,7 +43,7 @@ from cdm_data_loaders.pdb.constants import (
     PDBRecord,
 )
 from cdm_data_loaders.pipelines.core import run_cli
-from cdm_data_loaders.utils.s3 import get_s3_client
+from cdm_data_loaders.utils.file_transfer.s3 import client
 
 logger: Logger = getLogger(__name__)
 
@@ -205,8 +205,8 @@ def _generate_snapshot_from_s3_state(
     date: date,
 ) -> dict[str, PDBRecord]:
     """Bootstraps a holdings snapshot file based on the current store state."""
-    s3 = get_s3_client()
-    paginator = s3.get_paginator("list_objects_v2")
+    s3_client = client.get_s3_client()
+    paginator = s3_client.get_paginator("list_objects_v2")
     results: dict[str, PDBRecord] = {}
 
     for page in paginator.paginate(Bucket=str(bucket), Prefix=str(key_prefix)):
@@ -268,11 +268,11 @@ def _download_holdings_snapshot(
     key: PurePosixPath,
 ) -> dict[str, PDBRecord]:
     """Download and parse a holdings snapshot file from S3."""
-    s3 = get_s3_client()
+    s3_client = client.get_s3_client()
     with tempfile.NamedTemporaryFile(suffix=".json.gz", delete=False) as tmp:
         tmp_path = Path(tmp.name)
     try:
-        s3.download_file(Bucket=str(bucket), Key=str(key), Filename=str(tmp_path))
+        s3_client.download_file(Bucket=str(bucket), Key=str(key), Filename=str(tmp_path))
         return _load_holdings_snapshot(tmp_path)
     except ClientError:
         msg = (

--- a/src/cdm_data_loaders/utils/file_transfer/s3/cli.py
+++ b/src/cdm_data_loaders/utils/file_transfer/s3/cli.py
@@ -1,0 +1,5 @@
+"""Helper functions for command-line boto3 usage."""
+# No warnings for print statements
+# ruff: noqa: T201
+
+from cdm_data_loaders.utils.file_transfer.s3.object_utils import cmd_cp, cmd_head, cmd_ls, cmd_mb

--- a/src/cdm_data_loaders/utils/file_transfer/s3/client.py
+++ b/src/cdm_data_loaders/utils/file_transfer/s3/client.py
@@ -1,0 +1,89 @@
+"""S3 client creation and reset."""
+
+from logging import Logger, getLogger
+from typing import Final
+
+import boto3
+import botocore
+import botocore.client
+from botocore.config import Config
+from frozendict import frozendict
+
+# "legacy", "standard", "adaptive"
+AWS_CLIENT_RETRY_MODE: Final[str] = "adaptive"
+# how many times to retry, including the initial attempt
+AWS_CLIENT_TOTAL_MAX_ATTEMPTS: Final[int] = 10
+
+DEFAULT_EXTRA_ARGS: frozendict[str, str] = frozendict({"ChecksumAlgorithm": "CRC64NVME"})
+
+_s3_client: botocore.client.BaseClient | None = None
+
+logger: Logger = getLogger(__name__)
+
+
+def get_s3_client(args: dict[str, str | None] | None = None) -> botocore.client.BaseClient:
+    """Create an S3 client using the provided arguments.
+
+    The client is created once and cached for subsequent calls.
+    Call reset_s3_client() to force a new client to be created on the next call.
+
+    To configure the client using arguments, provide a dictionary with the following keys:
+        - aws_access_key_id: the access key ID for the S3 client
+        - aws_secret_access_key: the secret access key for the S3 client
+        - endpoint_url: the endpoint URL for the S3 client (e.g., "https://s3.amazonaws.com" or "https://my-s3-server.com")
+
+    If arguments are not provided, the client will be created using boto3's default
+    configuration method, which looks for environment variables (AWS_ACCESS_KEY_ID,
+    AWS_SECRET_ACCESS_KEY, and AWS_ENDPOINT_URL_S3 or AWS_ENDPOINT_URL) or an ``./aws`` config directory.
+    See the boto3 documentation for more details.
+
+    :param args: arguments for creating the S3 client, defaults to None
+    :type args: dict[str, str] | None, optional
+    :raises ValueError: if required arguments for creating the S3 client are missing
+    :return: initialised s3 client
+    :rtype: botocore.client.BaseClient
+    """
+    global _s3_client  # noqa: PLW0603
+    if _s3_client is not None:
+        return _s3_client
+
+    config = Config(retries={"total_max_attempts": AWS_CLIENT_TOTAL_MAX_ATTEMPTS, "mode": AWS_CLIENT_RETRY_MODE})
+
+    if not args:
+        args = {}
+
+    valid_kwargs = ["aws_access_key_id", "aws_secret_access_key", "endpoint_url"]
+    kwargs = {k: v for k, v in args.items() if k in valid_kwargs and v is not None}
+
+    # make sure that if aws_access_key_id or aws_secret_access_key is provided, the other is also provided.
+    if bool(kwargs.get("aws_access_key_id")) ^ bool(kwargs.get("aws_secret_access_key")):
+        msg = "Cannot initialise s3 client: aws_access_key_id and aws_secret_access_key must be provided together, either via args or environment variables or a config file"
+        raise ValueError(msg)
+
+    # initialise using boto3's default config behaviour, plus any overrides from args
+    client = boto3.client("s3", config=config, **kwargs)
+
+    missing = []
+    # boto3 will not raise an error on client creation if credentials are missing, so throw an error now
+    credentials = client._request_signer._credentials  # noqa: SLF001
+    if not credentials:
+        missing = ["aws_access_key_id", "aws_secret_access_key"]
+    else:
+        if not credentials.access_key:
+            missing.append("aws_access_key_id")
+        if not credentials.secret_key:
+            missing.append("aws_secret_access_key")
+
+    if missing:
+        msg = "Cannot initialise s3 client: missing configuration values: " + ", ".join(missing)
+        raise ValueError(msg)
+
+    # nothing missing: we are good to go!
+    _s3_client = client
+    return _s3_client
+
+
+def reset_s3_client() -> None:
+    """Reset the cached S3 client, forcing a new one to be created on the next call to get_s3_client."""
+    global _s3_client  # noqa: PLW0603
+    _s3_client = None

--- a/src/cdm_data_loaders/utils/file_transfer/s3/object_utils.py
+++ b/src/cdm_data_loaders/utils/file_transfer/s3/object_utils.py
@@ -6,12 +6,12 @@ from pathlib import Path
 from types import ModuleType
 from typing import Any
 
-import boto3
 import botocore
 import botocore.client
 import tqdm
-from botocore.config import Config
 from botocore.exceptions import ClientError
+
+from cdm_data_loaders.utils.file_transfer.s3 import client
 
 CDM_LAKE_BUCKET = "cdm-lake"
 DEFAULT_EXTRA_ARGS = {"ChecksumAlgorithm": "CRC64NVME"}
@@ -29,74 +29,6 @@ SUCCESS_RESPONSE = 200
 _s3_client: botocore.client.BaseClient | None = None
 
 logger: Logger = getLogger(__name__)
-
-
-def get_s3_client(args: dict[str, str | None] | None = None) -> botocore.client.BaseClient:
-    """Create an S3 client using the provided arguments.
-
-    The client is created once and cached for subsequent calls.
-    Call reset_s3_client() to force a new client to be created on the next call.
-
-    To configure the client using arguments, provide a dictionary with the following keys:
-        - aws_access_key_id: the access key ID for the S3 client
-        - aws_secret_access_key: the secret access key for the S3 client
-        - endpoint_url: the endpoint URL for the S3 client (e.g., "https://s3.amazonaws.com" or "https://my-s3-server.com")
-
-    If arguments are not provided, the client will be created using boto3's default
-    configuration method, which looks for environment variables (AWS_ACCESS_KEY_ID,
-    AWS_SECRET_ACCESS_KEY, and AWS_ENDPOINT_URL_S3 or AWS_ENDPOINT_URL) or an ``./aws`` config directory.
-    See the boto3 documentation for more details.
-
-    :param args: arguments for creating the S3 client, defaults to None
-    :type args: dict[str, str] | None, optional
-    :raises ValueError: if required arguments for creating the S3 client are missing
-    :return: initialised s3 client
-    :rtype: botocore.client.BaseClient
-    """
-    global _s3_client  # noqa: PLW0603
-    if _s3_client is not None:
-        return _s3_client
-
-    config = Config(retries={"total_max_attempts": AWS_CLIENT_TOTAL_MAX_ATTEMPTS, "mode": AWS_CLIENT_RETRY_MODE})
-
-    if not args:
-        args = {}
-
-    valid_kwargs = ["aws_access_key_id", "aws_secret_access_key", "endpoint_url"]
-    kwargs = {k: v for k, v in args.items() if k in valid_kwargs and v is not None}
-
-    # make sure that if aws_access_key_id or aws_secret_access_key is provided, the other is also provided.
-    if bool(kwargs.get("aws_access_key_id")) ^ bool(kwargs.get("aws_secret_access_key")):
-        msg = "Cannot initialise s3 client: aws_access_key_id and aws_secret_access_key must be provided together, either via args or environment variables or a config file"
-        raise ValueError(msg)
-
-    # initialise using boto3's default config behaviour, plus any overrides from args
-    client = boto3.client("s3", config=config, **kwargs)
-
-    missing = []
-    # boto3 will not raise an error on client creation if credentials are missing, so throw an error now
-    credentials = client._request_signer._credentials  # noqa: SLF001
-    if not credentials:
-        missing = ["aws_access_key_id", "aws_secret_access_key"]
-    else:
-        if not credentials.access_key:
-            missing.append("aws_access_key_id")
-        if not credentials.secret_key:
-            missing.append("aws_secret_access_key")
-
-    if missing:
-        msg = "Cannot initialise s3 client: missing configuration values: " + ", ".join(missing)
-        raise ValueError(msg)
-
-    # nothing missing: we are good to go!
-    _s3_client = client
-    return _s3_client
-
-
-def reset_s3_client() -> None:
-    """Reset the cached S3 client, forcing a new one to be created on the next call to get_s3_client."""
-    global _s3_client  # noqa: PLW0603
-    _s3_client = None
 
 
 def split_s3_path(s3_path: str, *, allow_bucket_only: bool = False) -> tuple[str | None, str]:
@@ -158,7 +90,7 @@ def list_matching_objects(s3_path: str, *, max_keys: int = 1000) -> list[dict[st
     :return: list of object metadata dicts in the directory
     :rtype: list[dict[str, Any]]
     """
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     (bucket, key) = split_s3_path(s3_path)
     paginator = s3.get_paginator("list_objects_v2")
     page_iterator = paginator.paginate(Bucket=bucket, Prefix=key, MaxKeys=max_keys)
@@ -178,7 +110,7 @@ def head_object(s3_path: str) -> dict[str, Any]:
     :return: response from the head_object request
     :rtype: dict[str, Any]
     """
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     (bucket, key) = split_s3_path(s3_path)
     return s3.head_object(Bucket=bucket, Key=key, ChecksumMode="ENABLED")
 
@@ -244,7 +176,7 @@ def upload_file(
         logger.debug("File already present: %s", s3_path)
         return True
 
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     (bucket, key) = split_s3_path(s3_path)
 
     extra_args = {**DEFAULT_EXTRA_ARGS, **(({"Metadata": user_metadata}) if user_metadata is not None else {})}
@@ -287,11 +219,11 @@ def stream_to_s3(url: str, s3_path: str, requests: ModuleType) -> str:
     :return: path of the file on s3, in the form bucket/key
     :rtype: str
     """
-    s3_client = get_s3_client()
+    s3 = client.get_s3_client()
     (bucket, key) = split_s3_path(s3_path)
     with requests.get(url, stream=True) as response:
         response.raise_for_status()
-        s3_client.upload_fileobj(
+        s3.upload_fileobj(
             # raw stream from urllib3
             response.raw,
             bucket,
@@ -330,7 +262,7 @@ def download_file(
             logger.exception("Could not save s3 file to %s", local_file_path)
             raise
 
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     (bucket, key) = split_s3_path(s3_path)
     kwargs = {"Bucket": bucket, "Key": key}
     if version_id is not None:
@@ -466,7 +398,7 @@ def copy_object(
     :return: dictionary containing response from the copy operation
     :rtype: dict[str, Any]
     """
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     (current_s3_bucket, current_s3_key) = split_s3_path(current_s3_path)
     (new_s3_bucket, new_s3_key) = split_s3_path(new_s3_path)
 
@@ -498,7 +430,7 @@ def copy_directory(current_s3_path: str, new_s3_path: str) -> tuple[dict[str, st
                for each failed copy
     :rtype: tuple[dict[str, str], dict[str, Any]]
     """
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     (current_s3_bucket, current_s3_prefix) = split_s3_path(current_s3_path)
     (new_s3_bucket, new_s3_prefix) = split_s3_path(new_s3_path)
 
@@ -554,7 +486,7 @@ def delete_object(s3_path: str) -> dict[str, Any]:
     :return: dictionary containing response
     :rtype: dict[str, Any]
     """
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     (bucket, key) = split_s3_path(s3_path)
     return s3.delete_object(Bucket=bucket, Key=key)
 
@@ -572,7 +504,7 @@ def delete_objects(bucket: str, keys: list[str]) -> list[dict[str, Any]]:
     if not keys:
         return []
 
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     errors: list[dict[str, Any]] = []
     for i in range(0, len(keys), 1000):
         batch = keys[i : i + 1000]
@@ -596,7 +528,7 @@ def cmd_mb(args: list[str]) -> None:
         bucket, _ = split_s3_path(args[0], allow_bucket_only=True)
     except ValueError as e:
         raise SystemExit(str(e)) from e
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     try:
         s3.head_bucket(Bucket=bucket)
         print(f"Bucket already exists: {bucket}")  # noqa: T201
@@ -615,7 +547,7 @@ def cmd_cp(args: list[str]) -> None:
         bucket, prefix = split_s3_path(args[1], allow_bucket_only=True)
     except ValueError as e:
         raise SystemExit(str(e)) from e
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     count = 0
     if local_path.is_file():
         if not prefix:
@@ -650,7 +582,7 @@ def cmd_ls(args: list[str]) -> None:
     if "--limit" in args:
         idx = args.index("--limit")
         limit = int(args[idx + 1])
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     paginator = s3.get_paginator("list_objects_v2")
     shown = 0
     for page in paginator.paginate(Bucket=bucket, Prefix=prefix):
@@ -670,7 +602,7 @@ def cmd_head(args: list[str]) -> None:
         bucket, key = split_s3_path(args[0])
     except ValueError as e:
         raise SystemExit(str(e)) from e
-    s3 = get_s3_client()
+    s3 = client.get_s3_client()
     meta = {}
     try:
         resp = s3.head_object(Bucket=bucket, Key=key)

--- a/src/cdm_data_loaders/utils/file_transfer/s3/streamer.py
+++ b/src/cdm_data_loaders/utils/file_transfer/s3/streamer.py
@@ -1,3 +1,3 @@
 """Stream HTTP resources directly into S3, without buffering to local disk."""
 
-from cdm_data_loaders.utils.s3 import stream_to_s3
+from cdm_data_loaders.utils.file_transfer.s3.object_utils import stream_to_s3

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -20,10 +20,9 @@ import pytest
 from botocore.exceptions import ClientError
 
 import cdm_data_loaders.ncbi_ftp.manifest as manifest_mod
-import cdm_data_loaders.ncbi_ftp.promote as promote_mod
-import cdm_data_loaders.utils.s3 as s3_utils
 from cdm_data_loaders.ncbi_ftp.assembly import build_accession_path
-from cdm_data_loaders.utils.s3 import reset_s3_client
+from cdm_data_loaders.utils.file_transfer.s3 import client, object_utils
+from cdm_data_loaders.utils.file_transfer.s3.client import reset_s3_client
 
 # Maximum length of a bucket name per S3/DNS spec
 _MAX_BUCKET_LEN = 63
@@ -77,16 +76,15 @@ def ceph_s3_client() -> Generator[botocore.client.BaseClient]:
     Patches ``get_s3_client`` on every module that uses it so internal calls
     are transparently routed to CEPH.
     """
-    client = boto3.client("s3")
+    s3_client = boto3.client("s3")
 
     reset_s3_client()
     with (
-        patch.object(s3_utils, "get_s3_client", return_value=client),
-        patch.object(promote_mod, "get_s3_client", return_value=client),
-        patch.object(manifest_mod, "head_object", wraps=s3_utils.head_object),
-        patch.object(s3_utils, "_s3_client", client),
+        patch.object(client, "get_s3_client", return_value=s3_client),
+        patch.object(client, "_s3_client", s3_client),
+        patch.object(manifest_mod, "head_object", wraps=object_utils.head_object),
     ):
-        yield client
+        yield s3_client
     reset_s3_client()
 
 

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -19,9 +19,8 @@ import botocore.config
 import pytest
 from botocore.exceptions import ClientError
 
-import cdm_data_loaders.ncbi_ftp.manifest as manifest_mod
 from cdm_data_loaders.ncbi_ftp.assembly import build_accession_path
-from cdm_data_loaders.utils.file_transfer.s3 import client, object_utils
+from cdm_data_loaders.utils.file_transfer.s3 import client
 from cdm_data_loaders.utils.file_transfer.s3.client import reset_s3_client
 
 # Maximum length of a bucket name per S3/DNS spec
@@ -82,7 +81,6 @@ def ceph_s3_client() -> Generator[botocore.client.BaseClient]:
     with (
         patch.object(client, "get_s3_client", return_value=s3_client),
         patch.object(client, "_s3_client", s3_client),
-        patch.object(manifest_mod, "head_object", wraps=object_utils.head_object),
     ):
         yield s3_client
     reset_s3_client()

--- a/tests/integration/test_download_e2e.py
+++ b/tests/integration/test_download_e2e.py
@@ -12,7 +12,6 @@ from unittest.mock import patch
 import pytest
 from botocore.client import BaseClient
 
-import cdm_data_loaders.utils.s3 as s3_utils
 from cdm_data_loaders.ncbi_ftp.manifest import (
     compute_diff,
     download_assembly_summary,
@@ -21,6 +20,7 @@ from cdm_data_loaders.ncbi_ftp.manifest import (
     write_transfer_manifest,
 )
 from cdm_data_loaders.pipelines.ncbi_ftp_download import download_and_stage, download_batch
+from cdm_data_loaders.utils.file_transfer.s3 import client
 
 # Use same stable prefix as manifest tests
 STABLE_PREFIX = "900"
@@ -148,7 +148,7 @@ def test_download_and_stage_e2e(
         Body=manifest_path.read_bytes(),
     )
 
-    with patch.object(s3_utils, "get_s3_client", return_value=ceph_s3_client):
+    with patch.object(client, "get_s3_client", return_value=ceph_s3_client):
         report = download_and_stage(
             bucket=test_bucket,
             staging_key_prefix=staging_prefix,

--- a/tests/integration/test_download_e2e.py
+++ b/tests/integration/test_download_e2e.py
@@ -7,7 +7,6 @@ Marked ``requires_ceph`` (if a running CEPH test store is required) and
 
 import json
 from pathlib import Path, PurePosixPath
-from unittest.mock import patch
 
 import pytest
 from botocore.client import BaseClient
@@ -20,7 +19,6 @@ from cdm_data_loaders.ncbi_ftp.manifest import (
     write_transfer_manifest,
 )
 from cdm_data_loaders.pipelines.ncbi_ftp_download import download_and_stage, download_batch
-from cdm_data_loaders.utils.file_transfer.s3 import client
 
 # Use same stable prefix as manifest tests
 STABLE_PREFIX = "900"
@@ -148,15 +146,14 @@ def test_download_and_stage_e2e(
         Body=manifest_path.read_bytes(),
     )
 
-    with patch.object(client, "get_s3_client", return_value=ceph_s3_client):
-        report = download_and_stage(
-            bucket=test_bucket,
-            staging_key_prefix=staging_prefix,
-            manifest_s3_key=manifest_s3_key,
-            threads=1,
-            limit=1,
-            dry_run=False,
-        )
+    report = download_and_stage(
+        bucket=test_bucket,
+        staging_key_prefix=staging_prefix,
+        manifest_s3_key=manifest_s3_key,
+        threads=1,
+        limit=1,
+        dry_run=False,
+    )
 
     assert report["succeeded"] >= 1
     assert report["failed"] == 0

--- a/tests/integration/test_pdb_manifest_pipeline.py
+++ b/tests/integration/test_pdb_manifest_pipeline.py
@@ -7,12 +7,10 @@ Tests in ``TestSnapshotCeph`` and ``TestGenerateSnapshotFromS3State`` require
 a running CEPH test store and are marked ``requires_ceph`` + ``slow_test``.
 """
 
-from collections.abc import Generator
 from datetime import date
 from pathlib import Path, PurePosixPath
 from types import SimpleNamespace
 from typing import ClassVar, cast
-from unittest.mock import patch
 
 import botocore.client
 import pytest
@@ -41,20 +39,6 @@ _FAKE_IDS = [
     "pdb_00001def",
     "pdb_aaaaaaaa",
 ]
-
-
-# ---------------------------------------------------------------------------
-# Local fixture - patch pdb_manifest's get_s3_client to use CEPH client
-# ---------------------------------------------------------------------------
-
-
-@pytest.fixture
-def pdb_ceph_client(
-    ceph_s3_client: botocore.client.BaseClient,
-) -> Generator[botocore.client.BaseClient]:
-    """Extend ceph_s3_client by also patching get_s3_client inside pdb_manifest."""
-    with patch.object(pdb_manifest_mod, "get_s3_client", return_value=ceph_s3_client):
-        yield ceph_s3_client
 
 
 def _seed_fake_pdb_objects(
@@ -126,7 +110,7 @@ class TestSnapshotCeph:
 
     def test_save_and_download_snapshot(
         self,
-        pdb_ceph_client: botocore.client.BaseClient,
+        ceph_s3_client: botocore.client.BaseClient,
         test_bucket: PurePosixPath,
         tmp_path: Path,
     ) -> None:
@@ -140,7 +124,7 @@ class TestSnapshotCeph:
 
         # Save locally then upload to CEPH
         _save_holdings_snapshot(records, local_file)
-        pdb_ceph_client.upload_file(
+        ceph_s3_client.upload_file(
             Filename=str(local_file),
             Bucket=str(test_bucket),
             Key=str(snapshot_key),
@@ -155,7 +139,7 @@ class TestSnapshotCeph:
 
     def test_empty_snapshot_round_trip(
         self,
-        pdb_ceph_client: botocore.client.BaseClient,
+        ceph_s3_client: botocore.client.BaseClient,
         test_bucket: PurePosixPath,
         tmp_path: Path,
     ) -> None:
@@ -163,7 +147,7 @@ class TestSnapshotCeph:
         snapshot_key = PurePosixPath("snapshots") / "empty_snapshot.json.gz"
         local_file = tmp_path / "empty.json.gz"
         _save_holdings_snapshot({}, local_file)
-        pdb_ceph_client.upload_file(
+        ceph_s3_client.upload_file(
             Filename=str(local_file),
             Bucket=str(test_bucket),
             Key=str(snapshot_key),
@@ -184,11 +168,11 @@ class TestGenerateSnapshotFromS3State:
 
     def test_finds_all_seeded_ids(
         self,
-        pdb_ceph_client: botocore.client.BaseClient,
+        ceph_s3_client: botocore.client.BaseClient,
         test_bucket: PurePosixPath,
     ) -> None:
         """Tests bootstrapped snapshot includes in-store ids."""
-        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _FAKE_IDS)
+        _seed_fake_pdb_objects(ceph_s3_client, test_bucket, _FAKE_IDS)
         bootstrap_date = date(2024, 1, 1)
 
         result = _generate_snapshot_from_s3_state(
@@ -201,11 +185,11 @@ class TestGenerateSnapshotFromS3State:
 
     def test_all_records_use_bootstrap_date(
         self,
-        pdb_ceph_client: botocore.client.BaseClient,
+        ceph_s3_client: botocore.client.BaseClient,
         test_bucket: PurePosixPath,
     ) -> None:
         """Ensures the provided snapshot date is properly set."""
-        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _FAKE_IDS)
+        _seed_fake_pdb_objects(ceph_s3_client, test_bucket, _FAKE_IDS)
         bootstrap_date = date(2024, 1, 1)
 
         result = _generate_snapshot_from_s3_state(
@@ -220,14 +204,14 @@ class TestGenerateSnapshotFromS3State:
 
     def test_deduplicates_multiple_objects_per_id(
         self,
-        pdb_ceph_client: botocore.client.BaseClient,
+        ceph_s3_client: botocore.client.BaseClient,
         test_bucket: PurePosixPath,
     ) -> None:
         """Multiple S3 objects sharing the same PDB ID produce a single snapshot entry."""
         pdb_id = "pdb_00001abc"
         for suffix in ("model.cif.gz", "data.cif.gz", "info.json"):
             key = str(_PDB_KEY_PREFIX / pdb_id / f"{pdb_id}_{suffix}")
-            pdb_ceph_client.put_object(Bucket=str(test_bucket), Key=key, Body=b"x")
+            ceph_s3_client.put_object(Bucket=str(test_bucket), Key=key, Body=b"x")
 
         result = _generate_snapshot_from_s3_state(
             bucket=test_bucket,
@@ -298,7 +282,7 @@ class TestRunManifestGenerationE2E:
     def _read_manifest(self, tmp_path: Path, filename: str) -> list[str]:
         return (tmp_path / filename).read_text().splitlines()
 
-    @pytest.mark.usefixtures("pdb_ceph_client")
+    @pytest.mark.usefixtures("ceph_s3_client")
     def test_skip_diff_all_current_records_are_new(
         self,
         test_bucket: PurePosixPath,
@@ -316,14 +300,14 @@ class TestRunManifestGenerationE2E:
 
     def test_bootstrap_date_uses_s3_state_as_previous(
         self,
-        pdb_ceph_client: botocore.client.BaseClient,
+        ceph_s3_client: botocore.client.BaseClient,
         test_bucket: PurePosixPath,
         tmp_path: Path,
     ) -> None:
         """With bootstrap_date, the S3 store determines the previous snapshot."""
         # pdb_00001def: in S3, bootstrap date older than current: updated.
         # pdb_00009999: in S3 but not in current holdings: removed.
-        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, ["pdb_00001def", "pdb_00009999"])
+        _seed_fake_pdb_objects(ceph_s3_client, test_bucket, ["pdb_00001def", "pdb_00009999"])
         bootstrap_date = date(2020, 1, 1)
 
         config = self._make_config(test_bucket, tmp_path, bootstrap_date=bootstrap_date)
@@ -341,7 +325,7 @@ class TestRunManifestGenerationE2E:
 
     def test_with_existing_snapshot_incremental_diff(
         self,
-        pdb_ceph_client: botocore.client.BaseClient,
+        ceph_s3_client: botocore.client.BaseClient,
         test_bucket: PurePosixPath,
         tmp_path: Path,
     ) -> None:
@@ -355,7 +339,7 @@ class TestRunManifestGenerationE2E:
         local_snapshot = tmp_path / "input_snapshot.json.gz"
         _save_holdings_snapshot(previous, local_snapshot)
         snapshot_key = _SNAPSHOT_PREFIX / _SNAPSHOT_FILENAME
-        pdb_ceph_client.upload_file(
+        ceph_s3_client.upload_file(
             Filename=str(local_snapshot),
             Bucket=str(test_bucket),
             Key=str(snapshot_key),
@@ -378,7 +362,7 @@ class TestRunManifestGenerationE2E:
         assert self._read_manifest(tmp_path, "removed_manifest.txt") == ["pdb_00009999"]
         assert self._read_manifest(tmp_path, "missing_dates.txt") == ["pdb_aaaaaaaa"]
 
-    @pytest.mark.usefixtures("pdb_ceph_client")
+    @pytest.mark.usefixtures("ceph_s3_client")
     @pytest.mark.parametrize(
         ("regex_filter", "expected_transfer", "expected_missing"),
         [
@@ -434,7 +418,7 @@ class TestSnapshotManifestRoundTripCeph:
     These tests verify the full contract between ``_generate_snapshot_from_s3_state``,
     ``_save_holdings_snapshot``, ``_download_holdings_snapshot``, and
     ``run_manifest_generation``.  PDB HTTP calls are mocked; all S3 interactions
-    use the real CEPH test store via ``pdb_ceph_client``.
+    use the real CEPH test store via ``ceph_s3_client``.
     """
 
     # A date well in the past so we can easily manufacture "newer" dates in holdings.
@@ -515,14 +499,14 @@ class TestSnapshotManifestRoundTripCeph:
 
     def test_no_changes_when_store_matches_holdings(
         self,
-        pdb_ceph_client: botocore.client.BaseClient,
+        ceph_s3_client: botocore.client.BaseClient,
         test_bucket: PurePosixPath,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """When the snapshot exactly matches the current holdings, all manifests are empty."""
-        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _ROUNDTRIP_IDS)
-        self._build_and_upload_snapshot(pdb_ceph_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap.json.gz")
+        _seed_fake_pdb_objects(ceph_s3_client, test_bucket, _ROUNDTRIP_IDS)
+        self._build_and_upload_snapshot(ceph_s3_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap.json.gz")
 
         # Holdings current = same IDs; last-modified dates match the bootstrap date.
         current = {id_: PDBRecord(id=id_) for id_ in _ROUNDTRIP_IDS}
@@ -540,7 +524,7 @@ class TestSnapshotManifestRoundTripCeph:
 
     def test_records_removed_from_store_reappear_in_transfer_manifest(
         self,
-        pdb_ceph_client: botocore.client.BaseClient,
+        ceph_s3_client: botocore.client.BaseClient,
         test_bucket: PurePosixPath,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -561,18 +545,18 @@ class TestSnapshotManifestRoundTripCeph:
         self._mock_holdings(monkeypatch, current, last_modified)
 
         # First run: baseline:nothing should appear in any manifest
-        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _ROUNDTRIP_IDS)
-        self._build_and_upload_snapshot(pdb_ceph_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap1.json.gz")
+        _seed_fake_pdb_objects(ceph_s3_client, test_bucket, _ROUNDTRIP_IDS)
+        self._build_and_upload_snapshot(ceph_s3_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap1.json.gz")
         run_manifest_generation(self._make_config(test_bucket, tmp_path / "run1"))
         assert self._read_manifest(tmp_path / "run1", "transfer_manifest.txt") == []
 
         # Remove some records from the store
         for pdb_id in removed_ids:
             key = str(_PDB_KEY_PREFIX / pdb_id / f"{pdb_id}_model.cif.gz")
-            pdb_ceph_client.delete_object(Bucket=str(test_bucket), Key=key)
+            ceph_s3_client.delete_object(Bucket=str(test_bucket), Key=key)
 
         # Second run: removed IDs are absent from new snapshot: should appear in transfer_manifest.txt
-        self._build_and_upload_snapshot(pdb_ceph_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap2.json.gz")
+        self._build_and_upload_snapshot(ceph_s3_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap2.json.gz")
         run_manifest_generation(self._make_config(test_bucket, tmp_path / "run2"))
 
         transfer = sorted(self._read_manifest(tmp_path / "run2", "transfer_manifest.txt"))
@@ -582,15 +566,15 @@ class TestSnapshotManifestRoundTripCeph:
 
     def test_holdings_newer_date_triggers_updated_manifest(
         self,
-        pdb_ceph_client: botocore.client.BaseClient,
+        ceph_s3_client: botocore.client.BaseClient,
         test_bucket: PurePosixPath,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
     ) -> None:
         """Records whose holdings last-modified date is newer than the snapshot appear in updated_manifest."""
         ids = ["pdb_00001abc", "pdb_00001def"]
-        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, ids)
-        self._build_and_upload_snapshot(pdb_ceph_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap.json.gz")
+        _seed_fake_pdb_objects(ceph_s3_client, test_bucket, ids)
+        self._build_and_upload_snapshot(ceph_s3_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap.json.gz")
 
         # pdb_00001abc has a newer date in holdings: should appear in updated
         # pdb_00001def has the same date as the snapshot: should not appear in updated
@@ -610,7 +594,7 @@ class TestSnapshotManifestRoundTripCeph:
 
     def test_id_absent_from_holdings_appears_in_removed_manifest(
         self,
-        pdb_ceph_client: botocore.client.BaseClient,
+        ceph_s3_client: botocore.client.BaseClient,
         test_bucket: PurePosixPath,
         tmp_path: Path,
         monkeypatch: pytest.MonkeyPatch,
@@ -620,8 +604,8 @@ class TestSnapshotManifestRoundTripCeph:
         dropped_from_holdings = ["pdb_aaaaaaaa"]
 
         # Seed all IDs so the snapshot contains all three.
-        _seed_fake_pdb_objects(pdb_ceph_client, test_bucket, _ROUNDTRIP_IDS)
-        self._build_and_upload_snapshot(pdb_ceph_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap.json.gz")
+        _seed_fake_pdb_objects(ceph_s3_client, test_bucket, _ROUNDTRIP_IDS)
+        self._build_and_upload_snapshot(ceph_s3_client, test_bucket, self._BOOTSTRAP_DATE, tmp_path / "snap.json.gz")
 
         # Holdings no longer lists pdb_aaaaaaaa as current.
         current = {id_: PDBRecord(id=id_) for id_ in kept_in_holdings}

--- a/tests/ncbi_ftp/conftest.py
+++ b/tests/ncbi_ftp/conftest.py
@@ -11,13 +11,13 @@ import pytest
 from moto import mock_aws
 
 import cdm_data_loaders.ncbi_ftp.manifest as manifest_mod
-import cdm_data_loaders.ncbi_ftp.promote as promote_mod
-import cdm_data_loaders.utils.s3 as s3_utils
-from cdm_data_loaders.utils.s3 import CDM_LAKE_BUCKET, reset_s3_client
+from cdm_data_loaders.utils.file_transfer.s3 import client
+from cdm_data_loaders.utils.file_transfer.s3.client import reset_s3_client
 from tests.s3_helpers import strip_checksum_algorithm
+from tests.utils.file_transfer.s3.conftest import TEST_BUCKET as test_bucket_str  # noqa: N811
 
 AWS_REGION = "us-east-1"
-TEST_BUCKET: PurePosixPath = PurePosixPath(CDM_LAKE_BUCKET)
+TEST_BUCKET: PurePosixPath = PurePosixPath(test_bucket_str)
 
 
 # Minimal assembly_summary_refseq.txt content (tab-separated, 20+ columns)
@@ -73,15 +73,12 @@ def mock_s3_client(monkeypatch: pytest.MonkeyPatch) -> Generator[botocore.client
     boto3.DEFAULT_SESSION = None
 
     with mock_aws():
-        client = boto3.client("s3", region_name=AWS_REGION)
-        client.create_bucket(Bucket=str(TEST_BUCKET))
+        s3_client = boto3.client("s3", region_name=AWS_REGION)
+        s3_client.create_bucket(Bucket=str(TEST_BUCKET))
 
         reset_s3_client()
-        with (
-            patch.object(s3_utils, "get_s3_client", return_value=client),
-            patch.object(promote_mod, "get_s3_client", return_value=client),
-        ):
-            yield client
+        with patch.object(client, "get_s3_client", return_value=s3_client):
+            yield s3_client
         reset_s3_client()
 
 

--- a/tests/ncbi_ftp/test_metadata.py
+++ b/tests/ncbi_ftp/test_metadata.py
@@ -13,7 +13,6 @@ import pytest
 from moto import mock_aws
 
 import cdm_data_loaders.ncbi_ftp.metadata as metadata_mod
-import cdm_data_loaders.utils.s3 as s3_utils
 from cdm_data_loaders.ncbi_ftp.metadata import (
     DescriptorResource,
     archive_descriptor,
@@ -23,7 +22,8 @@ from cdm_data_loaders.ncbi_ftp.metadata import (
     upload_descriptor,
     validate_descriptor,
 )
-from cdm_data_loaders.utils.s3 import reset_s3_client
+from cdm_data_loaders.utils.file_transfer.s3 import client
+from cdm_data_loaders.utils.file_transfer.s3.client import reset_s3_client
 from tests.ncbi_ftp.conftest import TEST_BUCKET
 
 AWS_REGION = "us-east-1"
@@ -221,14 +221,11 @@ def mock_s3(monkeypatch: pytest.MonkeyPatch) -> Generator[botocore.client.BaseCl
     monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
     boto3.DEFAULT_SESSION = None
     with mock_aws():
-        client = boto3.client("s3", region_name=AWS_REGION)
-        client.create_bucket(Bucket=str(TEST_BUCKET))
+        s3_client = boto3.client("s3", region_name=AWS_REGION)
+        s3_client.create_bucket(Bucket=str(TEST_BUCKET))
         reset_s3_client()
-        with (
-            patch.object(s3_utils, "get_s3_client", return_value=client),
-            patch.object(metadata_mod, "get_s3_client", return_value=client),
-        ):
-            yield client
+        with patch.object(client, "get_s3_client", return_value=s3_client):
+            yield s3_client
         reset_s3_client()
 
 

--- a/tests/pipelines/test_ncbi_ftp_download.py
+++ b/tests/pipelines/test_ncbi_ftp_download.py
@@ -11,7 +11,6 @@ import pytest
 from moto import mock_aws
 from pydantic import ValidationError
 
-import cdm_data_loaders.utils.s3 as s3_mod
 from cdm_data_loaders.core.fields import INPUT_MOUNT, OUTPUT_MOUNT
 from cdm_data_loaders.ncbi_ftp.assembly import FTP_HOST
 from cdm_data_loaders.pipelines.ncbi_ftp_download import (
@@ -19,7 +18,8 @@ from cdm_data_loaders.pipelines.ncbi_ftp_download import (
     download_and_stage,
     download_batch,
 )
-from cdm_data_loaders.utils.s3 import reset_s3_client
+from cdm_data_loaders.utils.file_transfer.s3 import client
+from cdm_data_loaders.utils.file_transfer.s3.client import reset_s3_client
 from tests.conftest import _generate_dlt_config
 
 _MOCK_STATS = {
@@ -269,9 +269,9 @@ def _make_moto_s3(monkeypatch: pytest.MonkeyPatch):  # noqa: ANN202
     monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
     monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
     boto3.DEFAULT_SESSION = None
-    client = boto3.client("s3", region_name="us-east-1")
-    client.create_bucket(Bucket=f"{_TEST_BUCKET}")
-    return client
+    s3_client = boto3.client("s3", region_name="us-east-1")
+    s3_client.create_bucket(Bucket=f"{_TEST_BUCKET}")
+    return s3_client
 
 
 # download_and_stage — manifest source
@@ -293,11 +293,11 @@ def test_download_and_stage_manifest_source(
 ) -> None:
     """Assembly paths from the manifest are processed regardless of source (S3 or local)."""
     reset_s3_client()
-    s3 = _make_moto_s3(monkeypatch)
+    s3_client = _make_moto_s3(monkeypatch)
 
     manifest_local: Path | None = None
     if manifest_s3_key is not None:
-        s3.put_object(Bucket=str(_TEST_BUCKET), Key=str(manifest_s3_key), Body=_MANIFEST_CONTENT.encode())
+        s3_client.put_object(Bucket=str(_TEST_BUCKET), Key=str(manifest_s3_key), Body=_MANIFEST_CONTENT.encode())
     else:
         manifest_local = tmp_path / "manifest.txt"
         manifest_local.write_text(_MANIFEST_CONTENT)
@@ -309,9 +309,8 @@ def test_download_and_stage_manifest_source(
         return _MOCK_STATS
 
     with (
-        patch.object(s3_mod, "get_s3_client", return_value=s3),
-        patch.object(s3_mod, "_s3_client", s3),
-        patch("cdm_data_loaders.pipelines.ncbi_ftp_download.get_s3_client", return_value=s3),
+        patch.object(client, "get_s3_client", return_value=s3_client),
+        patch.object(client, "_s3_client", s3_client),
         patch("cdm_data_loaders.pipelines.ncbi_ftp_download.ThreadLocalFTP"),
         patch(
             "cdm_data_loaders.pipelines.ncbi_ftp_download.download_assembly_to_local",
@@ -365,19 +364,18 @@ def test_download_and_stage_exactly_one_source_required(
                 manifest_local_path=local_path,
             )
     else:
-        s3 = _make_moto_s3(monkeypatch)
+        s3_client = _make_moto_s3(monkeypatch)
         # For s3_only: seed the object; for local_only: create the file
         if s3_key is not None:
-            s3.put_object(Bucket=str(_TEST_BUCKET), Key=str(s3_key), Body=_MANIFEST_CONTENT.encode())
+            s3_client.put_object(Bucket=str(_TEST_BUCKET), Key=str(s3_key), Body=_MANIFEST_CONTENT.encode())
         if local_path is not None:
             real_local = tmp_path / "manifest.txt"
             real_local.write_text(_MANIFEST_CONTENT)
             local_path = real_local
 
         with (
-            patch.object(s3_mod, "get_s3_client", return_value=s3),
-            patch.object(s3_mod, "_s3_client", s3),
-            patch("cdm_data_loaders.pipelines.ncbi_ftp_download.get_s3_client", return_value=s3),
+            patch.object(client, "get_s3_client", return_value=s3_client),
+            patch.object(client, "_s3_client", s3_client),
             patch("cdm_data_loaders.pipelines.ncbi_ftp_download.ThreadLocalFTP"),
             patch(
                 "cdm_data_loaders.pipelines.ncbi_ftp_download.download_assembly_to_local",
@@ -403,7 +401,7 @@ def test_download_and_stage_exactly_one_source_required(
 def test_download_and_stage_uploads_to_staging(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Files produced by download_assembly_to_local and download_report.json are all staged to S3."""
     reset_s3_client()
-    s3 = _make_moto_s3(monkeypatch)
+    s3_client = _make_moto_s3(monkeypatch)
 
     manifest_local = tmp_path / "manifest.txt"
     # Single assembly so the fake download writes exactly the files we expect
@@ -419,9 +417,8 @@ def test_download_and_stage_uploads_to_staging(tmp_path: Path, monkeypatch: pyte
         return {**_MOCK_STATS, "files_downloaded": 2}
 
     with (
-        patch.object(s3_mod, "get_s3_client", return_value=s3),
-        patch.object(s3_mod, "_s3_client", s3),
-        patch("cdm_data_loaders.pipelines.ncbi_ftp_download.get_s3_client", return_value=s3),
+        patch.object(client, "get_s3_client", return_value=s3_client),
+        patch.object(client, "_s3_client", s3_client),
         patch("cdm_data_loaders.pipelines.ncbi_ftp_download.ThreadLocalFTP"),
         patch(
             "cdm_data_loaders.pipelines.ncbi_ftp_download.download_assembly_to_local",
@@ -436,7 +433,7 @@ def test_download_and_stage_uploads_to_staging(tmp_path: Path, monkeypatch: pyte
             threads=1,
         )
 
-    paginator = s3.get_paginator("list_objects_v2")
+    paginator = s3_client.get_paginator("list_objects_v2")
     uploaded_keys: set[PurePosixPath] = {
         PurePosixPath(obj["Key"])
         for page in paginator.paginate(Bucket=str(_TEST_BUCKET))
@@ -461,7 +458,7 @@ def test_download_and_stage_uploads_to_staging(tmp_path: Path, monkeypatch: pyte
 def test_download_and_stage_dry_run_skips_upload(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """dry_run=True leaves S3 empty and returns staged_objects=0."""
     reset_s3_client()
-    s3 = _make_moto_s3(monkeypatch)
+    s3_client = _make_moto_s3(monkeypatch)
 
     manifest_local = tmp_path / "manifest.txt"
     manifest_local.write_text(_MANIFEST_CONTENT)
@@ -473,9 +470,8 @@ def test_download_and_stage_dry_run_skips_upload(tmp_path: Path, monkeypatch: py
         return _MOCK_STATS
 
     with (
-        patch.object(s3_mod, "get_s3_client", return_value=s3),
-        patch.object(s3_mod, "_s3_client", s3),
-        patch("cdm_data_loaders.pipelines.ncbi_ftp_download.get_s3_client", return_value=s3),
+        patch.object(client, "get_s3_client", return_value=s3_client),
+        patch.object(client, "_s3_client", s3_client),
         patch("cdm_data_loaders.pipelines.ncbi_ftp_download.ThreadLocalFTP"),
         patch(
             "cdm_data_loaders.pipelines.ncbi_ftp_download.download_assembly_to_local",
@@ -490,7 +486,7 @@ def test_download_and_stage_dry_run_skips_upload(tmp_path: Path, monkeypatch: py
             threads=1,
         )
 
-    listed = s3.list_objects_v2(Bucket=str(_TEST_BUCKET))
+    listed = s3_client.list_objects_v2(Bucket=str(_TEST_BUCKET))
     assert listed.get("KeyCount", 0) == 0
     assert report["staged_objects"] == 0
     assert report["dry_run"] is True
@@ -512,15 +508,14 @@ def test_download_and_stage_dry_run_skips_upload(tmp_path: Path, monkeypatch: py
 def test_download_and_stage_limit_forwarded(tmp_path: Path, limit: int, monkeypatch: pytest.MonkeyPatch) -> None:
     """The limit parameter truncates the number of assemblies processed."""
     reset_s3_client()
-    s3 = _make_moto_s3(monkeypatch)
+    s3_client = _make_moto_s3(monkeypatch)
 
     manifest_local = tmp_path / "manifest.txt"
     manifest_local.write_text(_MANIFEST_CONTENT)
 
     with (
-        patch.object(s3_mod, "get_s3_client", return_value=s3),
-        patch.object(s3_mod, "_s3_client", s3),
-        patch("cdm_data_loaders.pipelines.ncbi_ftp_download.get_s3_client", return_value=s3),
+        patch.object(client, "get_s3_client", return_value=s3_client),
+        patch.object(client, "_s3_client", s3_client),
         patch("cdm_data_loaders.pipelines.ncbi_ftp_download.ThreadLocalFTP"),
         patch(
             "cdm_data_loaders.pipelines.ncbi_ftp_download.download_assembly_to_local",
@@ -549,15 +544,14 @@ def test_download_and_stage_limit_forwarded(tmp_path: Path, limit: int, monkeypa
 def test_download_and_stage_report_shape(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> None:
     """Return value contains all expected keys including staged_objects, staging_key_prefix, dry_run."""
     reset_s3_client()
-    s3 = _make_moto_s3(monkeypatch)
+    s3_client = _make_moto_s3(monkeypatch)
 
     manifest_local = tmp_path / "manifest.txt"
     manifest_local.write_text(_MANIFEST_CONTENT)
 
     with (
-        patch.object(s3_mod, "get_s3_client", return_value=s3),
-        patch.object(s3_mod, "_s3_client", s3),
-        patch("cdm_data_loaders.pipelines.ncbi_ftp_download.get_s3_client", return_value=s3),
+        patch.object(client, "get_s3_client", return_value=s3_client),
+        patch.object(client, "_s3_client", s3_client),
         patch("cdm_data_loaders.pipelines.ncbi_ftp_download.ThreadLocalFTP"),
         patch(
             "cdm_data_loaders.pipelines.ncbi_ftp_download.download_assembly_to_local",

--- a/tests/pipelines/test_pdb_manifest.py
+++ b/tests/pipelines/test_pdb_manifest.py
@@ -32,6 +32,7 @@ from cdm_data_loaders.pipelines.pdb_manifest import (
     _save_summary_file,
     run_manifest_generation,
 )
+from cdm_data_loaders.utils.file_transfer.s3 import client
 
 # ---------------------------------------------------------------------------
 # Shared test data
@@ -287,7 +288,7 @@ class TestGenerateSnapshotFromS3StateUnit:
     def test_empty_store_returns_empty_dict(self) -> None:
         """Empty S3 store produces an empty snapshot."""
         mock_s3 = self._build_mock_s3([[]])
-        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+        with patch.object(client, "get_s3_client", return_value=mock_s3):
             result = _generate_snapshot_from_s3_state(
                 PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
             )
@@ -300,7 +301,7 @@ class TestGenerateSnapshotFromS3StateUnit:
             "prefix/pdb_00001def/pdb_00001def_data.cif.gz",
         ]
         mock_s3 = self._build_mock_s3([keys])
-        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+        with patch.object(client, "get_s3_client", return_value=mock_s3):
             result = _generate_snapshot_from_s3_state(
                 PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
             )
@@ -314,7 +315,7 @@ class TestGenerateSnapshotFromS3StateUnit:
         ]
         mock_s3 = self._build_mock_s3([keys])
         bootstrap = date(2023, 6, 15)
-        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+        with patch.object(client, "get_s3_client", return_value=mock_s3):
             result = _generate_snapshot_from_s3_state(PurePosixPath("bucket"), PurePosixPath("prefix"), bootstrap)
         for rec in result.values():
             assert rec.last_modified == bootstrap.isoformat()
@@ -328,7 +329,7 @@ class TestGenerateSnapshotFromS3StateUnit:
             f"prefix/{pdb_id}/{pdb_id}_info.json",
         ]
         mock_s3 = self._build_mock_s3([keys])
-        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+        with patch.object(client, "get_s3_client", return_value=mock_s3):
             result = _generate_snapshot_from_s3_state(
                 PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
             )
@@ -343,7 +344,7 @@ class TestGenerateSnapshotFromS3StateUnit:
             "prefix/pdb_00001abc/model.cif.gz",  # the only valid one
         ]
         mock_s3 = self._build_mock_s3([keys])
-        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+        with patch.object(client, "get_s3_client", return_value=mock_s3):
             result = _generate_snapshot_from_s3_state(
                 PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
             )
@@ -358,7 +359,7 @@ class TestGenerateSnapshotFromS3StateUnit:
                 ["prefix/pdb_aaaaaaaa/model.cif.gz"],
             ]
         )
-        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+        with patch.object(client, "get_s3_client", return_value=mock_s3):
             result = _generate_snapshot_from_s3_state(
                 PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
             )
@@ -367,7 +368,7 @@ class TestGenerateSnapshotFromS3StateUnit:
     def test_paginator_called_with_correct_bucket_and_prefix(self) -> None:
         """list_objects_v2 paginator receives the exact bucket name and prefix."""
         mock_s3 = self._build_mock_s3([[]])
-        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+        with patch.object(client, "get_s3_client", return_value=mock_s3):
             _generate_snapshot_from_s3_state(PurePosixPath("my-bucket"), PurePosixPath("a/b/c"), date(2024, 1, 1))
         mock_s3.get_paginator.assert_called_once_with("list_objects_v2")
         mock_s3.get_paginator.return_value.paginate.assert_called_once_with(Bucket="my-bucket", Prefix="a/b/c")
@@ -380,7 +381,7 @@ class TestGenerateSnapshotFromS3StateUnit:
                 ["prefix/pdb_00001abc/model.cif.gz"],
             ]
         )
-        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+        with patch.object(client, "get_s3_client", return_value=mock_s3):
             result = _generate_snapshot_from_s3_state(
                 PurePosixPath("bucket"), PurePosixPath("prefix"), date(2024, 1, 1)
             )
@@ -412,7 +413,7 @@ class TestDownloadHoldingsSnapshotUnit:
         """A successful download returns the correctly deserialised snapshot dict."""
         mock_s3 = MagicMock()
         mock_s3.download_file.side_effect = self._writing_side_effect(self._RECORDS)
-        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+        with patch.object(client, "get_s3_client", return_value=mock_s3):
             result = _download_holdings_snapshot(PurePosixPath("bucket"), PurePosixPath("path/snapshot.json.gz"))
         assert result == self._RECORDS
 
@@ -420,7 +421,7 @@ class TestDownloadHoldingsSnapshotUnit:
         """download_file is invoked with the exact bucket and key passed to the function."""
         mock_s3 = MagicMock()
         mock_s3.download_file.side_effect = self._writing_side_effect({})
-        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+        with patch.object(client, "get_s3_client", return_value=mock_s3):
             _download_holdings_snapshot(PurePosixPath("my-bucket"), PurePosixPath("some/key.json.gz"))
         mock_s3.download_file.assert_called_once_with(Bucket="my-bucket", Key="some/key.json.gz", Filename=ANY)
 
@@ -431,7 +432,7 @@ class TestDownloadHoldingsSnapshotUnit:
             {"Error": {"Code": "NoSuchKey", "Message": "Not found"}}, "GetObject"
         )
         with (
-            patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3),
+            patch.object(client, "get_s3_client", return_value=mock_s3),
             pytest.raises(ValueError, match="not found"),
         ):
             _download_holdings_snapshot(PurePosixPath("bucket"), PurePosixPath("missing/key.json.gz"))
@@ -441,7 +442,7 @@ class TestDownloadHoldingsSnapshotUnit:
         mock_s3 = MagicMock()
         mock_s3.download_file.side_effect = ClientError({"Error": {"Code": "NoSuchKey", "Message": ""}}, "GetObject")
         with (
-            patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3),
+            patch.object(client, "get_s3_client", return_value=mock_s3),
             pytest.raises(ValueError, match="Snapshot file") as exc_info,
         ):
             _download_holdings_snapshot(PurePosixPath("my-bucket"), PurePosixPath("path/to/snap.json.gz"))
@@ -459,7 +460,7 @@ class TestDownloadHoldingsSnapshotUnit:
             captured.append(kwargs["Filename"])
 
         mock_s3.download_file.side_effect = write_and_capture
-        with patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3):
+        with patch.object(client, "get_s3_client", return_value=mock_s3):
             _download_holdings_snapshot(PurePosixPath("b"), PurePosixPath("k.json.gz"))
 
         assert captured, "download_file was never called"
@@ -478,7 +479,7 @@ class TestDownloadHoldingsSnapshotUnit:
         mock_s3 = MagicMock()
         mock_s3.download_file.side_effect = ClientError({"Error": {"Code": "NoSuchKey", "Message": ""}}, "GetObject")
         with (
-            patch.object(pdb_manifest_mod, "get_s3_client", return_value=mock_s3),
+            patch.object(client, "get_s3_client", return_value=mock_s3),
             patch("cdm_data_loaders.pipelines.pdb_manifest.tempfile.NamedTemporaryFile", side_effect=recording_ntf),
             pytest.raises(ValueError, match="not found"),
         ):

--- a/tests/utils/file_transfer/s3/conftest.py
+++ b/tests/utils/file_transfer/s3/conftest.py
@@ -1,0 +1,176 @@
+"""Tests for s3 utils.py using moto to mock AWS S3."""
+
+from collections.abc import Generator
+from pathlib import Path
+from typing import Any, Final
+from unittest.mock import patch
+
+import boto3
+import pytest
+from moto import mock_aws
+
+import cdm_data_loaders.utils.file_transfer.s3.client as s3_client
+from cdm_data_loaders.utils.file_transfer.s3.client import reset_s3_client
+from tests.s3_helpers import strip_checksum_algorithm
+
+HTTP_200: Final[int] = 200  # Status OK
+HTTP_204: Final[int] = 204  # Status no content
+
+SIZE_HELLO: Final[int] = 5
+SIZE_DATA: Final[int] = 4
+
+SAMPLE_FILES = [
+    "dir_one/file1.txt",
+    "dir_one/file2.txt",
+    "dir_one/sub_dir/file3.txt",
+    "dir_one/sub_dir/under_dir/file4.txt",
+]
+
+TEST_BUCKET: Final[str] = "test_bucket"
+ALT_BUCKET: Final[str] = "alt_bucket"
+
+FILES_IN_BUCKETS = {
+    TEST_BUCKET: SAMPLE_FILES,
+    ALT_BUCKET: ["dir_one/file1.txt"],
+}
+BUCKETS = [TEST_BUCKET, ALT_BUCKET]
+
+
+# CLI helper function tests
+
+NO_PATH_FOUND: Final[str] = "No path found"
+START_WITH_BUCKET_NAME: Final[str] = "s3 paths must start with the bucket name"
+COULD_NOT_PARSE: Final[str] = "Could not parse out bucket and key"
+
+TEST_PROTOCOLS = [
+    "",
+    "s3://",
+    "s3a://",
+]
+
+TEST_MB_PARAMS = [
+    pytest.param("one-bucket", "one-bucket", id="name only"),
+    pytest.param("two-bucket/", "two-bucket", id="trailing slash"),
+    pytest.param("red-bucket/key", "red-bucket", id="red-bucket"),
+    pytest.param("blue-bucket/foo/bar.txt", "blue-bucket", id="blue-bucket"),
+]
+
+ERROR_MB_USAGE: Final[str] = "Usage: s3_local.py mb s3://BUCKET"
+
+TEST_MB_ARGS_ERROR = [
+    pytest.param([], ERROR_MB_USAGE, id="no args"),
+    pytest.param(["foo", "bar"], ERROR_MB_USAGE, id="two args"),
+    pytest.param(["foo", "bar", "baz"], ERROR_MB_USAGE, id="three args"),
+    pytest.param([""], NO_PATH_FOUND, id="missing bucket"),
+    pytest.param(["/bucket"], START_WITH_BUCKET_NAME, id="preceding slash"),
+    pytest.param(["/"], START_WITH_BUCKET_NAME, id="root"),
+]
+
+
+@pytest.fixture
+def mock_s3_client(monkeypatch: pytest.MonkeyPatch) -> Generator[Any, Any]:
+    """Yield a mocked S3 client with both valid buckets created.
+
+    The function get_s3_client() is patched to ensure that all module functions use this client.
+
+    Resets the cached client before and after to prevent state leaking between tests.
+    """
+    # Remove any real endpoint/credential env vars so moto intercepts all HTTP calls.
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+    boto3.DEFAULT_SESSION = None
+
+    with mock_aws():
+        reset_s3_client()
+        client = boto3.client("s3")
+        for bucket in FILES_IN_BUCKETS:
+            client.create_bucket(Bucket=bucket)
+
+        # delete any existing client
+        reset_s3_client()
+        assert s3_client._s3_client is None  # noqa: SLF001
+
+        # patch in the client that we have just created
+        with patch.object(s3_client, "get_s3_client", return_value=client):
+            yield client
+
+        reset_s3_client()
+        assert s3_client._s3_client is None  # noqa: SLF001
+
+
+@pytest.fixture
+def mocked_s3_client_no_checksum(mock_s3_client: Any) -> Any:
+    """Yield the mocked S3 client with copy_object patched to strip ChecksumAlgorithm.
+
+    This works around the moto limitation of not supporting CRC64NVME checksums,
+    allowing copy_object calls that include ChecksumAlgorithm to succeed.
+    """
+    mock_s3_client.copy_object = strip_checksum_algorithm(mock_s3_client.copy_object)
+    return mock_s3_client
+
+
+@pytest.fixture
+def sample_file(tmp_path: Path) -> Path:
+    """Create a small temporary file for upload tests."""
+    f = tmp_path / "sample.txt"
+    f.write_text("hello s3")
+    return f
+
+
+@pytest.fixture
+def sample_dir(tmp_path: Path) -> Path:
+    """Create a small temporary directory tree for upload_dir tests.
+
+    Structure (same as TEST_BUCKET files)
+
+    dir_one/file1.txt
+    dir_one/file2.txt
+    dir_one/sub_dir/file3.txt
+    dir_one/sub_dir/under_dir/file4.txt
+    """
+    sample_dir = tmp_path / "sample_dir"
+    for f in SAMPLE_FILES:
+        new_file = sample_dir / f
+        # ensure the parent dir exists
+        new_file.parent.mkdir(parents=True, exist_ok=True)
+        # add the (relative) path as the content
+        new_file.write_text(f)
+    return sample_dir
+
+
+def populate_mock_s3(client: Any, file_list_by_bucket: dict[str, list[str]]) -> None:
+    """Populate buckets with a list of files.
+
+    File names should be a list, indexed by bucket.
+
+    Files will be populated with the file name as bytes if the top level directory is `dir_one`;
+    otherwise, the content will just be `x`.
+
+    :param client: s3 client
+    :type client: Any
+    :param file_list: list of files, indexed by bucket
+    :type file_list: dict[str, list[str]]
+    """
+    for bucket, file_list in file_list_by_bucket.items():
+        for file in file_list:
+            full_path = f"{bucket}/{file}"
+            if file.startswith("dir_one"):
+                client.put_object(Bucket=bucket, Key=file, Body=full_path.encode("utf-8"))
+            else:
+                client.put_object(Bucket=bucket, Key=file, Body=b"x")
+            # if this errors, the transfer was not successful
+            client.head_object(Bucket=bucket, Key=file)
+
+
+def prep_client_init(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set up environment variables to allow get_s3_client to initialize without error."""
+    reset_s3_client()
+    assert s3_client._s3_client is None  # noqa: SLF001
+    # set up env vars to ensure that the argument takes precedence
+    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://env-endpoint.com")
+    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "aws_access_key_id_env_var")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key_env_var")

--- a/tests/utils/file_transfer/s3/test_client.py
+++ b/tests/utils/file_transfer/s3/test_client.py
@@ -1,0 +1,273 @@
+"""Tests for S3 client creation and caching using moto to mock AWS S3."""
+
+import re
+
+import pytest
+from botocore.exceptions import PartialCredentialsError
+from moto import mock_aws
+
+from cdm_data_loaders.utils.file_transfer.s3 import client
+from cdm_data_loaders.utils.file_transfer.s3.client import (
+    get_s3_client,
+    reset_s3_client,
+)
+from tests.utils.file_transfer.s3.conftest import prep_client_init
+
+
+# Client creation / reset
+@mock_aws
+@pytest.mark.s3
+@pytest.mark.parametrize("endpoint_url", ["http://localhost", None])
+def test_get_s3_client_success_via_args(endpoint_url: str | None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that get_s3_client creates a client with the correct credentials and endpoint URL using args for the creds."""
+    prep_client_init(monkeypatch)
+
+    args = {
+        "aws_access_key_id": "aws_access_key_id_argument",
+        "aws_secret_access_key": "aws_secret_access_key_argument",
+        "endpoint_url": endpoint_url,
+    }
+
+    s3_client = get_s3_client(args)
+    assert s3_client is not None
+    credentials = s3_client._request_signer._credentials  # noqa: SLF001
+    assert credentials.access_key == "aws_access_key_id_argument"
+    assert credentials.secret_key == "aws_secret_access_key_argument"  # noqa: S105
+    expected_endpoint = endpoint_url or "http://env-endpoint.com"
+    assert s3_client.meta.endpoint_url == expected_endpoint
+
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+
+@mock_aws
+@pytest.mark.s3
+@pytest.mark.parametrize("endpoint_url", ["http://localhost", None])
+def test_get_s3_client_success_via_env(endpoint_url: str | None, monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that get_s3_client creates a client with the correct credentials and endpoint URL using env vars for the creds."""
+    prep_client_init(monkeypatch)
+
+    args = {
+        "endpoint_url": endpoint_url,
+    }
+
+    s3_client = get_s3_client(args)
+    assert s3_client is not None
+    credentials = s3_client._request_signer._credentials  # noqa: SLF001
+    assert credentials.access_key == "aws_access_key_id_env_var"
+    assert credentials.secret_key == "aws_secret_access_key_env_var"  # noqa: S105
+    expected_endpoint = endpoint_url or "http://env-endpoint.com"
+    assert s3_client.meta.endpoint_url == expected_endpoint
+
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+
+@mock_aws
+@pytest.mark.s3
+@pytest.mark.parametrize(
+    ("aws_access_key_id", "aws_secret_access_key"), [("aws_access_key_id", None), (None, "aws_secret_access_key")]
+)
+def test_get_s3_client_incomplete_creds_via_args(
+    aws_access_key_id: str | None, aws_secret_access_key: str | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that get_s3_client raises ValueError when only one of aws_access_key_id or aws_secret_access_key is provided via arguments."""
+    prep_client_init(monkeypatch)
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+    args = {
+        "aws_access_key_id": aws_access_key_id,
+        "aws_secret_access_key": aws_secret_access_key,
+    }
+    with pytest.raises(
+        ValueError,
+        match="Cannot initialise s3 client: aws_access_key_id and aws_secret_access_key must be provided together",
+    ):
+        get_s3_client(args)
+    assert client._s3_client is None  # noqa: SLF001
+
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+
+@mock_aws
+@pytest.mark.s3
+@pytest.mark.parametrize(
+    ("aws_access_key_id", "aws_secret_access_key", "error_type", "error_msg"),
+    [
+        (
+            "aws_access_key_id",
+            None,
+            PartialCredentialsError,
+            "Partial credentials found in env, missing: AWS_SECRET_ACCESS_KEY",
+        ),
+        (None, "aws_secret_access_key", ValueError, "missing configuration values: aws_access_key_id"),
+        (None, None, ValueError, "missing configuration values: aws_access_key_id, aws_secret_access_key"),
+    ],
+)
+def test_get_s3_client_incomplete_creds_via_env(
+    aws_access_key_id: str | None,
+    aws_secret_access_key: str | None,
+    error_type: type[Exception],
+    error_msg: str,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Verify that get_s3_client raises ValueError when only one of aws_access_key_id or aws_secret_access_key is provided."""
+    prep_client_init(monkeypatch)
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+    args = {
+        "aws_access_key_id": aws_access_key_id,
+        "aws_secret_access_key": aws_secret_access_key,
+    }
+    for key, value in args.items():
+        if value:
+            monkeypatch.setenv(key.upper(), value)
+        else:
+            monkeypatch.delenv(key.upper(), raising=False)
+    # ensure that the AWS config file cannot accidentally be used to provide creds
+    monkeypatch.setenv("AWS_CONFIG_FILE", "/dev/null")
+
+    with pytest.raises(
+        error_type,
+        match=error_msg,
+    ):
+        get_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+
+@mock_aws
+@pytest.mark.s3
+def test_get_s3_client_retry_configuration(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that the S3 client is configured with the expected retry mode and max attempts."""
+    prep_client_init(monkeypatch)
+
+    s3_client = get_s3_client()
+    retries_config = s3_client.meta.config.retries
+
+    assert retries_config["mode"] == s3_client.AWS_CLIENT_RETRY_MODE
+    assert retries_config["total_max_attempts"] == s3_client.AWS_CLIENT_TOTAL_MAX_ATTEMPTS
+
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+
+@mock_aws
+@pytest.mark.s3
+def test_get_s3_client_ignores_unknown_args(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that unknown/unsupported keys in args are silently ignored on first (uncached) client creation."""
+    prep_client_init(monkeypatch)
+
+    args = {
+        "aws_access_key_id": "valid_key",
+        "aws_secret_access_key": "valid_secret",
+        "unexpected_key": "should_be_ignored",
+        # region_name is a legitimate boto3.client kwarg, but is NOT in the module's
+        # allow-list, so it must be dropped rather than passed through to boto3.client()
+        "region_name": "us-west-2",
+    }
+
+    s3_client = get_s3_client(args)  # type: ignore[reportArgumentType]
+    assert s3_client is not None
+
+    credentials = s3_client._request_signer._credentials  # noqa: SLF001
+    assert credentials.access_key == "valid_key"
+    assert credentials.secret_key == "valid_secret"  # noqa: S105
+    # endpoint_url was not in args, so it should fall back to the env var
+    assert s3_client.meta.endpoint_url == "http://env-endpoint.com"
+
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+
+@mock_aws
+@pytest.mark.s3
+def test_get_s3_client_default_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Verify that get_s3_client falls back to the default AWS endpoint when none is configured via args or env."""
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "aws_access_key_id_env_var")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key_env_var")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+
+    s3_client = get_s3_client()
+    assert s3_client is not None
+    assert "env-endpoint.com" not in s3_client.meta.endpoint_url
+    assert re.search(r"amazonaws\.com", s3_client.meta.endpoint_url)
+
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+
+@mock_aws
+@pytest.mark.s3
+@pytest.mark.parametrize("args", [None, {}], ids=["none", "empty_dict"])
+def test_get_s3_client_no_args_variants_are_equivalent(
+    args: dict[str, str | None] | None, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Verify that get_s3_client(None) and get_s3_client({}) both behave like get_s3_client() with no args."""
+    prep_client_init(monkeypatch)
+
+    s3_client = get_s3_client(args)
+    assert s3_client is not None
+
+    credentials = s3_client._request_signer._credentials  # noqa: SLF001
+    assert credentials.access_key == "aws_access_key_id_env_var"
+    assert credentials.secret_key == "aws_secret_access_key_env_var"  # noqa: S105
+    assert s3_client.meta.endpoint_url == "http://env-endpoint.com"
+
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+
+@pytest.mark.s3
+def test_reset_s3_client_idempotent() -> None:
+    """Verify that reset_s3_client is safe to call repeatedly, including when no client has ever been created."""
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+    # calling again with nothing to reset should not raise
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+
+@mock_aws
+@pytest.mark.s3
+def test_get_s3_client_returns_same_instance() -> None:
+    """Verify that repeated calls to get_s3_client return the exact same cached client instance."""
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+
+    args = {
+        "endpoint_url": "http://localhost:9000",
+        "aws_access_key_id": "key",
+        "aws_secret_access_key": "secret",
+    }
+    client_a = get_s3_client(args)  # type: ignore[reportArgumentType]
+    assert client._s3_client is not None  # noqa: SLF001
+    # call again with no args - should return the stored version
+    client_b = get_s3_client()
+    assert client_a is client_b
+    # call again with invalid args - should return the stored version, ignoring args
+    client_c = get_s3_client(args={"this": "that", "pip": "pop"})
+    assert client_c == client_a
+    # reset the client and call
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001
+    client_d = get_s3_client(
+        {
+            "endpoint_url": "http://localhost:9000",
+            "aws_access_key_id": "not a key",
+            "aws_secret_access_key": "not a secret",
+        }
+    )
+    assert client_d != client_a
+
+    reset_s3_client()
+    assert client._s3_client is None  # noqa: SLF001

--- a/tests/utils/file_transfer/s3/test_client.py
+++ b/tests/utils/file_transfer/s3/test_client.py
@@ -148,8 +148,8 @@ def test_get_s3_client_retry_configuration(monkeypatch: pytest.MonkeyPatch) -> N
     s3_client = get_s3_client()
     retries_config = s3_client.meta.config.retries
 
-    assert retries_config["mode"] == s3_client.AWS_CLIENT_RETRY_MODE
-    assert retries_config["total_max_attempts"] == s3_client.AWS_CLIENT_TOTAL_MAX_ATTEMPTS
+    assert retries_config["mode"] == client.AWS_CLIENT_RETRY_MODE
+    assert retries_config["total_max_attempts"] == client.AWS_CLIENT_TOTAL_MAX_ATTEMPTS
 
     reset_s3_client()
     assert client._s3_client is None  # noqa: SLF001

--- a/tests/utils/file_transfer/s3/test_object_utils.py
+++ b/tests/utils/file_transfer/s3/test_object_utils.py
@@ -694,7 +694,10 @@ def test_copy_directory_copy_within_same_bucket(mock_s3_client: Any) -> None:
 
     successes, errors = copy_directory(f"s3://{TEST_BUCKET}/foo", f"s3://{TEST_BUCKET}/bar")
 
-    assert successes == {"cdm-lake/foo/a.txt": "cdm-lake/bar/a.txt", "cdm-lake/foo/b.txt": "cdm-lake/bar/b.txt"}
+    assert successes == {
+        f"{TEST_BUCKET}/foo/a.txt": f"{TEST_BUCKET}/bar/a.txt",
+        f"{TEST_BUCKET}/foo/b.txt": f"{TEST_BUCKET}/bar/b.txt",
+    }
     assert errors == {}
     assert list_keys(mock_s3_client, TEST_BUCKET, prefix="bar") == {"bar/a.txt", "bar/b.txt"}
     assert list_keys(mock_s3_client, TEST_BUCKET) == {"foo/a.txt", "foo/b.txt", "bar/a.txt", "bar/b.txt"}
@@ -866,7 +869,7 @@ def test_copy_object_preserves_user_metadata(mocked_s3_client_no_checksum: Any, 
         f"{TEST_BUCKET}/src/file.txt",
         f"{destination}/archive/file.txt",
     )
-    assert response["ResponseMetadata"]["HTTPStatusCode"] == HTTP_STATUS_OK
+    assert response["ResponseMetadata"]["HTTPStatusCode"] == HTTP_200
 
     # source user metadata is preserved (MetadataDirective=COPY)
     resp = mocked_s3_client_no_checksum.head_object(Bucket=destination, Key="archive/file.txt")

--- a/tests/utils/file_transfer/s3/test_object_utils.py
+++ b/tests/utils/file_transfer/s3/test_object_utils.py
@@ -1,24 +1,19 @@
-"""Tests for s3_utils.py using moto to mock AWS S3."""
+"""Tests for s3_object utils.py using moto to mock AWS S3."""
 
 import io
 import json
 import logging
 import re
-from collections.abc import Generator
 from pathlib import Path
 from typing import Any
 from unittest.mock import MagicMock, call, patch
 
-import boto3
 import pytest
-from botocore.exceptions import ClientError, PartialCredentialsError
-from moto import mock_aws
+from botocore.exceptions import ClientError
 from requests.exceptions import ConnectionError as ConnError
 from requests.exceptions import HTTPError
 
-import cdm_data_loaders.utils.s3 as s3_utils
-from cdm_data_loaders.utils.s3 import (
-    CDM_LAKE_BUCKET,
+from cdm_data_loaders.utils.file_transfer.s3.object_utils import (
     DEFAULT_EXTRA_ARGS,
     cmd_cp,
     cmd_head,
@@ -29,300 +24,27 @@ from cdm_data_loaders.utils.s3 import (
     delete_object,
     delete_objects,
     download_file,
-    get_s3_client,
     head_object,
     list_matching_objects,
     object_exists,
-    reset_s3_client,
     split_s3_path,
     stream_to_s3,
     upload_dir,
     upload_file,
 )
 from tests.s3_helpers import strip_checksum_algorithm
-
-HTTP_200 = 200
-HTTP_204 = 204
-
-SAMPLE_FILES = [
-    "dir_one/file1.txt",
-    "dir_one/file2.txt",
-    "dir_one/sub_dir/file3.txt",
-    "dir_one/sub_dir/under_dir/file4.txt",
-]
-
-ALT_BUCKET = "cts"  # second valid bucket from VALID_BUCKETS
-
-FILES_IN_BUCKETS = {
-    CDM_LAKE_BUCKET: SAMPLE_FILES,
-    ALT_BUCKET: ["dir_one/file1.txt"],
-}
-BUCKETS = [CDM_LAKE_BUCKET, ALT_BUCKET]
-
-HTTP_STATUS_OK = 200
-HTTP_STATUS_NO_CONTENT = 204
-SIZE_HELLO = 5
-SIZE_DATA = 4
-
-
-@pytest.fixture
-def mock_s3_client(monkeypatch: pytest.MonkeyPatch) -> Generator[Any, Any]:
-    """Yield a mocked S3 client with both valid buckets created.
-
-    The function get_s3_client() is patched to ensure that all module functions use this client.
-
-    Resets the cached client before and after to prevent state leaking between tests.
-    """
-    # Remove any real endpoint/credential env vars so moto intercepts all HTTP calls.
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
-    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
-    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
-    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
-    boto3.DEFAULT_SESSION = None
-
-    with mock_aws():
-        reset_s3_client()
-        client = boto3.client("s3")
-        for bucket in FILES_IN_BUCKETS:
-            client.create_bucket(Bucket=bucket)
-
-        # delete any existing client
-        reset_s3_client()
-        assert s3_utils._s3_client is None  # noqa: SLF001
-
-        # patch in the client that we have just created
-        with patch.object(s3_utils, "get_s3_client", return_value=client):
-            yield client
-
-        reset_s3_client()
-        assert s3_utils._s3_client is None  # noqa: SLF001
-
-
-@pytest.fixture
-def sample_file(tmp_path: Path) -> Path:
-    """Create a small temporary file for upload tests."""
-    f = tmp_path / "sample.txt"
-    f.write_text("hello s3")
-    return f
-
-
-@pytest.fixture
-def sample_dir(tmp_path: Path) -> Path:
-    """Create a small temporary directory tree for upload_dir tests.
-
-    Structure (same as CDM_LAKE_BUCKET files)
-
-    dir_one/file1.txt
-    dir_one/file2.txt
-    dir_one/sub_dir/file3.txt
-    dir_one/sub_dir/under_dir/file4.txt
-    """
-    sample_dir = tmp_path / "sample_dir"
-    for f in SAMPLE_FILES:
-        new_file = sample_dir / f
-        # ensure the parent dir exists
-        new_file.parent.mkdir(parents=True, exist_ok=True)
-        # add the (relative) path as the content
-        new_file.write_text(f)
-    return sample_dir
-
-
-def populate_mock_s3(client: Any, file_list_by_bucket: dict[str, list[str]]) -> None:
-    """Populate buckets with a list of files.
-
-    File names should be a list, indexed by bucket.
-
-    Files will be populated with the file name as bytes if the top level directory is `dir_one`;
-    otherwise, the content will just be `x`.
-
-    :param client: s3 client
-    :type client: Any
-    :param file_list: list of files, indexed by bucket
-    :type file_list: dict[str, list[str]]
-    """
-    for bucket, file_list in file_list_by_bucket.items():
-        for file in file_list:
-            full_path = f"{bucket}/{file}"
-            if file.startswith("dir_one"):
-                client.put_object(Bucket=bucket, Key=file, Body=full_path.encode("utf-8"))
-            else:
-                client.put_object(Bucket=bucket, Key=file, Body=b"x")
-            # if this errors, the transfer was not successful
-            client.head_object(Bucket=bucket, Key=file)
-
-
-def prep_client_init(monkeypatch: pytest.MonkeyPatch) -> None:
-    """Set up environment variables to allow get_s3_client to initialize without error."""
-    reset_s3_client()
-    assert s3_utils._s3_client is None  # noqa: SLF001
-    # set up env vars to ensure that the argument takes precedence
-    monkeypatch.setenv("AWS_ENDPOINT_URL", "http://env-endpoint.com")
-    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "aws_access_key_id_env_var")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "aws_secret_access_key_env_var")
-
-
-# Client creation / reset
-@mock_aws
-@pytest.mark.s3
-@pytest.mark.parametrize("endpoint_url", ["http://localhost", None])
-def test_get_s3_client_success_via_args(endpoint_url: str | None, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verify that get_s3_client creates a client with the correct credentials and endpoint URL using args for the creds."""
-    prep_client_init(monkeypatch)
-
-    args = {
-        "aws_access_key_id": "aws_access_key_id_argument",
-        "aws_secret_access_key": "aws_secret_access_key_argument",
-        "endpoint_url": endpoint_url,
-    }
-
-    client = get_s3_client(args)
-    assert client is not None
-    credentials = client._request_signer._credentials  # noqa: SLF001
-    assert credentials.access_key == "aws_access_key_id_argument"
-    assert credentials.secret_key == "aws_secret_access_key_argument"  # noqa: S105
-    expected_endpoint = endpoint_url or "http://env-endpoint.com"
-    assert client.meta.endpoint_url == expected_endpoint
-
-    reset_s3_client()
-    assert s3_utils._s3_client is None  # noqa: SLF001
-
-
-@mock_aws
-@pytest.mark.s3
-@pytest.mark.parametrize("endpoint_url", ["http://localhost", None])
-def test_get_s3_client_success_via_env(endpoint_url: str | None, monkeypatch: pytest.MonkeyPatch) -> None:
-    """Verify that get_s3_client creates a client with the correct credentials and endpoint URL using env vars for the creds."""
-    prep_client_init(monkeypatch)
-
-    args = {
-        "endpoint_url": endpoint_url,
-    }
-
-    client = get_s3_client(args)
-    assert client is not None
-    credentials = client._request_signer._credentials  # noqa: SLF001
-    assert credentials.access_key == "aws_access_key_id_env_var"
-    assert credentials.secret_key == "aws_secret_access_key_env_var"  # noqa: S105
-    expected_endpoint = endpoint_url or "http://env-endpoint.com"
-    assert client.meta.endpoint_url == expected_endpoint
-
-    reset_s3_client()
-    assert s3_utils._s3_client is None  # noqa: SLF001
-
-
-@mock_aws
-@pytest.mark.s3
-@pytest.mark.parametrize(
-    ("aws_access_key_id", "aws_secret_access_key"), [("aws_access_key_id", None), (None, "aws_secret_access_key")]
+from tests.utils.file_transfer.s3.conftest import (
+    ALT_BUCKET,
+    BUCKETS,
+    FILES_IN_BUCKETS,
+    HTTP_200,
+    HTTP_204,
+    SAMPLE_FILES,
+    SIZE_DATA,
+    SIZE_HELLO,
+    TEST_BUCKET,
+    populate_mock_s3,
 )
-def test_get_s3_client_incomplete_creds_via_args(
-    aws_access_key_id: str | None, aws_secret_access_key: str | None, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    """Verify that get_s3_client raises ValueError when only one of aws_access_key_id or aws_secret_access_key is provided via arguments."""
-    prep_client_init(monkeypatch)
-    reset_s3_client()
-    assert s3_utils._s3_client is None  # noqa: SLF001
-    args = {
-        "aws_access_key_id": aws_access_key_id,
-        "aws_secret_access_key": aws_secret_access_key,
-    }
-    with pytest.raises(
-        ValueError,
-        match="Cannot initialise s3 client: aws_access_key_id and aws_secret_access_key must be provided together",
-    ):
-        get_s3_client(args)
-    assert s3_utils._s3_client is None  # noqa: SLF001
-
-    reset_s3_client()
-    assert s3_utils._s3_client is None  # noqa: SLF001
-
-
-@mock_aws
-@pytest.mark.s3
-@pytest.mark.parametrize(
-    ("aws_access_key_id", "aws_secret_access_key", "error_type", "error_msg"),
-    [
-        (
-            "aws_access_key_id",
-            None,
-            PartialCredentialsError,
-            "Partial credentials found in env, missing: AWS_SECRET_ACCESS_KEY",
-        ),
-        (None, "aws_secret_access_key", ValueError, "missing configuration values: aws_access_key_id"),
-        (None, None, ValueError, "missing configuration values: aws_access_key_id, aws_secret_access_key"),
-    ],
-)
-def test_get_s3_client_incomplete_creds_via_env(
-    aws_access_key_id: str | None,
-    aws_secret_access_key: str | None,
-    error_type: type[Exception],
-    error_msg: str,
-    monkeypatch: pytest.MonkeyPatch,
-) -> None:
-    """Verify that get_s3_client raises ValueError when only one of aws_access_key_id or aws_secret_access_key is provided."""
-    prep_client_init(monkeypatch)
-    reset_s3_client()
-    assert s3_utils._s3_client is None  # noqa: SLF001
-    args = {
-        "aws_access_key_id": aws_access_key_id,
-        "aws_secret_access_key": aws_secret_access_key,
-    }
-    for key, value in args.items():
-        if value:
-            monkeypatch.setenv(key.upper(), value)
-        else:
-            monkeypatch.delenv(key.upper(), raising=False)
-    # ensure that the AWS config file cannot accidentally be used to provide creds
-    monkeypatch.setenv("AWS_CONFIG_FILE", "/dev/null")
-
-    with pytest.raises(
-        error_type,
-        match=error_msg,
-    ):
-        get_s3_client()
-    assert s3_utils._s3_client is None  # noqa: SLF001
-
-    reset_s3_client()
-    assert s3_utils._s3_client is None  # noqa: SLF001
-
-
-@mock_aws
-@pytest.mark.s3
-def test_get_s3_client_returns_same_instance() -> None:
-    """Verify that repeated calls to get_s3_client return the exact same cached client instance."""
-    reset_s3_client()
-    assert s3_utils._s3_client is None  # noqa: SLF001
-
-    args = {
-        "endpoint_url": "http://localhost:9000",
-        "aws_access_key_id": "key",
-        "aws_secret_access_key": "secret",
-    }
-    client_a = get_s3_client(args)  # type: ignore[reportArgumentType]
-    assert s3_utils._s3_client is not None  # noqa: SLF001
-    # call again with no args - should return the stored version
-    client_b = get_s3_client()
-    assert client_a is client_b
-    # call again with invalid args - should return the stored version, ignoring args
-    client_c = get_s3_client(args={"this": "that", "pip": "pop"})
-    assert client_c == client_a
-    # reset the client and call
-    reset_s3_client()
-    assert s3_utils._s3_client is None  # noqa: SLF001
-    client_d = get_s3_client(
-        {
-            "endpoint_url": "http://localhost:9000",
-            "aws_access_key_id": "not a key",
-            "aws_secret_access_key": "not a secret",
-        }
-    )
-    assert client_d != client_a
-
-    reset_s3_client()
-    assert s3_utils._s3_client is None  # noqa: SLF001
-
 
 # split_s3_path
 PATH = "path"
@@ -443,7 +165,7 @@ def test_list_matching_objects_filters_by_prefix(
     dir_path: str,
 ) -> None:
     """Check that more specific queries, including those that have 'incomplete' dir/file names, return correct results."""
-    bucket = CDM_LAKE_BUCKET
+    bucket = TEST_BUCKET
     populate_mock_s3(mock_s3_client, {bucket: FILES_IN_BUCKETS[bucket]})
     contents = list_matching_objects(f"{bucket}/{dir_path}")
     keys = {obj["Key"] for obj in contents}
@@ -470,16 +192,16 @@ DIR_TWO_FILES = [f"dir_two/file_{i:04d}.txt" for i in range(N_FILES)]
 DIRTY_DATA = [f"dirty_data/file_{i:04d}.txt" for i in range(N_FILES)]
 # pagination tests (1005 objects each, to exceed the 1000-item S3 page limit)
 LOTS_OF_FILES = {
-    CDM_LAKE_BUCKET: [
+    TEST_BUCKET: [
         *DIR_TWO_FILES,
         *DIRTY_DATA,
     ]
 }
 
 EXPECTED_FILE_LIST = {
-    "di": [*FILES_IN_BUCKETS[CDM_LAKE_BUCKET], *LOTS_OF_FILES[CDM_LAKE_BUCKET]],
-    "dir": [*FILES_IN_BUCKETS[CDM_LAKE_BUCKET], *LOTS_OF_FILES[CDM_LAKE_BUCKET]],
-    "dir_": [*FILES_IN_BUCKETS[CDM_LAKE_BUCKET], *DIR_TWO_FILES],
+    "di": [*FILES_IN_BUCKETS[TEST_BUCKET], *LOTS_OF_FILES[TEST_BUCKET]],
+    "dir": [*FILES_IN_BUCKETS[TEST_BUCKET], *LOTS_OF_FILES[TEST_BUCKET]],
+    "dir_": [*FILES_IN_BUCKETS[TEST_BUCKET], *DIR_TWO_FILES],
     "dirty_data": DIRTY_DATA,
 }
 
@@ -493,10 +215,10 @@ def test_list_matching_objects_returns_more_than_1000_entries(
 ) -> None:
     """Verify that pagination is followed so that more than 1000 objects are returned."""
     populate_mock_s3(mock_s3_client, FILES_IN_BUCKETS)
-    # this adds two extra dirs to CDM_LAKE_BUCKET with 1005 files in each
+    # this adds two extra dirs to TEST_BUCKET with 1005 files in each
     populate_mock_s3(mock_s3_client, LOTS_OF_FILES)
 
-    contents = list_matching_objects(f"{CDM_LAKE_BUCKET}/{dir_path}")
+    contents = list_matching_objects(f"{TEST_BUCKET}/{dir_path}")
     keys = {obj["Key"] for obj in contents}
     assert keys == set(EXPECTED_FILE_LIST[dir_path])
 
@@ -548,20 +270,20 @@ def test_upload_file_succeeds(
 @pytest.mark.s3
 def test_upload_file_uses_custom_object_name(mock_s3_client: Any, sample_file: Path) -> None:
     """Verify that the object_name argument overrides the source filename as the S3 key."""
-    result = upload_file(sample_file, f"{CDM_LAKE_BUCKET}/uploads", object_name="custom.txt")
+    result = upload_file(sample_file, f"{TEST_BUCKET}/uploads", object_name="custom.txt")
     assert result is True
-    obj = mock_s3_client.get_object(Bucket=CDM_LAKE_BUCKET, Key="uploads/custom.txt")
+    obj = mock_s3_client.get_object(Bucket=TEST_BUCKET, Key="uploads/custom.txt")
     assert obj["Body"].read() == b"hello s3"
 
 
 @pytest.mark.s3
 def test_upload_file_skips_when_already_present(mock_s3_client: Any, sample_file: Path) -> None:
     """Verify that uploading a file that already exists is skipped, returns True, and leaves the object unchanged."""
-    mock_s3_client.put_object(Bucket=CDM_LAKE_BUCKET, Key=f"uploads/{sample_file.name}", Body=b"old")
-    result = upload_file(sample_file, f"{CDM_LAKE_BUCKET}/uploads")
+    mock_s3_client.put_object(Bucket=TEST_BUCKET, Key=f"uploads/{sample_file.name}", Body=b"old")
+    result = upload_file(sample_file, f"{TEST_BUCKET}/uploads")
     assert result is True
     # The existing object must not have been overwritten
-    obj = mock_s3_client.get_object(Bucket=CDM_LAKE_BUCKET, Key=f"uploads/{sample_file.name}")
+    obj = mock_s3_client.get_object(Bucket=TEST_BUCKET, Key=f"uploads/{sample_file.name}")
     assert obj["Body"].read() == b"old"
 
 
@@ -570,7 +292,7 @@ def test_upload_file_skips_when_already_present(mock_s3_client: Any, sample_file
 @pytest.mark.s3
 def test_upload_file_accepts_str_and_path(sample_file: Path, path_type: type[str] | type[Path]) -> None:
     """Verify that upload_file accepts both str and Path objects for the local file path."""
-    result = upload_file(path_type(sample_file), f"{CDM_LAKE_BUCKET}/uploads")
+    result = upload_file(path_type(sample_file), f"{TEST_BUCKET}/uploads")
     assert result is True
 
 
@@ -810,7 +532,7 @@ def test_download_file_does_not_exist(tmp_path: Path, caplog: pytest.LogCaptureF
 
 
 # upload_dir
-@pytest.mark.parametrize("bucket", [CDM_LAKE_BUCKET, ALT_BUCKET])
+@pytest.mark.parametrize("bucket", [TEST_BUCKET, ALT_BUCKET])
 @pytest.mark.s3
 def test_upload_dir_uploads_recursively(mock_s3_client: Any, bucket: str, sample_dir: Path) -> None:
     """Verify that upload_dir recurses into subdirectories and uploads nested files."""
@@ -826,7 +548,7 @@ def test_upload_dir_accepts_str_and_path(
     mock_s3_client: Any, sample_dir: Path, path_type: type[str] | type[Path]
 ) -> None:
     """Verify that upload_dir accepts both str and Path objects for the local directory path."""
-    bucket = CDM_LAKE_BUCKET
+    bucket = TEST_BUCKET
     result = upload_dir(path_type(sample_dir), f"{bucket}/remote")
     assert result is True
     keys = {obj["Key"] for obj in mock_s3_client.list_objects_v2(Bucket=bucket)["Contents"]}
@@ -838,7 +560,7 @@ def test_upload_dir_accepts_str_and_path(
 def test_upload_dir_raises_on_empty_source() -> None:
     """Verify that upload_dir raises ValueError when no source directory is provided."""
     with pytest.raises(ValueError, match="No source directory"):
-        upload_dir("", f"{CDM_LAKE_BUCKET}/remote")
+        upload_dir("", f"{TEST_BUCKET}/remote")
 
 
 @pytest.mark.usefixtures("mock_s3_client")
@@ -865,12 +587,12 @@ def mocked_s3_client_no_checksum(mock_s3_client: Any) -> Any:
 @pytest.mark.s3
 def test_copy_object(mocked_s3_client_no_checksum: Any, destination: str) -> None:
     """Verify that copy_object copies an object to a new key within the same bucket."""
-    mocked_s3_client_no_checksum.put_object(Bucket=CDM_LAKE_BUCKET, Key="src/file.txt", Body=b"copy me")
-    assert object_exists(f"{CDM_LAKE_BUCKET}/src/file.txt")
-    response = copy_object(f"{CDM_LAKE_BUCKET}/src/file.txt", f"{destination}/dst/path/to/file.txt")
+    mocked_s3_client_no_checksum.put_object(Bucket=TEST_BUCKET, Key="src/file.txt", Body=b"copy me")
+    assert object_exists(f"{TEST_BUCKET}/src/file.txt")
+    response = copy_object(f"{TEST_BUCKET}/src/file.txt", f"{destination}/dst/path/to/file.txt")
 
     # check both objects exist
-    assert object_exists(f"{CDM_LAKE_BUCKET}/src/file.txt")
+    assert object_exists(f"{TEST_BUCKET}/src/file.txt")
     assert object_exists(f"{destination}/dst/path/to/file.txt")
 
     obj = mocked_s3_client_no_checksum.get_object(Bucket=destination, Key="dst/path/to/file.txt")
@@ -882,10 +604,10 @@ def test_copy_object(mocked_s3_client_no_checksum: Any, destination: str) -> Non
 @pytest.mark.usefixtures("mock_s3_client")
 def test_copy_object_source_object_nonexistent() -> None:
     """Ensure that the code throws an error if the source object does not exist."""
-    s3_path = f"{CDM_LAKE_BUCKET}/some/path/to/file"
+    s3_path = f"{TEST_BUCKET}/some/path/to/file"
     assert object_exists(s3_path) is False
     with pytest.raises(Exception, match="The specified key does not exist"):
-        copy_object(s3_path, f"{CDM_LAKE_BUCKET}/a/different/path/to/file")
+        copy_object(s3_path, f"{TEST_BUCKET}/a/different/path/to/file")
 
 
 @pytest.mark.s3
@@ -895,17 +617,17 @@ def test_copy_object_source_bucket_nonexistent() -> None:
     s3_path = "some-bucket/some/path/to/file"
     assert object_exists(s3_path) is False
     with pytest.raises(Exception, match="The specified bucket does not exist"):
-        copy_object(s3_path, f"{CDM_LAKE_BUCKET}/a/different/path/to/file")
+        copy_object(s3_path, f"{TEST_BUCKET}/a/different/path/to/file")
 
 
 @pytest.mark.s3
 @pytest.mark.usefixtures("mock_s3_client")
 def test_copy_file_source_object_nonexistent() -> None:
     """Ensure that the code throws an error if the source object does not exist."""
-    s3_path = f"{CDM_LAKE_BUCKET}/some/path/to/file"
+    s3_path = f"{TEST_BUCKET}/some/path/to/file"
     assert object_exists(s3_path) is False
     with pytest.raises(Exception, match="The specified key does not exist"):
-        copy_object(s3_path, f"{CDM_LAKE_BUCKET}/a/different/path/to/file")
+        copy_object(s3_path, f"{TEST_BUCKET}/a/different/path/to/file")
 
 
 # copy_directory tests
@@ -935,23 +657,23 @@ def test_copy_directory_copies_all_objects_to_dest(
     Ensure that copy works correctly with or without a slash at the end of the directory name.
     """
     mock_s3_client = mocked_s3_client_no_checksum
-    populate_mock_s3(mock_s3_client, {CDM_LAKE_BUCKET: FILES_IN_BUCKETS[CDM_LAKE_BUCKET]})
-    source_bucket_files = list_keys(mock_s3_client, CDM_LAKE_BUCKET)
+    populate_mock_s3(mock_s3_client, {TEST_BUCKET: FILES_IN_BUCKETS[TEST_BUCKET]})
+    source_bucket_files = list_keys(mock_s3_client, TEST_BUCKET)
     assert set(source_bucket_files) == set(SAMPLE_FILES)
     dest_bucket_files = list_keys(mock_s3_client, ALT_BUCKET)
     assert dest_bucket_files == set()
 
     successes, errors = copy_directory(
-        f"s3://{CDM_LAKE_BUCKET}/dir_one{source_suffix}", f"s3://{ALT_BUCKET}/some/destination/dir{dest_suffix}"
+        f"s3://{TEST_BUCKET}/dir_one{source_suffix}", f"s3://{ALT_BUCKET}/some/destination/dir{dest_suffix}"
     )
 
     assert errors == {}
     expected_files = {
-        f"{CDM_LAKE_BUCKET}/{f}": f"{ALT_BUCKET}/some/destination/dir{f.replace('dir_one', '')}" for f in SAMPLE_FILES
+        f"{TEST_BUCKET}/{f}": f"{ALT_BUCKET}/some/destination/dir{f.replace('dir_one', '')}" for f in SAMPLE_FILES
     }
     assert successes == expected_files
     # ensure that the original files are still in place
-    assert set(list_keys(mock_s3_client, CDM_LAKE_BUCKET)) == set(SAMPLE_FILES)
+    assert set(list_keys(mock_s3_client, TEST_BUCKET)) == set(SAMPLE_FILES)
     # destination should have new files from the source
     assert set(list_keys(mock_s3_client, ALT_BUCKET)) == {
         f.removeprefix(f"{ALT_BUCKET}/") for f in expected_files.values()
@@ -959,7 +681,7 @@ def test_copy_directory_copies_all_objects_to_dest(
 
     # check the content
     for src, dest in expected_files.items():
-        src_resp = mock_s3_client.get_object(Bucket=CDM_LAKE_BUCKET, Key=src.removeprefix(f"{CDM_LAKE_BUCKET}/"))
+        src_resp = mock_s3_client.get_object(Bucket=TEST_BUCKET, Key=src.removeprefix(f"{TEST_BUCKET}/"))
         assert src_resp["Body"].read() == src.encode()
         dest_resp = mock_s3_client.get_object(Bucket=ALT_BUCKET, Key=dest.removeprefix(f"{ALT_BUCKET}/"))
         assert dest_resp["Body"].read() == src.encode()
@@ -968,21 +690,21 @@ def test_copy_directory_copies_all_objects_to_dest(
 @pytest.mark.s3
 def test_copy_directory_copy_within_same_bucket(mock_s3_client: Any) -> None:
     """Verify that copying between two prefixes within the same bucket works correctly."""
-    populate_mock_s3(mock_s3_client, {CDM_LAKE_BUCKET: ["foo/a.txt", "foo/b.txt"]})
+    populate_mock_s3(mock_s3_client, {TEST_BUCKET: ["foo/a.txt", "foo/b.txt"]})
 
-    successes, errors = copy_directory(f"s3://{CDM_LAKE_BUCKET}/foo", f"s3://{CDM_LAKE_BUCKET}/bar")
+    successes, errors = copy_directory(f"s3://{TEST_BUCKET}/foo", f"s3://{TEST_BUCKET}/bar")
 
     assert successes == {"cdm-lake/foo/a.txt": "cdm-lake/bar/a.txt", "cdm-lake/foo/b.txt": "cdm-lake/bar/b.txt"}
     assert errors == {}
-    assert list_keys(mock_s3_client, CDM_LAKE_BUCKET, prefix="bar") == {"bar/a.txt", "bar/b.txt"}
-    assert list_keys(mock_s3_client, CDM_LAKE_BUCKET) == {"foo/a.txt", "foo/b.txt", "bar/a.txt", "bar/b.txt"}
+    assert list_keys(mock_s3_client, TEST_BUCKET, prefix="bar") == {"bar/a.txt", "bar/b.txt"}
+    assert list_keys(mock_s3_client, TEST_BUCKET) == {"foo/a.txt", "foo/b.txt", "bar/a.txt", "bar/b.txt"}
 
 
 @pytest.mark.s3
 @pytest.mark.usefixtures("mock_s3_client")
 def test_copy_directory_empty_directory_returns_empty_dicts() -> None:
     """Verify that when the source prefix matches no objects, both the successes and errors dictionaries are returned empty."""
-    successes, errors = copy_directory(f"s3://{CDM_LAKE_BUCKET}/nonexistent/", f"s3://{ALT_BUCKET}/bar/")
+    successes, errors = copy_directory(f"s3://{TEST_BUCKET}/nonexistent/", f"s3://{ALT_BUCKET}/bar/")
 
     assert successes == {}
     assert errors == {}
@@ -998,13 +720,13 @@ def test_copy_directory_does_not_copy_objects_outside_prefix(mock_s3_client: Any
     populate_mock_s3(
         mock_s3_client,
         {
-            CDM_LAKE_BUCKET: [
+            TEST_BUCKET: [
                 "foo/a.txt",
                 "foobar/should-not-be-copied.txt",
             ]
         },
     )
-    copy_directory(f"s3://{CDM_LAKE_BUCKET}/foo", f"s3://{ALT_BUCKET}/bar")
+    copy_directory(f"s3://{TEST_BUCKET}/foo", f"s3://{ALT_BUCKET}/bar")
     assert list_keys(mock_s3_client, ALT_BUCKET) == {"bar/a.txt"}
 
 
@@ -1014,7 +736,7 @@ def test_copy_directory_missing_source_bucket_returns_error() -> None:
     """Verify that when the source bucket does not exist, botocore throws an error."""
     # FIXME: throws a s3.Client.exceptions.NoSuchBucket
     with pytest.raises(Exception, match="The specified bucket does not exist"):
-        copy_directory("s3://nonexistent-bucket/bar", f"s3://{CDM_LAKE_BUCKET}/foo")
+        copy_directory("s3://nonexistent-bucket/bar", f"s3://{TEST_BUCKET}/foo")
 
 
 @pytest.mark.s3
@@ -1022,15 +744,15 @@ def test_copy_directory_missing_source_bucket_returns_error() -> None:
 def test_copy_directory_missing_dest_bucket_records_errors(mock_s3_client: Any) -> None:
     """Verify that when the destination bucket does not exist, the errors dict contains all objects under the original dir."""
     # FIXME: throw a bucket not exists error?
-    populate_mock_s3(mock_s3_client, {CDM_LAKE_BUCKET: ["foo/a.txt", "foo/b.txt"]})
+    populate_mock_s3(mock_s3_client, {TEST_BUCKET: ["foo/a.txt", "foo/b.txt"]})
 
     # with pytest.raises(FileNotFoundError, match="The specified bucket does not exist"):
-    successes, errors = copy_directory(f"s3://{CDM_LAKE_BUCKET}/foo", "s3://nonexistent-bucket/bar")
+    successes, errors = copy_directory(f"s3://{TEST_BUCKET}/foo", "s3://nonexistent-bucket/bar")
 
     assert successes == {}
-    assert f"{CDM_LAKE_BUCKET}/foo/a.txt" in errors
-    assert f"{CDM_LAKE_BUCKET}/foo/b.txt" in errors
-    assert isinstance(errors[f"{CDM_LAKE_BUCKET}/foo/a.txt"], Exception)
+    assert f"{TEST_BUCKET}/foo/a.txt" in errors
+    assert f"{TEST_BUCKET}/foo/b.txt" in errors
+    assert isinstance(errors[f"{TEST_BUCKET}/foo/a.txt"], Exception)
 
 
 # delete_object
@@ -1070,19 +792,19 @@ def test_upload_file_with_metadata_attaches_metadata(mock_s3_client: Any, sample
 @pytest.mark.s3
 def test_upload_file_with_metadata_custom_object_name(mock_s3_client: Any, sample_file: Path) -> None:
     """Verify that the object_name parameter overrides the filename."""
-    result = upload_file(sample_file, f"{CDM_LAKE_BUCKET}/uploads", user_metadata={"k": "v"}, object_name="renamed.txt")
+    result = upload_file(sample_file, f"{TEST_BUCKET}/uploads", user_metadata={"k": "v"}, object_name="renamed.txt")
     assert result is True
-    obj = mock_s3_client.get_object(Bucket=CDM_LAKE_BUCKET, Key="uploads/renamed.txt")
+    obj = mock_s3_client.get_object(Bucket=TEST_BUCKET, Key="uploads/renamed.txt")
     assert obj["Body"].read() == b"hello s3"
 
 
 @pytest.mark.s3
 def test_upload_file_with_metadata_overwrites_existing(mock_s3_client: Any, sample_file: Path) -> None:
     """Verify that upload_file with metadata uploads even when the object already exists."""
-    mock_s3_client.put_object(Bucket=CDM_LAKE_BUCKET, Key=f"uploads/{sample_file.name}", Body=b"old")
-    result = upload_file(sample_file, f"{CDM_LAKE_BUCKET}/uploads", user_metadata={"new": "true"})
+    mock_s3_client.put_object(Bucket=TEST_BUCKET, Key=f"uploads/{sample_file.name}", Body=b"old")
+    result = upload_file(sample_file, f"{TEST_BUCKET}/uploads", user_metadata={"new": "true"})
     assert result is True
-    obj = mock_s3_client.get_object(Bucket=CDM_LAKE_BUCKET, Key=f"uploads/{sample_file.name}")
+    obj = mock_s3_client.get_object(Bucket=TEST_BUCKET, Key=f"uploads/{sample_file.name}")
     assert obj["Body"].read() == b"hello s3"
 
 
@@ -1099,7 +821,7 @@ def test_upload_file_with_metadata_raises_on_empty_destination(sample_file: Path
 @pytest.mark.s3
 def test_upload_file_with_metadata_accepts_str_and_path(sample_file: Path, path_type: type[str] | type[Path]) -> None:
     """Verify that upload_file with metadata accepts both str and Path."""
-    result = upload_file(path_type(sample_file), f"{CDM_LAKE_BUCKET}/uploads", user_metadata={})
+    result = upload_file(path_type(sample_file), f"{TEST_BUCKET}/uploads", user_metadata={})
     assert result is True
 
 
@@ -1107,8 +829,8 @@ def test_upload_file_with_metadata_accepts_str_and_path(sample_file: Path, path_
 @pytest.mark.s3
 def test_head_object_returns_info(mock_s3_client: Any) -> None:
     """Verify that head_object returns size, metadata, and checksum fields."""
-    mock_s3_client.put_object(Bucket=CDM_LAKE_BUCKET, Key="info/file.txt", Body=b"hello", Metadata={"md5": "abc123"})
-    result = head_object(f"{CDM_LAKE_BUCKET}/info/file.txt")
+    mock_s3_client.put_object(Bucket=TEST_BUCKET, Key="info/file.txt", Body=b"hello", Metadata={"md5": "abc123"})
+    result = head_object(f"{TEST_BUCKET}/info/file.txt")
     assert result is not None
     assert result["ContentLength"] == SIZE_HELLO
     assert result["Metadata"]["md5"] == "abc123"
@@ -1119,15 +841,15 @@ def test_head_object_returns_info(mock_s3_client: Any) -> None:
 def test_head_object_raises_for_missing() -> None:
     """Verify that head_object returns None for a non-existent object."""
     with pytest.raises(ClientError, match="404"):
-        _ = head_object(f"{CDM_LAKE_BUCKET}/does/not/exist.txt")
+        _ = head_object(f"{TEST_BUCKET}/does/not/exist.txt")
 
 
 @pytest.mark.parametrize("protocol", ["", "s3://", "s3a://"])
 @pytest.mark.s3
 def test_head_object_with_protocols(mock_s3_client: Any, protocol: str) -> None:
     """Verify that head_object handles all valid protocol prefixes."""
-    mock_s3_client.put_object(Bucket=CDM_LAKE_BUCKET, Key="proto/file.txt", Body=b"data")
-    result = head_object(f"{protocol}{CDM_LAKE_BUCKET}/proto/file.txt")
+    mock_s3_client.put_object(Bucket=TEST_BUCKET, Key="proto/file.txt", Body=b"data")
+    result = head_object(f"{protocol}{TEST_BUCKET}/proto/file.txt")
     assert result is not None
     assert result["ContentLength"] == SIZE_DATA
 
@@ -1138,10 +860,10 @@ def test_head_object_with_protocols(mock_s3_client: Any, protocol: str) -> None:
 def test_copy_object_preserves_user_metadata(mocked_s3_client_no_checksum: Any, destination: str) -> None:
     """copy_object preserves source user metadata (MetadataDirective=COPY default)."""
     mocked_s3_client_no_checksum.put_object(
-        Bucket=CDM_LAKE_BUCKET, Key="src/file.txt", Body=b"archive me", Metadata={"md5": "abc123"}
+        Bucket=TEST_BUCKET, Key="src/file.txt", Body=b"archive me", Metadata={"md5": "abc123"}
     )
     response = copy_object(
-        f"{CDM_LAKE_BUCKET}/src/file.txt",
+        f"{TEST_BUCKET}/src/file.txt",
         f"{destination}/archive/file.txt",
     )
     assert response["ResponseMetadata"]["HTTPStatusCode"] == HTTP_STATUS_OK
@@ -1151,18 +873,18 @@ def test_copy_object_preserves_user_metadata(mocked_s3_client_no_checksum: Any, 
     assert resp["Metadata"].get("md5") == "abc123"
 
     # verify source still exists
-    assert object_exists(f"{CDM_LAKE_BUCKET}/src/file.txt")
+    assert object_exists(f"{TEST_BUCKET}/src/file.txt")
 
 
 @pytest.mark.s3
 def test_copy_object_preserves_content(mocked_s3_client_no_checksum: Any) -> None:
     """Verify that the content of the copied object matches the original."""
-    mocked_s3_client_no_checksum.put_object(Bucket=CDM_LAKE_BUCKET, Key="src/data.bin", Body=b"binary data")
+    mocked_s3_client_no_checksum.put_object(Bucket=TEST_BUCKET, Key="src/data.bin", Body=b"binary data")
     copy_object(
-        f"{CDM_LAKE_BUCKET}/src/data.bin",
-        f"{CDM_LAKE_BUCKET}/dst/data.bin",
+        f"{TEST_BUCKET}/src/data.bin",
+        f"{TEST_BUCKET}/dst/data.bin",
     )
-    obj = mocked_s3_client_no_checksum.get_object(Bucket=CDM_LAKE_BUCKET, Key="dst/data.bin")
+    obj = mocked_s3_client_no_checksum.get_object(Bucket=TEST_BUCKET, Key="dst/data.bin")
     assert obj["Body"].read() == b"binary data"
 
 
@@ -1183,28 +905,28 @@ def test_delete_objects_removes_all(mock_s3_client: Any) -> None:
     """delete_objects removes every listed key in a single call."""
     keys = ["bulk/a.txt", "bulk/b.txt", "bulk/c.txt"]
     for k in keys:
-        mock_s3_client.put_object(Bucket=CDM_LAKE_BUCKET, Key=k, Body=b"data")
+        mock_s3_client.put_object(Bucket=TEST_BUCKET, Key=k, Body=b"data")
 
-    errors = delete_objects(CDM_LAKE_BUCKET, keys)
+    errors = delete_objects(TEST_BUCKET, keys)
 
     assert errors == []
     for k in keys:
-        assert object_exists(f"{CDM_LAKE_BUCKET}/{k}") is False
+        assert object_exists(f"{TEST_BUCKET}/{k}") is False
 
 
 @pytest.mark.s3
 def test_delete_objects_empty_list_is_noop(mock_s3_client: Any) -> None:
     """delete_objects with an empty list makes no API call and returns no errors."""
-    mock_s3_client.put_object(Bucket=CDM_LAKE_BUCKET, Key="keep/me.txt", Body=b"safe")
-    errors = delete_objects(CDM_LAKE_BUCKET, [])
+    mock_s3_client.put_object(Bucket=TEST_BUCKET, Key="keep/me.txt", Body=b"safe")
+    errors = delete_objects(TEST_BUCKET, [])
     assert errors == []
-    assert object_exists(f"{CDM_LAKE_BUCKET}/keep/me.txt") is True
+    assert object_exists(f"{TEST_BUCKET}/keep/me.txt") is True
 
 
 @pytest.mark.s3
 def test_delete_objects_nonexistent_keys_no_error(mock_s3_client: Any) -> None:
     """Deleting keys that don't exist returns no errors (S3 delete is idempotent)."""
-    errors = delete_objects(CDM_LAKE_BUCKET, ["ghost/a.txt", "ghost/b.txt"])
+    errors = delete_objects(TEST_BUCKET, ["ghost/a.txt", "ghost/b.txt"])
     assert errors == []
 
 


### PR DESCRIPTION
- Move `cdm_data_loaders.utils.s3` to `cdm_data_loaders.utils.file_transfer.s3.object_utils`
- Split out the client init and reset into `cdm_data_loaders.utils.file_transfer.s3.client`
- Add in a `cli.py` file, which will contain the s3 shortcuts `cmd_cp`, `cmd_mv`, etc.
- Import `client` from `cdm_data_loaders.utils.file_transfer.s3` and call `client.get_s3_client` instead of importing the function to make it easier to mock in tests.