### PR TITLE
Adding JSON schema for various different file types

### DIFF
--- a/src/cdm_data_loaders/parsers/all_the_bacteria/schema/all_atb_files.tsv.schema.json
+++ b/src/cdm_data_loaders/parsers/all_the_bacteria/schema/all_atb_files.tsv.schema.json
@@ -1,0 +1,59 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "JSON Schema for the All The Bacteria file index TSV.",
+    "properties": {
+        "project": {
+            "description": "the name of the project/component, plus its parents, with the names separated by /. For example the Metadata component sits directly under the main AllTheBacteria project, and is called AlTheBacteria/Metadata.",
+            "minLength": 1,
+            "type": [
+                "string"
+            ]
+        },
+        "project_id": {
+            "description": "the project identifier. This is useful if you want to make your own file list (see below)",
+            "minLength": 1,
+            "type": [
+                "string"
+            ]
+        },
+        "filename": {
+            "description": "the name of the file",
+            "minLength": 1,
+            "type": [
+                "string"
+            ]
+        },
+        "url": {
+            "description": "the URL of the file on the osf server",
+            "minLength": 1,
+            "type": [
+                "string"
+            ]
+        },
+        "md5": {
+            "description": "the MD5 sum of the file",
+            "minLength": 32,
+            "maxLength": 32,
+            "type": [
+                "string"
+            ]
+        },
+        "size(MB)": {
+            "description": "size of the file in MB",
+            "minimum": 0,
+            "type": [
+                "number"
+            ]
+        }
+    },
+    "required": [
+        "project",
+        "project_id",
+        "filename",
+        "url",
+        "md5",
+        "size(MB)"
+    ],
+    "title": "JSON Schema for the All The Bacteria index file.",
+    "type": "object"
+}

--- a/src/cdm_data_loaders/parsers/all_the_bacteria/schema/assembly_index.tsv.schema.json
+++ b/src/cdm_data_loaders/parsers/all_the_bacteria/schema/assembly_index.tsv.schema.json
@@ -1,0 +1,47 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "JSON Schema for the All The Bacteria assembly index file.",
+    "properties": {
+        "sample": {
+            "type": "string",
+            "description": "the INSDC sample accession"
+        },
+        "sylph_species": {
+            "type": "string",
+            "description": "inferred species call from running sylph on the reads. This is using the “post-202505” method on all of the samples. Meaning that species calls in files from 202505 onwards are not the same as in files before 202505. See the species calls page for more details"
+        },
+        "filename_in_tar_xz": {
+            "type": "string",
+            "description": "the FASTA filename for this sample inside the tar.xz file"
+        },
+        "tar_xz": {
+            "type": "string",
+            "description": "the name of the tar.xz file where this sample's FASTA lives"
+        },
+        "tar_xz_url": {
+            "type": "string",
+            "description": "URL of tar_xz"
+        },
+        "tar_xz_md5": {
+            "type": "string",
+            "description": "MD5 sum of tar_xz",
+            "minLength": 32,
+            "maxLength": 32
+        },
+        "tar_xz_size_MB": {
+            "type": "number",
+            "description": "size of the tar_xz file in MB"
+        }
+    },
+    "required": [
+        "sample",
+        "sylph_species",
+        "filename_in_tar_xz",
+        "tar_xz",
+        "tar_xz_url",
+        "tar_xz_md5",
+        "tar_xz_size_MB"
+    ],
+    "title": "All the Bacteria assembly index file schema",
+    "type": "object"
+}

--- a/src/cdm_data_loaders/parsers/all_the_bacteria/schema/bakta_index.tsv.schema.json
+++ b/src/cdm_data_loaders/parsers/all_the_bacteria/schema/bakta_index.tsv.schema.json
@@ -1,0 +1,51 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "JSON Schema for the All The Bacteria Bakta index file.",
+    "properties": {
+        "sample": {
+            "type": "string",
+            "description": "the INSDC sample accession"
+        },
+        "status": {
+            "type": "string",
+            "description": "the status of the Bakta run (PASS, FAIL)",
+            "enum": [
+                "PASS",
+                "FAIL"
+            ]
+        },
+        "file_name": {
+            "type": "string",
+            "description": "the name of the Bakta JSON result file, e.g. SAMN38372697.bakta.json"
+        },
+        "file_md5": {
+            "type": "string",
+            "description": "MD5 sum of file_name",
+            "minLength": 32,
+            "maxLength": 32
+        },
+        "tar_xz": {
+            "type": "string",
+            "description": "the name of the tar.xz file where this sample's JSON lives following a fix schema: atb. analysis . release . batch .tar.xz, e.g. atb.bakta.r0.2.batch.1.tar.xz"
+        },
+        "tar_xz_md5": {
+            "type": "string",
+            "description": "MD5 sum of tar_xz"
+        },
+        "tar_xz_size_MB": {
+            "type": "number",
+            "description": "size of the tar_xz file in MB"
+        }
+    },
+    "required": [
+        "sample",
+        "status",
+        "file_name",
+        "file_md5",
+        "tar_xz",
+        "tar_xz_md5",
+        "tar_xz_size_MB"
+    ],
+    "title": "All the Bacteria Bakta index file schema",
+    "type": "object"
+}

--- a/src/cdm_data_loaders/parsers/gtdb/schema/gtdb_metadata.schema.json
+++ b/src/cdm_data_loaders/parsers/gtdb/schema/gtdb_metadata.schema.json
@@ -1,0 +1,1036 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JSON Schema for GTDB metadata files.",
+  "description": "Inferred JSON Schema with `qsv schema /Users/gwg/code/kbase/cdm-data-loaders/src/cdm_data_loaders/parsers/gtdb/files/ar53_metadata.tsv`",
+  "type": "object",
+  "properties": {
+    "accession": {
+      "description": "Unique genome identifier. Data from NCBI or GTDB.",
+      "minLength": 18,
+      "maxLength": 18,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(RS_GCF|GB_GCA)_[0-9]{9,}\\.[0-9]+$$"
+    },
+    "ambiguous_bases": {
+      "description": "Number of ambiguous bases. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "checkm2_completeness": {
+      "description": "Estimated completeness of genome using CheckM v2. Data from CheckM.",
+      "minimum": 0.0,
+      "maximum": 100.0,
+      "type": [
+        "number"
+      ]
+    },
+    "checkm2_contamination": {
+      "description": "Estimated contamination of genome using CheckM v2. Data from CheckM.",
+      "minimum": 0.0,
+      "maximum": 100.0,
+      "type": [
+        "number"
+      ]
+    },
+    "checkm2_model": {
+      "description": "Model used by CheckM v2 to estimate completeness and contamination. Data from CheckM.",
+      "minLength": 7,
+      "maxLength": 8,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "General",
+        "Specific"
+      ]
+    },
+    "checkm_completeness": {
+      "description": "Estimated completeness of genome. Data from CheckM.",
+      "minimum": 0.0,
+      "maximum": 100.0,
+      "type": [
+        "number"
+      ]
+    },
+    "checkm_contamination": {
+      "description": "Estimated contamination of genome. Data from CheckM.",
+      "minimum": 0.0,
+      "maximum": 100.0,
+      "type": [
+        "number"
+      ]
+    },
+    "checkm_marker_count": {
+      "description": "Number of marker genes used to estimate genome quality. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "checkm_marker_lineage": {
+      "description": "Lineage of marker genes used to estimate genome quality. Data from CheckM.",
+      "minLength": 7,
+      "type": [
+        "string"
+      ],
+      "pattern": "^[a-z]__\\S+ \\(UID[0-9]+\\)$"
+    },
+    "checkm_marker_set_count": {
+      "description": "Number of marker sets used to estimate genome quality. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "checkm_strain_heterogeneity": {
+      "description": "Estimated strain heterogeneity of genome. Data from CheckM.",
+      "minimum": 0.0,
+      "maximum": 100.0,
+      "type": [
+        "number"
+      ]
+    },
+    "coding_bases": {
+      "description": "Number of coding bases. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "coding_density": {
+      "description": "Coding density of genome. Data from CheckM.",
+      "minimum": 0.0,
+      "maximum": 100.0,
+      "type": [
+        "number"
+      ]
+    },
+    "contig_count": {
+      "description": "Number of contigs. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "gc_count": {
+      "description": "Number of GC bases. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "gc_percentage": {
+      "description": "GC-content of genome. Data from CheckM.",
+      "minimum": 0.0,
+      "maximum": 100.0,
+      "type": [
+        "number"
+      ]
+    },
+    "genome_size": {
+      "description": "Size of genome. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "gtdb_genome_representative": {
+      "description": "Indicates the representative genome of the GTDB species cluster to which this genome is assigned. Data from GTDB.",
+      "minLength": 18,
+      "maxLength": 18,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(RS_GCF|GB_GCA)_[0-9]{9,}\\.[0-9]+$$"
+    },
+    "gtdb_representative": {
+      "description": "Indicates if a genome is the representative of a GTDB species cluster. Data from GTDB.",
+      "minLength": 1,
+      "maxLength": 1,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "f",
+        "t"
+      ]
+    },
+    "gtdb_taxonomy": {
+      "description": "GTDB taxonomy string. Data from GTDB.",
+      "minLength": 20,
+      "type": [
+        "string"
+      ]
+    },
+    "gtdb_type_designation_ncbi_taxa": {
+      "description": "Indicates if genome is assembled from the type strain of a species or subspecies according to its NCBI classification. Data from GTDB.",
+      "minLength": 1,
+      "maxLength": 50,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "not type material",
+        "not used as type",
+        "type strain of subspecies",
+        "type strain of heterotypic synonym",
+        "type strain of species"
+      ]
+    },
+    "gtdb_type_designation_ncbi_taxa_sources": {
+      "description": "Authoritative sources supporting type designation in gtdb_type_designation_ncbi_taxa. Data from GTDB.",
+      "minLength": 4,
+      "maxLength": 12,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "LPSN",
+        "Seqcode",
+        "Seqcode;LPSN",
+        "none"
+      ]
+    },
+    "gtdb_type_species_of_genus": {
+      "description": "Indicates if genome is assembled from the type species of the genus. Data from GTDB.",
+      "minLength": 1,
+      "maxLength": 1,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "f",
+        "t"
+      ]
+    },
+    "l50_contigs": {
+      "description": "L50 of contigs. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "l50_scaffolds": {
+      "description": "L50 of scaffolds. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "longest_contig": {
+      "description": "Longest contig. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "longest_scaffold": {
+      "description": "Longest scaffold. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "lsu_23s_contig_len": {
+      "description": "Length of contig containing selected 23S rRNA gene. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(none|\\d+)$"
+    },
+    "lsu_23s_count": {
+      "description": "Number of 23S rRNA genes. Data from HMMER w/ Barrnap HMMs.",
+      "type": [
+        "string"
+      ],
+      "pattern": "^(none|\\d+)$"
+    },
+    "lsu_23s_length": {
+      "description": "Length of single 23S rRNA gene selected from genome. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "lsu_23s_query_id": {
+      "description": "Identifier of contig containing selected 23S rRNA gene. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "lsu_5s_contig_len": {
+      "description": "Length of contig containing selected 5S rRNA gene. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(none|\\d+)$"
+    },
+    "lsu_5s_count": {
+      "description": "Number of 5S rRNA genes. Data from HMMER w/ Barrnap HMMs.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "lsu_5s_length": {
+      "description": "Length of single 5S rRNA gene selected from genome. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(none|\\d+)$"
+    },
+    "lsu_5s_query_id": {
+      "description": "Identifier of contig containing selected 5S rRNA gene. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "lsu_silva_23s_blast_align_len": {
+      "description": "Alignment length of top BLAST hit in SILVA LSU database. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(none|\\d+)$"
+    },
+    "lsu_silva_23s_blast_bitscore": {
+      "description": "Bitscore of top BLAST hit in SILVA LSU database. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^([0-9]+(\\.[0-9]+)?|none)$"
+    },
+    "lsu_silva_23s_blast_evalue": {
+      "description": "E-value of top BLAST hit in SILVA LSU database. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "lsu_silva_23s_blast_perc_identity": {
+      "description": "Percent identity of top BLAST hit in SILVA LSU database. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^([0-9]+(\\.[0-9]+)?|none)$"
+    },
+    "lsu_silva_23s_blast_subject_id": {
+      "description": "Identifier of top BLAST hit in SILVA LSU database. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "lsu_silva_23s_taxonomy": {
+      "description": "SILVA taxonomy of top BLAST hit for selected 23S rRNA gene. Data from SILVA.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "mean_contig_length": {
+      "description": "Average length of contigs. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "mean_scaffold_length": {
+      "description": "Average length of scaffolds. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "mimag_high_quality": {
+      "description": "Indicates if genome meets the high-quality MIMAG criteria. Data from GTDB.",
+      "minLength": 1,
+      "maxLength": 1,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "f",
+        "t"
+      ]
+    },
+    "mimag_low_quality": {
+      "description": "Indicates if genome meets the low-quality MIMAG criteria. Data from GTDB.",
+      "minLength": 1,
+      "maxLength": 1,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "f",
+        "t"
+      ]
+    },
+    "mimag_medium_quality": {
+      "description": "Indicates if genome meets the medium-quality MIMAG criteria. Data from GTDB.",
+      "minLength": 1,
+      "maxLength": 1,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "f",
+        "t"
+      ]
+    },
+    "n50_contigs": {
+      "description": "N50 of contigs. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "n50_scaffolds": {
+      "description": "N50 of scaffolds. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "ncbi_assembly_level": {
+      "description": "NCBI assembly level. Data from NCBI.",
+      "minLength": 6,
+      "maxLength": 15,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "Chromosome",
+        "Complete Genome",
+        "Contig",
+        "Scaffold"
+      ]
+    },
+    "ncbi_assembly_name": {
+      "description": "Assembly name. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_assembly_type": {
+      "description": "NCBI assembly type. Data from NCBI.",
+      "minLength": 2,
+      "maxLength": 2,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_bioproject": {
+      "description": "NCBI BioProject for genome. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^PRJ[DEN][A-Z][0-9]+$"
+    },
+    "ncbi_biosample": {
+      "description": "NCBI BioSample for genome. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(none|SAM[NED][A-Za-z0-9_]?[0-9]+)$"
+    },
+    "ncbi_contig_count": {
+      "description": "Number of contigs. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^([0-9]+|none)$"
+    },
+    "ncbi_contig_n50": {
+      "description": "N50 of contigs. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_country": {
+      "description": "Country. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_date": {
+      "description": "Data submitted to NCBI. Data from NCBI.",
+      "minLength": 10,
+      "maxLength": 10,
+      "type": [
+        "string"
+      ],
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "ncbi_genbank_assembly_accession": {
+      "description": "GenBank assembly accession.. Data from NCBI.",
+      "minLength": 15,
+      "maxLength": 15,
+      "type": [
+        "string"
+      ],
+      "pattern": "^GCA_\\d{9,}\\.\\d+$$"
+    },
+    "ncbi_genome_category": {
+      "description": "Genome is assembled from a single cell, metagenome, or environmental sample. Data from NCBI/GTDB.",
+      "minLength": 4,
+      "maxLength": 33,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "derived from environmental sample",
+        "derived from metagenome",
+        "derived from single cell",
+        "none"
+      ]
+    },
+    "ncbi_genome_representation": {
+      "description": "Indicates if genome is full or partial. Data from NCBI.",
+      "minLength": 4,
+      "maxLength": 7,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "full",
+        "partial"
+      ]
+    },
+    "ncbi_isolate": {
+      "description": "Isolate name at NCBI. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_isolation_source": {
+      "description": "Isolation source. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_lat_lon": {
+      "description": "Latitude and longitude. Data from NCBI.",
+      "minLength": 4,
+      "maxLength": 39,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_molecule_count": {
+      "description": "Molecule count. Data from NCBI.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "ncbi_ncrna_count": {
+      "description": "Non-coding RNA count. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(none|[0-9]+)$"
+    },
+    "ncbi_organism_name": {
+      "description": "Organism name at NCBI. Data from NCBI.",
+      "minLength": 8,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_protein_count": {
+      "description": "Protein count. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(none|[0-9]+)$"
+    },
+    "ncbi_refseq_category": {
+      "description": "NCBI RefSeq genome category. Data from NCBI.",
+      "minLength": 2,
+      "maxLength": 16,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "na",
+        "reference genome"
+      ]
+    },
+    "ncbi_rrna_count": {
+      "description": "rRNA count. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^([0-9]+|none)$"
+    },
+    "ncbi_scaffold_count": {
+      "description": "Number of scaffolds. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(none|[0-9]+)$"
+    },
+    "ncbi_scaffold_l50": {
+      "description": "L50 of scaffolds. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(none|[0-9]+)$"
+    },
+    "ncbi_scaffold_n50": {
+      "description": "N50 of scaffolds. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_scaffold_n75": {
+      "description": "N75 of scaffolds. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_scaffold_n90": {
+      "description": "N90 of scaffolds. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_seq_rel_date": {
+      "description": "NCBI sequence release date. Data from NCBI.",
+      "minLength": 10,
+      "maxLength": 10,
+      "type": [
+        "string"
+      ],
+      "pattern": "^[0-9]{4}-[0-9]{2}-[0-9]{2}$"
+    },
+    "ncbi_spanned_gaps": {
+      "description": "Number of spanned gaps. Data from NCBI.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "ncbi_species_taxid": {
+      "description": "NCBI species taxonomy identifier. Data from NCBI.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "ncbi_ssu_count": {
+      "description": "Number of 16S rRNA genes. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^([0-9]+|none)$"
+    },
+    "ncbi_strain_identifiers": {
+      "description": "NCBI strain information from the assembly report. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_submitter": {
+      "description": "Submitter at NCBI. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_taxid": {
+      "description": "NCBI taxonomy identifier. Data from NCBI.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "ncbi_taxonomy": {
+      "description": "NCBI taxonomy string. Data from NCBI.",
+      "minLength": 4,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_taxonomy_unfiltered": {
+      "description": "Full NCBI taxonomy string, including non-standard or unspecified ranks. Data from NCBI.",
+      "minLength": 4,
+      "type": [
+        "string"
+      ]
+    },
+    "ncbi_total_gap_length": {
+      "description": "Length of all gaps. Data from NCBI.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "ncbi_total_length": {
+      "description": "Size of genome. Data from NCBI.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "ncbi_translation_table": {
+      "description": "Translation table. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^([0-9]+|none)$"
+    },
+    "ncbi_trna_count": {
+      "description": "tRNA count. Data from NCBI.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^([0-9]+|none)$"
+    },
+    "ncbi_type_material_designation": {
+      "description": "Indicates if genome is assembled from type material. Data from NCBI.",
+      "minLength": 2,
+      "maxLength": 47,
+      "type": [
+        "string"
+      ],
+      "enum": [
+        "assembly designated as clade exemplar",
+        "assembly designated as neotype",
+        "assembly designated as reftype",
+        "assembly from heterotypic synonym type material",
+        "assembly from pathotype material",
+        "assembly from type material",
+        "na"
+      ]
+    },
+    "ncbi_ungapped_length": {
+      "description": "Number of ungapped bases. Data from NCBI.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "ncbi_unspanned_gaps": {
+      "description": "Number of unspanned gaps. Data from NCBI.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "ncbi_wgs_master": {
+      "description": "NCBI WGS accession. Data from NCBI.",
+      "minLength": 2,
+      "maxLength": 17,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(na|[A-Z]{4,6}[0-9]+(\\.\\d+)?)$"
+    },
+    "protein_count": {
+      "description": "Number of proteins. Data from Prodigal.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "scaffold_count": {
+      "description": "Number of scaffolds. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "ssu_contig_len": {
+      "description": "Length of contig containing selected 16S rRNA gene. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ssu_count": {
+      "description": "Number of 16S rRNA genes. Data from HMMER w/ Barrnap HMMs.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "ssu_gg_blast_align_len": {
+      "description": "Alignment length of top BLAST hit in Greengenes. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ssu_gg_blast_bitscore": {
+      "description": "Bitscore of top BLAST hit in Greengenes. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^([0-9]+(\\.[0-9]+)?|none)$"
+    },
+    "ssu_gg_blast_evalue": {
+      "description": "E-value of top BLAST hit in Greengenes. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ssu_gg_blast_perc_identity": {
+      "description": "Percent identity of top BLAST hit in Greengenes. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^([0-9]+(\\.[0-9]+)?|none)$"
+    },
+    "ssu_gg_blast_subject_id": {
+      "description": "Identifier of top BLAST hit in Greengenes. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ssu_gg_taxonomy": {
+      "description": "Greengenes taxonomy. Data from Greengenes.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ssu_length": {
+      "description": "Length of single 16S rRNA gene selected from genome. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(none|\\d+)$"
+    },
+    "ssu_query_id": {
+      "description": "Identifier of contig containing selected 16S rRNA gene. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ssu_silva_blast_align_len": {
+      "description": "Alignment length of top BLAST hit in SILVA SSU database. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ssu_silva_blast_bitscore": {
+      "description": "Bitscore of top BLAST hit in SILVA SSU database. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ],
+      "pattern": "^([0-9]+(\\.[0-9]+)?|none)$"
+    },
+    "ssu_silva_blast_evalue": {
+      "description": "E-value of top BLAST hit in SILVA SSU database. Data from GTDB.",
+      "minLength": 1,
+      "type": [
+        "string"
+      ]
+    },
+    "ssu_silva_blast_perc_identity": {
+      "description": "Percent identity of top BLAST hit in SILVA SSU database. Data from GTDB.",
+      "type": [
+        "string"
+      ],
+      "pattern": "^([0-9]+(\\.[0-9]+)?|none)$"
+    },
+    "ssu_silva_blast_subject_id": {
+      "description": "Identifier of top BLAST hit in SILVA SSU database. Data from GTDB.",
+      "minLength": 4,
+      "type": [
+        "string"
+      ]
+    },
+    "ssu_silva_taxonomy": {
+      "description": "SILVA taxonomy of top BLAST hit for selected 16S rRNA gene. Data from SILVA.",
+      "minLength": 4,
+      "type": [
+        "string"
+      ]
+    },
+    "total_gap_length": {
+      "description": "Length of all gaps. Data from CheckM.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "trna_aa_count": {
+      "description": "Number of standard amino acids with a tRNA. Data from tRNAscan-SE.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "trna_count": {
+      "description": "Total number of identified tRNAs. Data from tRNAscan-SE.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    },
+    "trna_selenocysteine_count": {
+      "description": "Number of tRNAs for selenocysteine. Data from tRNAscan-SE.",
+      "minimum": 0,
+      "type": [
+        "integer"
+      ]
+    }
+  },
+  "required": [
+    "accession",
+    "ambiguous_bases",
+    "checkm2_completeness",
+    "checkm2_contamination",
+    "checkm2_model",
+    "checkm_completeness",
+    "checkm_contamination",
+    "checkm_marker_count",
+    "checkm_marker_lineage",
+    "checkm_marker_set_count",
+    "checkm_strain_heterogeneity",
+    "coding_bases",
+    "coding_density",
+    "contig_count",
+    "gc_count",
+    "gc_percentage",
+    "genome_size",
+    "gtdb_genome_representative",
+    "gtdb_representative",
+    "gtdb_taxonomy",
+    "gtdb_type_designation_ncbi_taxa",
+    "gtdb_type_designation_ncbi_taxa_sources",
+    "gtdb_type_species_of_genus",
+    "l50_contigs",
+    "l50_scaffolds",
+    "longest_contig",
+    "longest_scaffold",
+    "lsu_23s_contig_len",
+    "lsu_23s_count",
+    "lsu_23s_length",
+    "lsu_23s_query_id",
+    "lsu_5s_contig_len",
+    "lsu_5s_count",
+    "lsu_5s_length",
+    "lsu_5s_query_id",
+    "lsu_silva_23s_blast_align_len",
+    "lsu_silva_23s_blast_bitscore",
+    "lsu_silva_23s_blast_evalue",
+    "lsu_silva_23s_blast_perc_identity",
+    "lsu_silva_23s_blast_subject_id",
+    "lsu_silva_23s_taxonomy",
+    "mean_contig_length",
+    "mean_scaffold_length",
+    "mimag_high_quality",
+    "mimag_low_quality",
+    "mimag_medium_quality",
+    "n50_contigs",
+    "n50_scaffolds",
+    "ncbi_assembly_level",
+    "ncbi_assembly_name",
+    "ncbi_assembly_type",
+    "ncbi_bioproject",
+    "ncbi_biosample",
+    "ncbi_contig_count",
+    "ncbi_contig_n50",
+    "ncbi_country",
+    "ncbi_date",
+    "ncbi_genbank_assembly_accession",
+    "ncbi_genome_category",
+    "ncbi_genome_representation",
+    "ncbi_isolate",
+    "ncbi_isolation_source",
+    "ncbi_lat_lon",
+    "ncbi_molecule_count",
+    "ncbi_ncrna_count",
+    "ncbi_organism_name",
+    "ncbi_protein_count",
+    "ncbi_refseq_category",
+    "ncbi_rrna_count",
+    "ncbi_scaffold_count",
+    "ncbi_scaffold_l50",
+    "ncbi_scaffold_n50",
+    "ncbi_scaffold_n75",
+    "ncbi_scaffold_n90",
+    "ncbi_seq_rel_date",
+    "ncbi_spanned_gaps",
+    "ncbi_species_taxid",
+    "ncbi_ssu_count",
+    "ncbi_strain_identifiers",
+    "ncbi_submitter",
+    "ncbi_taxid",
+    "ncbi_taxonomy",
+    "ncbi_taxonomy_unfiltered",
+    "ncbi_total_gap_length",
+    "ncbi_total_length",
+    "ncbi_translation_table",
+    "ncbi_trna_count",
+    "ncbi_type_material_designation",
+    "ncbi_ungapped_length",
+    "ncbi_unspanned_gaps",
+    "ncbi_wgs_master",
+    "protein_count",
+    "scaffold_count",
+    "ssu_contig_len",
+    "ssu_count",
+    "ssu_gg_blast_align_len",
+    "ssu_gg_blast_bitscore",
+    "ssu_gg_blast_evalue",
+    "ssu_gg_blast_perc_identity",
+    "ssu_gg_blast_subject_id",
+    "ssu_gg_taxonomy",
+    "ssu_length",
+    "ssu_query_id",
+    "ssu_silva_blast_align_len",
+    "ssu_silva_blast_bitscore",
+    "ssu_silva_blast_evalue",
+    "ssu_silva_blast_perc_identity",
+    "ssu_silva_blast_subject_id",
+    "ssu_silva_taxonomy",
+    "total_gap_length",
+    "trna_aa_count",
+    "trna_count",
+    "trna_selenocysteine_count"
+  ]
+}

--- a/src/cdm_data_loaders/parsers/gtdb/schema/gtdb_taxonomy.schema.json
+++ b/src/cdm_data_loaders/parsers/gtdb/schema/gtdb_taxonomy.schema.json
@@ -1,0 +1,29 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "JSON Schema for ar53_taxonomy.tsv",
+  "description": "Inferred JSON Schema with `qsv schema /Users/gwg/code/kbase/cdm-data-loaders/src/cdm_data_loaders/parsers/gtdb/files/ar53_taxonomy.tsv`",
+  "type": "object",
+  "properties": {
+    "ncbi_id": {
+      "description": "ncbi_id column from ar53_taxonomy.tsv",
+      "minLength": 18,
+      "maxLength": 19,
+      "type": [
+        "string"
+      ],
+      "pattern": "^(GB_GCA|RS_GCF)_[0-9]+\\.[0-9]+$"
+    },
+    "gtdb_id": {
+      "description": "gtdb_id column from ar53_taxonomy.tsv",
+      "minLength": 27,
+      "type": [
+        "string"
+      ],
+      "pattern": "^d__.*?;p__.*?;c__.*?;o__.*?;f__.*?;g__.*?;s__.+$"
+    }
+  },
+  "required": [
+    "ncbi_id",
+    "gtdb_id"
+  ]
+}

--- a/src/cdm_data_loaders/parsers/uniprot/idmapping.schema.json
+++ b/src/cdm_data_loaders/parsers/uniprot/idmapping.schema.json
@@ -1,0 +1,34 @@
+{
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "JSON Schema for the UniProt ID mapping files, which map UniProt IDs to IDs in other databases. The schema defines the expected structure and data types for the fields in the ID mapping files.",
+    "properties": {
+        "uniprot_id": {
+            "description": "Identifier for the protein in the UniProt database.",
+            "minLength": 6,
+            "type": [
+                "string"
+            ]
+        },
+        "db": {
+            "description": "Abbreviation for the database from which the internal ID in the `xref` column is derived.",
+            "minLength": 1,
+            "type": [
+                "string"
+            ]
+        },
+        "xref": {
+            "description": "Internal ID at the database in the `db` column.",
+            "minLength": 1,
+            "type": [
+                "string"
+            ]
+        }
+    },
+    "required": [
+        "uniprot_id",
+        "db",
+        "xref"
+    ],
+    "title": "JSON Schema for UniProt ID mapping files",
+    "type": "object"
+}


### PR DESCRIPTION
JSON schemas for data validation for the following resources:

- GTDB taxonomy and metadata
- AllTheBacteria file listing, assembly index, bakta index
- UniProt ID mapping