### PR TITLE
Minor reorg:

### DIFF
--- a/src/cdm_data_loaders/ncbi_ftp/manifest.py
+++ b/src/cdm_data_loaders/ncbi_ftp/manifest.py
@@ -29,7 +29,10 @@ from cdm_data_loaders.ncbi_ftp.assembly import (
     parse_md5_checksums_file,
 )
 from cdm_data_loaders.ncbi_ftp.constants import ACCESSION_PARTS_REGEX, ASSEMBLY_PATH_REGEX
-from cdm_data_loaders.utils.file_transfer.s3.object_utils import head_object, list_matching_objects
+from cdm_data_loaders.utils.file_transfer.s3.object_utils import (
+    head_object,
+    list_objects,
+)
 from cdm_data_loaders.utils.ftp_client import FTP, connect_ftp, ftp_noop_keepalive, ftp_retrieve_text
 
 logger: Logger = getLogger(__name__)
@@ -351,7 +354,7 @@ def scan_store_to_synthetic_summary(
     processed_count = 0
 
     try:
-        objs = list_matching_objects(str(bucket / key_prefix))
+        objs = list_objects(str(bucket / key_prefix))
 
         for obj in objs:
             try:
@@ -510,7 +513,7 @@ def verify_transfer_candidates(  # noqa: PLR0913
             s3_prefix = key_prefix / s3_rel
 
             # Quick check: does *anything* exist under this prefix?
-            resp = list_matching_objects(str(bucket / s3_prefix), max_keys=1)
+            resp = list_objects(str(bucket / s3_prefix), max_keys=1)
             if not resp:
                 # Nothing in the store — definitely needs downloading
                 confirmed.append(acc)

--- a/src/cdm_data_loaders/ncbi_ftp/promote.py
+++ b/src/cdm_data_loaders/ncbi_ftp/promote.py
@@ -29,7 +29,7 @@ from cdm_data_loaders.utils.file_transfer.s3 import client
 from cdm_data_loaders.utils.file_transfer.s3.object_utils import (
     copy_object,
     delete_objects,
-    list_matching_objects,
+    list_objects,
     object_exists,
     upload_file,
 )
@@ -71,7 +71,7 @@ def promote_from_s3(  # noqa: PLR0913
     :return: report dict with counts
     """
     # Get list of objects under the staging prefix
-    staged_objects: list[dict[str, Any]] = list_matching_objects(f"{staging_bucket / staging_key_prefix}/")
+    staged_objects: list[dict[str, Any]] = list_objects(f"{staging_bucket / staging_key_prefix}/")
 
     # Separate data files from sidecars
     sidecars = {PurePosixPath(k["Key"]) for k in staged_objects if k["Key"].endswith((".crc64nvme", ".md5"))}
@@ -394,7 +394,7 @@ def _get_source_dest_pairs_for_accession(
     source_prefix = _get_accession_path_prefix(accession, lakehouse_key_prefix)
     if not source_prefix:
         return []
-    matching_objs: list[dict[str, Any]] = list_matching_objects(f"{lakehouse_bucket / source_prefix}")
+    matching_objs: list[dict[str, Any]] = list_objects(f"{lakehouse_bucket / source_prefix}")
     return [
         (
             PurePosixPath(obj["Key"]),

--- a/src/cdm_data_loaders/parsers/uniprot/idmapping.py
+++ b/src/cdm_data_loaders/parsers/uniprot/idmapping.py
@@ -36,7 +36,7 @@ from pyspark.sql.types import StringType, StructField
 from cdm_data_loaders.core.constants import CDM_LAKE_S3, INVALID_DATA_FIELD_NAME
 from cdm_data_loaders.core.pipeline_run import PipelineRun
 from cdm_data_loaders.readers.dsv import read
-from cdm_data_loaders.utils.file_transfer.s3.object_utils import list_matching_objects
+from cdm_data_loaders.utils.file_transfer.s3.object_utils import list_objects
 from cdm_data_loaders.utils.spark import APPEND, set_up_workspace, write_table
 from cdm_data_loaders.validation.dataframe_validator import DataFrameValidator, Validator
 from cdm_data_loaders.validation.df_nullable_fields import validate as check_nullable_fields
@@ -143,7 +143,7 @@ def cli(source: str, namespace: str, tenant_name: str | None) -> None:
     (spark, database_name) = set_up_workspace(APP_NAME, namespace, tenant_name)
 
     # TODO: other locations / local files?
-    bucket_list = list_matching_objects(source)
+    bucket_list = list_objects(source)
     for file in bucket_list:
         # file names are in the 'Key' value
         # 'tenant-general-warehouse/kbase/datasets/uniprot/id_mapping/id_mapping_part_001.tsv.gz'

--- a/src/cdm_data_loaders/utils/file_transfer/async_client.py
+++ b/src/cdm_data_loaders/utils/file_transfer/async_client.py
@@ -33,6 +33,8 @@ from tenacity import (
 )
 
 from cdm_data_loaders.utils.file_transfer.core import (
+    HTTP_CLIENT_DEFAULTS,
+    RETRY_DEFAULTS,
     DownloadCore,
     DownloadError,
     NonRetryableDownloadError,
@@ -43,14 +45,7 @@ logger: Logger = getLogger(__name__)
 
 def get_async_httpx_client() -> httpx.AsyncClient:
     """Get a basic client for executing http requests."""
-    return httpx.AsyncClient(
-        timeout=httpx.Timeout(30.0),
-        limits=httpx.Limits(
-            max_connections=20,
-            max_keepalive_connections=10,
-        ),
-        follow_redirects=True,
-    )
+    return httpx.AsyncClient(**HTTP_CLIENT_DEFAULTS)
 
 
 class AsyncFileDownloader:
@@ -67,9 +62,9 @@ class AsyncFileDownloader:
     def __init__(  # noqa: PLR0913
         self,
         client: httpx.AsyncClient | None = None,
-        max_attempts: int = 5,
-        min_backoff: int = 1,
-        max_backoff: int = 30,
+        max_attempts: int = RETRY_DEFAULTS["max_attempts"],
+        min_backoff: int = RETRY_DEFAULTS["min_backoff"],
+        max_backoff: int = RETRY_DEFAULTS["max_backoff"],
         chunk_size: int = 8192,
         max_concurrency: int | None = None,
     ) -> None:

--- a/src/cdm_data_loaders/utils/file_transfer/core.py
+++ b/src/cdm_data_loaders/utils/file_transfer/core.py
@@ -7,6 +7,7 @@ from pathlib import Path
 from typing import Any
 
 import httpx
+from frozendict import frozendict
 
 from cdm_data_loaders.utils.checksums import validate_checksum_fn
 
@@ -23,6 +24,27 @@ class NonRetryableDownloadError(Exception):
 
 class ChecksumMismatchError(NonRetryableDownloadError):
     """Checksum validation failed."""
+
+
+HTTP_CLIENT_DEFAULTS = frozendict(
+    {
+        "timeout": httpx.Timeout(30.0),
+        "limits": httpx.Limits(
+            max_connections=20,
+            max_keepalive_connections=10,
+        ),
+        "follow_redirects": True,
+    }
+)
+
+
+RETRY_DEFAULTS = frozendict(
+    {
+        "max_attempts": 5,
+        "min_backoff": 1,
+        "max_backoff": 30,
+    }
+)
 
 
 class DownloadCore:
@@ -72,6 +94,7 @@ class DownloadCore:
         """Check the response from the server and act accordingly."""
         status = response.status_code
 
+        # not modified since last accessed
         if status == 304:  # noqa: PLR2004
             return False
 

--- a/src/cdm_data_loaders/utils/file_transfer/s3/client.py
+++ b/src/cdm_data_loaders/utils/file_transfer/s3/client.py
@@ -9,9 +9,18 @@ from types_boto3_s3.client import S3Client
 # "legacy", "standard", "adaptive"
 AWS_CLIENT_RETRY_MODE: Final[str] = "adaptive"
 # how many times to retry, including the initial attempt
-AWS_CLIENT_TOTAL_MAX_ATTEMPTS: Final[int] = 10
+AWS_CLIENT_TOTAL_MAX_ATTEMPTS: Final[int] = 5
 
 _s3_client: S3Client | None = None
+
+
+def _client_config() -> Config:
+    """Configuration for S3 client."""
+    return Config(
+        retries={"total_max_attempts": AWS_CLIENT_TOTAL_MAX_ATTEMPTS, "mode": AWS_CLIENT_RETRY_MODE},
+        request_checksum_calculation="when_supported",
+        response_checksum_validation="when_supported",
+    )
 
 
 def get_s3_client(args: dict[str, str | None] | None = None) -> S3Client:
@@ -40,12 +49,6 @@ def get_s3_client(args: dict[str, str | None] | None = None) -> S3Client:
     if _s3_client is not None:
         return _s3_client
 
-    config = Config(
-        retries={"total_max_attempts": AWS_CLIENT_TOTAL_MAX_ATTEMPTS, "mode": AWS_CLIENT_RETRY_MODE},
-        request_checksum_calculation="when_supported",
-        response_checksum_validation="when_supported",
-    )
-
     if not args:
         args = {}
 
@@ -58,7 +61,7 @@ def get_s3_client(args: dict[str, str | None] | None = None) -> S3Client:
         raise ValueError(msg)
 
     # initialise using boto3's default config behaviour, plus any overrides from args
-    client = boto3.client("s3", config=config, **kwargs)  # pyright: ignore[reportArgumentType, reportCallIssue]
+    client = boto3.client("s3", config=_client_config(), **kwargs)  # pyright: ignore[reportArgumentType, reportCallIssue]
 
     missing = []
     # boto3 will not raise an error on client creation if credentials are missing, so throw an error now

--- a/src/cdm_data_loaders/utils/file_transfer/s3/object_utils.py
+++ b/src/cdm_data_loaders/utils/file_transfer/s3/object_utils.py
@@ -71,7 +71,7 @@ def split_s3_path(s3_path: str, *, allow_bucket_only: bool = False) -> tuple[str
     return (path_parts[0], path_parts[1])
 
 
-def list_matching_objects(s3_path: str, *, max_keys: int = 1000) -> list[dict[str, Any]]:
+def list_objects(s3_path: str, *, max_keys: int = 1000) -> list[dict[str, Any]]:
     """List the remote paths that start with ``s3_path``.
 
     Note: since s3 paths are basically cosmetic, this function returns all paths that start with

--- a/src/cdm_data_loaders/utils/file_transfer/sync_client.py
+++ b/src/cdm_data_loaders/utils/file_transfer/sync_client.py
@@ -33,6 +33,8 @@ from tenacity import (
 )
 
 from cdm_data_loaders.utils.file_transfer.core import (
+    HTTP_CLIENT_DEFAULTS,
+    RETRY_DEFAULTS,
     DownloadCore,
     DownloadError,
     NonRetryableDownloadError,
@@ -43,14 +45,7 @@ logger: Logger = getLogger(__name__)
 
 def get_httpx_client() -> httpx.Client:
     """Get a basic client for executing http requests."""
-    return httpx.Client(
-        timeout=httpx.Timeout(30.0),
-        limits=httpx.Limits(
-            max_connections=20,
-            max_keepalive_connections=10,
-        ),
-        follow_redirects=True,
-    )
+    return httpx.Client(**HTTP_CLIENT_DEFAULTS)
 
 
 class FileDownloader:
@@ -67,9 +62,9 @@ class FileDownloader:
     def __init__(
         self,
         client: httpx.Client | None = None,
-        max_attempts: int = 5,
-        min_backoff: int = 1,
-        max_backoff: int = 30,
+        max_attempts: int = RETRY_DEFAULTS["max_attempts"],
+        min_backoff: int = RETRY_DEFAULTS["min_backoff"],
+        max_backoff: int = RETRY_DEFAULTS["max_backoff"],
         chunk_size: int = 8192,
     ) -> None:
         """Initialise a synchronous download client.

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,9 +8,12 @@ from copy import deepcopy
 from importlib.util import find_spec
 from pathlib import Path
 from typing import Any, Final
+from unittest.mock import patch
 
+import boto3
 import pytest
 from frozendict import frozendict
+from moto import mock_aws
 from pyspark.conf import SparkConf
 from pyspark.sql import DataFrame, SparkSession
 from pyspark.sql.types import (
@@ -23,7 +26,9 @@ from pyspark.sql.types import (
     StructField,
     StructType,
 )
+from types_boto3_s3.client import S3Client
 
+import cdm_data_loaders.utils.file_transfer.s3.client as s3_client
 from cdm_data_loaders.audit.schema import (
     NAMESPACE,
     PIPELINE,
@@ -33,6 +38,8 @@ from cdm_data_loaders.audit.schema import (
 )
 from cdm_data_loaders.core.pipeline_run import PipelineRun
 from cdm_data_loaders.readers.dsv import INVALID_DATA_FIELD
+from cdm_data_loaders.utils.file_transfer.s3.client import _client_config, reset_s3_client
+from tests.s3_helpers import strip_checksum_algorithm
 
 SAVE_DIR: Final[str] = "spark.sql.warehouse.dir"
 
@@ -40,7 +47,7 @@ TEST_NS: Final[str] = "test_ns"
 PIPELINE_RUN = frozendict({RUN_ID: "1234-5678-90", PIPELINE: "KeystoneXL", SOURCE: "/path/to/file"})
 ALT_PIPELINE_RUN = frozendict({RUN_ID: "9876-5432-10", PIPELINE: "KeystoneXXXL", SOURCE: "/path/to/dir"})
 
-CASSETTES_DIR = "tests/cassettes"
+CASSETTES_DIR: Final[str] = "tests/cassettes"
 
 DEFAULT_VCR_CONFIG = frozendict(
     {
@@ -584,3 +591,58 @@ def pipeline_run() -> PipelineRun:
 def alt_pipeline_run() -> PipelineRun:
     """Generate a different pipeline run."""
     return PipelineRun(**{**ALT_PIPELINE_RUN, NAMESPACE: TEST_NS})
+
+
+"""S3 Client mocks"""
+
+
+TEST_BUCKET: Final[str] = "test_bucket"
+ALT_BUCKET: Final[str] = "alt_bucket"
+BUCKETS = [TEST_BUCKET, ALT_BUCKET]
+
+
+@pytest.fixture
+def mock_s3_client(monkeypatch: pytest.MonkeyPatch) -> Generator[S3Client, Any]:
+    """Yield a mocked S3 client with both valid buckets created.
+
+    The function get_s3_client() is patched to ensure that all module functions use this client.
+
+    Resets the cached client before and after to prevent state leaking between tests.
+    """
+    # Remove any real endpoint/credential env vars so moto intercepts all HTTP calls.
+    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
+    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
+    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
+    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
+    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
+    boto3.DEFAULT_SESSION = None
+
+    with mock_aws():
+        reset_s3_client()
+        client: S3Client = boto3.client("s3", config=_client_config())
+
+        for bucket in BUCKETS:
+            client.create_bucket(Bucket=bucket)
+
+        # delete any existing client
+        reset_s3_client()
+        assert s3_client._s3_client is None  # noqa: SLF001
+
+        # patch in the client that we have just created
+        with patch.object(s3_client, "get_s3_client", return_value=client):
+            yield client
+
+        reset_s3_client()
+        assert s3_client._s3_client is None  # noqa: SLF001
+
+
+@pytest.fixture
+def mock_s3_client_no_checksum(mock_s3_client: S3Client) -> S3Client:
+    """Yield the mocked S3 client with copy_object patched to strip ChecksumAlgorithm.
+
+    This works around the moto limitation of not supporting CRC64NVME checksums,
+    allowing copy and upload calls that include ChecksumAlgorithm to succeed.
+    """
+    for function in ["copy", "copy_object", "upload_file", "upload_fileobj"]:
+        setattr(mock_s3_client, function, strip_checksum_algorithm(getattr(mock_s3_client, function)))
+    return mock_s3_client

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -39,7 +39,6 @@ from cdm_data_loaders.audit.schema import (
 from cdm_data_loaders.core.pipeline_run import PipelineRun
 from cdm_data_loaders.readers.dsv import INVALID_DATA_FIELD
 from cdm_data_loaders.utils.file_transfer.s3.client import _client_config, reset_s3_client
-from tests.s3_helpers import strip_checksum_algorithm
 
 SAVE_DIR: Final[str] = "spark.sql.warehouse.dir"
 
@@ -634,15 +633,3 @@ def mock_s3_client(monkeypatch: pytest.MonkeyPatch) -> Generator[S3Client, Any]:
 
         reset_s3_client()
         assert s3_client._s3_client is None  # noqa: SLF001
-
-
-@pytest.fixture
-def mock_s3_client_no_checksum(mock_s3_client: S3Client) -> S3Client:
-    """Yield the mocked S3 client with copy_object patched to strip ChecksumAlgorithm.
-
-    This works around the moto limitation of not supporting CRC64NVME checksums,
-    allowing copy and upload calls that include ChecksumAlgorithm to succeed.
-    """
-    for function in ["copy", "copy_object", "upload_file", "upload_fileobj"]:
-        setattr(mock_s3_client, function, strip_checksum_algorithm(getattr(mock_s3_client, function)))
-    return mock_s3_client

--- a/tests/integration/conftest.py
+++ b/tests/integration/conftest.py
@@ -21,7 +21,7 @@ from botocore.exceptions import ClientError
 
 from cdm_data_loaders.ncbi_ftp.assembly import build_accession_path
 from cdm_data_loaders.utils.file_transfer.s3 import client
-from cdm_data_loaders.utils.file_transfer.s3.client import reset_s3_client
+from cdm_data_loaders.utils.file_transfer.s3.client import _client_config, reset_s3_client
 
 # Maximum length of a bucket name per S3/DNS spec
 _MAX_BUCKET_LEN = 63
@@ -75,7 +75,7 @@ def ceph_s3_client() -> Generator[botocore.client.BaseClient]:
     Patches ``get_s3_client`` on every module that uses it so internal calls
     are transparently routed to CEPH.
     """
-    s3_client = boto3.client("s3")
+    s3_client = boto3.client("s3", config=_client_config())
 
     reset_s3_client()
     with (

--- a/tests/ncbi_ftp/conftest.py
+++ b/tests/ncbi_ftp/conftest.py
@@ -1,23 +1,16 @@
 """Shared fixtures for ncbi_ftp tests."""
 
-from collections.abc import Generator
 from pathlib import PurePosixPath
 from types import SimpleNamespace
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
-import boto3
-import botocore.client
 import pytest
-from moto import mock_aws
 
 import cdm_data_loaders.ncbi_ftp.manifest as manifest_mod
-from cdm_data_loaders.utils.file_transfer.s3 import client
-from cdm_data_loaders.utils.file_transfer.s3.client import reset_s3_client
-from tests.s3_helpers import strip_checksum_algorithm
-from tests.utils.file_transfer.s3.conftest import TEST_BUCKET as test_bucket_str  # noqa: N811
+from tests.conftest import TEST_BUCKET as TEST_BUCKET_STR
 
 AWS_REGION = "us-east-1"
-TEST_BUCKET: PurePosixPath = PurePosixPath(test_bucket_str)
+TEST_BUCKET: PurePosixPath = PurePosixPath(TEST_BUCKET_STR)
 
 
 # Minimal assembly_summary_refseq.txt content (tab-separated, 20+ columns)
@@ -62,41 +55,12 @@ _MD5_CHECKSUMS_TXT = (
 
 
 @pytest.fixture
-def mock_s3_client(monkeypatch: pytest.MonkeyPatch) -> Generator[botocore.client.BaseClient]:
-    """Yield a mocked S3 client with the CDM Lake bucket created."""
-    # Remove any real endpoint/credential env vars so moto intercepts all HTTP calls.
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
-    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
-    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
-    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
-    boto3.DEFAULT_SESSION = None
-
-    with mock_aws():
-        s3_client = boto3.client("s3", region_name=AWS_REGION)
-        s3_client.create_bucket(Bucket=str(TEST_BUCKET))
-
-        reset_s3_client()
-        with patch.object(client, "get_s3_client", return_value=s3_client):
-            yield s3_client
-        reset_s3_client()
-
-
-@pytest.fixture
-def mock_s3_client_no_checksum(mock_s3_client: botocore.client.BaseClient) -> botocore.client.BaseClient:
-    """Mocked S3 client with copy_object and upload_file patched to strip ChecksumAlgorithm."""
-    mock_s3_client.copy_object = strip_checksum_algorithm(mock_s3_client.copy_object)  # type: ignore[method-assign]
-    mock_s3_client.upload_file = strip_checksum_algorithm(mock_s3_client.upload_file)  # type: ignore[method-assign]
-    return mock_s3_client
-
-
-@pytest.fixture
 def manifest_transfer_mocks(monkeypatch: pytest.MonkeyPatch) -> SimpleNamespace:
     """Mocked manifest transfer functions for retrieving MD5 checksum text and listing matching S3 objects."""
     mock_retrieve = MagicMock(return_value=_MD5_CHECKSUMS_TXT)
     mock_list = MagicMock(return_value=["one key"])
 
     monkeypatch.setattr(manifest_mod, "ftp_retrieve_text", mock_retrieve)
-    monkeypatch.setattr(manifest_mod, "list_matching_objects", mock_list)
+    monkeypatch.setattr(manifest_mod, "list_objects", mock_list)
 
     return SimpleNamespace(retrieve=mock_retrieve, list=mock_list)

--- a/tests/ncbi_ftp/test_manifest.py
+++ b/tests/ncbi_ftp/test_manifest.py
@@ -387,7 +387,7 @@ def test_verify_transfer_candidates_empty_input() -> None:
 
 
 @pytest.mark.usefixtures("manifest_transfer_mocks")
-@patch("cdm_data_loaders.ncbi_ftp.manifest.list_matching_objects", return_value=["one key"])
+@patch("cdm_data_loaders.ncbi_ftp.manifest.list_objects", return_value=["one key"])
 def test_verify_transfer_candidates_unknown_accession_kept(
     mock_connect: MagicMock,
 ) -> None:
@@ -540,10 +540,10 @@ def _make_mock_list_object_return_value() -> list[dict[str, Any]]:
     ]
 
 
-@patch("cdm_data_loaders.ncbi_ftp.manifest.list_matching_objects")
-def test_scan_store_builds_summary(mock_list_matching_objects: MagicMock) -> None:
+@patch("cdm_data_loaders.ncbi_ftp.manifest.list_objects")
+def test_scan_store_builds_summary(mock_list_objects: MagicMock) -> None:
     """Synthetic summary is built correctly with provided release_date for all assemblies."""
-    mock_list_matching_objects.return_value = _make_mock_list_object_return_value()
+    mock_list_objects.return_value = _make_mock_list_object_return_value()
     assert scan_store_to_synthetic_summary(PurePosixPath("test-bucket"), PurePosixPath("prefix"), "2024/01/31") == {
         "GCF_000001215.4": AssemblyRecord(
             accession="GCF_000001215.4",
@@ -562,10 +562,10 @@ def test_scan_store_builds_summary(mock_list_matching_objects: MagicMock) -> Non
     }
 
 
-@patch("cdm_data_loaders.ncbi_ftp.manifest.list_matching_objects")
-def test_scan_store_applies_release_date_to_all(mock_list_matching_objects: MagicMock) -> None:
+@patch("cdm_data_loaders.ncbi_ftp.manifest.list_objects")
+def test_scan_store_applies_release_date_to_all(mock_list_objects: MagicMock) -> None:
     """Provided release_date is used even when files have different LastModified dates."""
-    mock_list_matching_objects.return_value = [
+    mock_list_objects.return_value = [
         {
             "Key": "prefix/GCF_000001215.4_v1/file_newer.gz",
             "LastModified": datetime(2024, 3, 20, tzinfo=UTC),
@@ -583,18 +583,18 @@ def test_scan_store_applies_release_date_to_all(mock_list_matching_objects: Magi
     )
 
 
-@patch("cdm_data_loaders.ncbi_ftp.manifest.list_matching_objects")
-def test_scan_store_raises_for_invalid_release_date(mock_list_matching_objects: MagicMock) -> None:
+@patch("cdm_data_loaders.ncbi_ftp.manifest.list_objects")
+def test_scan_store_raises_for_invalid_release_date(mock_list_objects: MagicMock) -> None:
     """Invalid release_date format is rejected."""
-    mock_list_matching_objects.return_value = _make_mock_list_object_return_value()
+    mock_list_objects.return_value = _make_mock_list_object_return_value()
     with pytest.raises(ValueError, match="Invalid release_date"):
         scan_store_to_synthetic_summary(PurePosixPath("test-bucket"), PurePosixPath("prefix"), "2024-03-31")
 
 
-@patch("cdm_data_loaders.ncbi_ftp.manifest.list_matching_objects")
-def test_scan_store_invokes_progress_callback(mock_list_matching_objects: MagicMock) -> None:
+@patch("cdm_data_loaders.ncbi_ftp.manifest.list_objects")
+def test_scan_store_invokes_progress_callback(mock_list_objects: MagicMock) -> None:
     """Progress callback is called once per unique assembly discovered."""
-    mock_list_matching_objects.return_value = _make_mock_list_object_return_value()
+    mock_list_objects.return_value = _make_mock_list_object_return_value()
     calls: list[tuple[int, str]] = []
     scan_store_to_synthetic_summary(
         PurePosixPath("test-bucket"),
@@ -607,17 +607,17 @@ def test_scan_store_invokes_progress_callback(mock_list_matching_objects: MagicM
     assert calls[1][0] == 2  # noqa: PLR2004
 
 
-@patch("cdm_data_loaders.ncbi_ftp.manifest.list_matching_objects")
-def test_scan_store_handles_empty_store(mock_list_matching_objects: MagicMock) -> None:
+@patch("cdm_data_loaders.ncbi_ftp.manifest.list_objects")
+def test_scan_store_handles_empty_store(mock_list_objects: MagicMock) -> None:
     """Empty store returns empty dict."""
-    mock_list_matching_objects.return_value = []
+    mock_list_objects.return_value = []
     assert scan_store_to_synthetic_summary(PurePosixPath("test-bucket"), PurePosixPath("prefix"), "2024/01/31") == {}
 
 
-@patch("cdm_data_loaders.ncbi_ftp.manifest.list_matching_objects")
-def test_scan_store_skips_objects_without_accession(mock_list_matching_objects: MagicMock) -> None:
+@patch("cdm_data_loaders.ncbi_ftp.manifest.list_objects")
+def test_scan_store_skips_objects_without_accession(mock_list_objects: MagicMock) -> None:
     """Objects without valid accessions in the key are skipped."""
-    mock_list_matching_objects.return_value = [
+    mock_list_objects.return_value = [
         {
             "Key": PurePosixPath("prefix") / "some" / "random" / "file.txt",
             "LastModified": datetime(2024, 1, 1, tzinfo=UTC),
@@ -632,14 +632,14 @@ def test_scan_store_skips_objects_without_accession(mock_list_matching_objects: 
     assert "GCF_000001215.4" in result
 
 
-@patch("cdm_data_loaders.ncbi_ftp.manifest.list_matching_objects")
-def test_scan_store_assembly_dir_survives_round_trip(mock_list_matching_objects: MagicMock, tmp_path: Path) -> None:
+@patch("cdm_data_loaders.ncbi_ftp.manifest.list_objects")
+def test_scan_store_assembly_dir_survives_round_trip(mock_list_objects: MagicMock, tmp_path: Path) -> None:
     """assembly_dir is preserved after save-to-file / parse-back round-trip.
 
     Regression: previously ftp_path was written as "" causing assembly_dir=""
     and compute_diff flagging every assembly as updated.
     """
-    mock_list_matching_objects.return_value = [
+    mock_list_objects.return_value = [
         {
             "Key": "prefix/GCF_000001215.4_Release_6_plus_ISO1_MT/file.gz",
             "LastModified": datetime(2024, 3, 10, tzinfo=UTC),

--- a/tests/ncbi_ftp/test_promote.py
+++ b/tests/ncbi_ftp/test_promote.py
@@ -85,10 +85,10 @@ def _stage_files(s3_client: botocore.client.BaseClient, prefix: PurePosixPath) -
 
 
 @pytest.mark.s3
-def test_promote_dry_run_no_writes(mock_s3_client_no_checksum: botocore.client.BaseClient) -> None:
+def test_promote_dry_run_no_writes(mock_s3_client: botocore.client.BaseClient) -> None:
     """Verify dry_run does not write any objects."""
     prefix = PurePosixPath("staging/run1")
-    _stage_files(mock_s3_client_no_checksum, prefix)
+    _stage_files(mock_s3_client, prefix)
 
     report = promote_from_s3(
         staging_key_prefix=prefix,
@@ -101,17 +101,14 @@ def test_promote_dry_run_no_writes(mock_s3_client_no_checksum: botocore.client.B
     assert report["dry_run"] is True
 
     final_key = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_215 / "GCF_000001215.4_genomic.fna.gz"
-    assert (
-        mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(final_key)).get("KeyCount", 0)
-        == 0
-    )
+    assert mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(final_key)).get("KeyCount", 0) == 0
 
 
 @pytest.mark.s3
-def test_promote_with_metadata(mock_s3_client_no_checksum: botocore.client.BaseClient) -> None:
+def test_promote_with_metadata(mock_s3_client: botocore.client.BaseClient) -> None:
     """Objects are promoted with MD5 metadata; download_report.json is skipped."""
     prefix = PurePosixPath("staging/run1")
-    _stage_files(mock_s3_client_no_checksum, prefix)
+    _stage_files(mock_s3_client, prefix)
 
     report = promote_from_s3(
         staging_key_prefix=prefix,
@@ -123,7 +120,7 @@ def test_promote_with_metadata(mock_s3_client_no_checksum: botocore.client.BaseC
     assert report["failed"] == 0
 
     final_key = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_215 / "GCF_000001215.4_genomic.fna.gz"
-    resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(final_key))
+    resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(final_key))
     assert resp["Metadata"].get("md5") == "md5hash123"
 
 
@@ -149,7 +146,7 @@ def test_promote_with_metadata(mock_s3_client_no_checksum: botocore.client.BaseC
     ],
 )
 def test_trim_manifest(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
     manifest_body: str,
     promoted_set: set[str],
     expected_present: list[str],
@@ -157,11 +154,9 @@ def test_trim_manifest(
 ) -> None:
     """Promoted accessions are removed; others remain (partial) or the manifest empties (all)."""
     manifest_key = PurePosixPath("manifests/transfer_manifest.txt")
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(manifest_key), Body=manifest_body.encode())
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(manifest_key), Body=manifest_body.encode())
     _trim_manifest(manifest_key, TEST_BUCKET, promoted_set)
-    remaining = (
-        mock_s3_client_no_checksum.get_object(Bucket=str(TEST_BUCKET), Key=str(manifest_key))["Body"].read().decode()
-    )
+    remaining = mock_s3_client.get_object(Bucket=str(TEST_BUCKET), Key=str(manifest_key))["Body"].read().decode()
     for acc in expected_present:
         assert acc in remaining
     for acc in expected_absent:
@@ -171,7 +166,7 @@ def test_trim_manifest(
 # Helpers for _archive_assemblies tests
 
 
-def _mock_list_matching_objects(path: str) -> list[dict[str, str]]:
+def _mock_list_objects(path: str) -> list[dict[str, str]]:
     bucket = PurePosixPath("some-bucket")
     prefix = PurePosixPath("some/prefix")
     p = PurePosixPath(path)
@@ -307,7 +302,7 @@ def test_get_source_dest_pairs_for_accession(
     expected: list[tuple[str, str]],
 ) -> None:
     """get_source_dest_pairs_for_accession returns correct source-dest pairs for valid accessions, empty list for invalid."""
-    with patch("cdm_data_loaders.ncbi_ftp.promote.list_matching_objects", side_effect=_mock_list_matching_objects):
+    with patch("cdm_data_loaders.ncbi_ftp.promote.list_objects", side_effect=_mock_list_objects):
         result = _get_source_dest_pairs_for_accession(
             accession,
             bucket,
@@ -394,7 +389,7 @@ def test_dry_run_output(
 )
 @pytest.mark.s3
 def test_archive_objects(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
     key_pairs: list[tuple[PurePosixPath, PurePosixPath]],
     bucket: PurePosixPath,
     delete_source: bool,
@@ -403,19 +398,19 @@ def test_archive_objects(
 ) -> None:
     """_archive_assemblies copies source to dest for each pair, and deletes source if delete_source=True."""
     for source, _ in key_pairs:
-        mock_s3_client_no_checksum.put_object(Bucket=str(bucket), Key=str(source), Body=b"data")
+        mock_s3_client.put_object(Bucket=str(bucket), Key=str(source), Body=b"data")
     assert _archive_objects(key_pairs, bucket, delete_source=delete_source) == expected
-    assert mock_s3_client_no_checksum.list_objects_v2(Bucket=str(bucket)).get("KeyCount", 0) == len(existing_objects)
-    for obj in mock_s3_client_no_checksum.list_objects_v2(Bucket=str(bucket)).get("Contents", []):
+    assert mock_s3_client.list_objects_v2(Bucket=str(bucket)).get("KeyCount", 0) == len(existing_objects)
+    for obj in mock_s3_client.list_objects_v2(Bucket=str(bucket)).get("Contents", []):
         assert obj["Key"] in existing_objects, f"Unexpected object in bucket: {obj['Key']}"
 
 
 @pytest.mark.s3
-def test_archive_assemblies_removed(mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path) -> None:
+def test_archive_assemblies_removed(mock_s3_client: botocore.client.BaseClient, tmp_path: Path) -> None:
     """Removed accessions are archived and originals deleted."""
     accession = "GCF_000005845.2"
     key = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_845 / f"{accession}_genomic.fna.gz"
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"data")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"data")
 
     manifest = tmp_path / "removed.txt"
     manifest.write_text(f"{accession}\n")
@@ -431,7 +426,7 @@ def test_archive_assemblies_removed(mock_s3_client_no_checksum: botocore.client.
         )
         == 1
     )
-    assert mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(key)).get("KeyCount", 0) == 0
+    assert mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(key)).get("KeyCount", 0) == 0
 
     archive_key = (
         DEFAULT_LAKEHOUSE_KEY_PREFIX
@@ -442,20 +437,15 @@ def test_archive_assemblies_removed(mock_s3_client_no_checksum: botocore.client.
         / ACC_PATH_845
         / f"{accession}_genomic.fna.gz"
     )
-    assert (
-        mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(archive_key)).get("KeyCount", 0)
-        == 1
-    )
+    assert mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(archive_key)).get("KeyCount", 0) == 1
 
 
 @pytest.mark.s3
-def test_archive_assemblies_updated_no_delete(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
-) -> None:
+def test_archive_assemblies_updated_no_delete(mock_s3_client: botocore.client.BaseClient, tmp_path: Path) -> None:
     """Updated accessions are archived but originals remain."""
     accession = "GCF_000001215.4"
     key = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_215 / f"{accession}_genomic.fna.gz"
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"original-data")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"original-data")
 
     manifest = tmp_path / "updated.txt"
     manifest.write_text(f"{accession}\n")
@@ -471,7 +461,7 @@ def test_archive_assemblies_updated_no_delete(
         )
         == 1
     )
-    assert mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(key)).get("KeyCount", 0) == 1
+    assert mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(key)).get("KeyCount", 0) == 1
 
     archive_key = (
         DEFAULT_LAKEHOUSE_KEY_PREFIX
@@ -482,18 +472,18 @@ def test_archive_assemblies_updated_no_delete(
         / ACC_PATH_215
         / f"{accession}_genomic.fna.gz"
     )
-    resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(archive_key))
+    resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(archive_key))
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK
 
 
 @pytest.mark.s3
 def test_archive_assemblies_multiple_releases_no_collision(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
+    mock_s3_client: botocore.client.BaseClient, tmp_path: Path
 ) -> None:
     """Archiving the same accession in different releases creates distinct folders."""
     accession = "GCF_000001215.4"
     key = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_215 / f"{accession}_genomic.fna.gz"
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"v1-data")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"v1-data")
 
     manifest = tmp_path / "updated.txt"
     manifest.write_text(f"{accession}\n")
@@ -505,7 +495,7 @@ def test_archive_assemblies_multiple_releases_no_collision(
         ncbi_release="2024-01",
         archive_reason="updated",
     )
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"v2-data")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"v2-data")
     _archive_assemblies(
         manifest,
         lakehouse_bucket=TEST_BUCKET,
@@ -532,22 +522,16 @@ def test_archive_assemblies_multiple_releases_no_collision(
         / ACC_PATH_215
         / f"{accession}_genomic.fna.gz"
     )
-    assert (
-        mock_s3_client_no_checksum.get_object(Bucket=str(TEST_BUCKET), Key=str(archive_key_1))["Body"].read()
-        == b"v1-data"
-    )
-    assert (
-        mock_s3_client_no_checksum.get_object(Bucket=str(TEST_BUCKET), Key=str(archive_key_2))["Body"].read()
-        == b"v2-data"
-    )
+    assert mock_s3_client.get_object(Bucket=str(TEST_BUCKET), Key=str(archive_key_1))["Body"].read() == b"v1-data"
+    assert mock_s3_client.get_object(Bucket=str(TEST_BUCKET), Key=str(archive_key_2))["Body"].read() == b"v2-data"
 
 
 @pytest.mark.s3
-def test_archive_assemblies_dry_run(mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path) -> None:
+def test_archive_assemblies_dry_run(mock_s3_client: botocore.client.BaseClient, tmp_path: Path) -> None:
     """dry_run does not copy or delete anything."""
     accession = "GCF_000005845.2"
     key = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_845 / f"{accession}_genomic.fna.gz"
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"data")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"data")
 
     manifest = tmp_path / "removed.txt"
     manifest.write_text(f"{accession}\n")
@@ -564,20 +548,15 @@ def test_archive_assemblies_dry_run(mock_s3_client_no_checksum: botocore.client.
         )
         == 1
     )
-    assert mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(key)).get("KeyCount", 0) == 1
+    assert mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(key)).get("KeyCount", 0) == 1
 
     archive_prefix = DEFAULT_LAKEHOUSE_KEY_PREFIX / "archive" / "2024-01"
-    assert (
-        mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(archive_prefix)).get(
-            "KeyCount", 0
-        )
-        == 0
-    )
+    assert mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(archive_prefix)).get("KeyCount", 0) == 0
 
 
 @pytest.mark.s3
 def test_archive_assemblies_no_objects_skips(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,  # noqa: ARG001
+    mock_s3_client: botocore.client.BaseClient,  # noqa: ARG001
     tmp_path: Path,
 ) -> None:
     """Accessions with no existing S3 objects are silently skipped."""
@@ -596,12 +575,12 @@ def test_archive_assemblies_no_objects_skips(
 
 @pytest.mark.s3
 def test_archive_assemblies_unknown_release_fallback(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
+    mock_s3_client: botocore.client.BaseClient, tmp_path: Path
 ) -> None:
     """ncbi_release=None falls back to 'unknown' in the archive path."""
     accession = "GCF_000001215.4"
     key = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_215 / f"{accession}_genomic.fna.gz"
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"data")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"data")
 
     manifest = tmp_path / "updated.txt"
     manifest.write_text(f"{accession}\n")
@@ -622,19 +601,14 @@ def test_archive_assemblies_unknown_release_fallback(
         / ACC_PATH_215
         / f"{accession}_genomic.fna.gz"
     )
-    assert (
-        mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(archive_key)).get("KeyCount", 0)
-        == 1
-    )
+    assert mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(archive_key)).get("KeyCount", 0) == 1
 
 
 # Concurrent / multi-file archive (new behaviour)
 
 
 @pytest.mark.s3
-def test_archive_assemblies_multi_file_all_copied(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
-) -> None:
+def test_archive_assemblies_multi_file_all_copied(mock_s3_client: botocore.client.BaseClient, tmp_path: Path) -> None:
     """All files for an accession are copied concurrently — none missed."""
     accession = "GCF_000001215.4"
     base = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_215
@@ -646,7 +620,7 @@ def test_archive_assemblies_multi_file_all_copied(
         f"{accession}_assembly_stats.txt",
     ]
     for fname in file_names:
-        mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(base / fname), Body=fname.encode())
+        mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(base / fname), Body=fname.encode())
 
     manifest = tmp_path / "updated.txt"
     manifest.write_text(f"{accession}\n")
@@ -663,13 +637,13 @@ def test_archive_assemblies_multi_file_all_copied(
     assert archived == len(file_names)
     archive_base = DEFAULT_LAKEHOUSE_KEY_PREFIX / "archive" / "2024-01" / "updated" / "raw_data" / ACC_PATH_215
     for fname in file_names:
-        resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(archive_base / fname))
+        resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(archive_base / fname))
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK
 
 
 @pytest.mark.s3
 def test_archive_assemblies_multi_file_content_preserved(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
+    mock_s3_client: botocore.client.BaseClient, tmp_path: Path
 ) -> None:
     """Archive copies preserve byte-for-byte content of each file."""
     accession = "GCF_000001215.4"
@@ -679,7 +653,7 @@ def test_archive_assemblies_multi_file_content_preserved(
         f"{accession}_protein.faa.gz": b"\x1f\x8bPROTEIN",
     }
     for fname, body in files.items():
-        mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(base / fname), Body=body)
+        mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(base / fname), Body=body)
 
     manifest = tmp_path / "updated.txt"
     manifest.write_text(f"{accession}\n")
@@ -695,14 +669,12 @@ def test_archive_assemblies_multi_file_content_preserved(
 
     archive_base = DEFAULT_LAKEHOUSE_KEY_PREFIX / "archive" / "2024-01" / "updated" / "raw_data" / ACC_PATH_215
     for fname, original_body in files.items():
-        obj = mock_s3_client_no_checksum.get_object(Bucket=str(TEST_BUCKET), Key=str(archive_base / fname))
+        obj = mock_s3_client.get_object(Bucket=str(TEST_BUCKET), Key=str(archive_base / fname))
         assert obj["Body"].read() == original_body, f"Content mismatch for {fname}"
 
 
 @pytest.mark.s3
-def test_archive_assemblies_multi_file_delete_all(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
-) -> None:
+def test_archive_assemblies_multi_file_delete_all(mock_s3_client: botocore.client.BaseClient, tmp_path: Path) -> None:
     """Batch delete removes ALL source files when delete_source=True."""
     accession = "GCF_000005845.2"
     base = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_845
@@ -712,7 +684,7 @@ def test_archive_assemblies_multi_file_delete_all(
         f"{accession}_assembly_report.txt",
     ]
     for fname in file_names:
-        mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(base / fname), Body=b"data")
+        mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(base / fname), Body=b"data")
 
     manifest = tmp_path / "removed.txt"
     manifest.write_text(f"{accession}\n")
@@ -729,14 +701,14 @@ def test_archive_assemblies_multi_file_delete_all(
     assert archived == len(file_names)
     # All sources deleted
     for fname in file_names:
-        result = mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(base / fname))
+        result = mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(base / fname))
         assert result.get("KeyCount", 0) == 0, f"Source not deleted: {fname}"
     # All archives present
     archive_base = (
         DEFAULT_LAKEHOUSE_KEY_PREFIX / "archive" / "2024-03" / "replaced_or_suppressed" / "raw_data" / ACC_PATH_845
     )
     for fname in file_names:
-        resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(archive_base / fname))
+        resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(archive_base / fname))
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK
 
 
@@ -745,7 +717,7 @@ def test_archive_assemblies_multi_file_delete_all(
 
 @pytest.mark.s3
 def test_archive_assemblies_partial_already_archived_overwritten(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
+    mock_s3_client: botocore.client.BaseClient, tmp_path: Path
 ) -> None:
     """Re-running archive after a partial run overwrites the already-archived files.
 
@@ -759,12 +731,10 @@ def test_archive_assemblies_partial_already_archived_overwritten(
     file_a = f"{accession}_genomic.fna.gz"
     file_b = f"{accession}_protein.faa.gz"
 
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(base / file_a), Body=b"new-genomic")
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(base / file_b), Body=b"new-protein")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(base / file_a), Body=b"new-genomic")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(base / file_b), Body=b"new-protein")
     # Simulate partial prior run: file_a already archived with stale content
-    mock_s3_client_no_checksum.put_object(
-        Bucket=str(TEST_BUCKET), Key=f"{archive_base / file_a}", Body=b"stale-genomic"
-    )
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=f"{archive_base / file_a}", Body=b"stale-genomic")
 
     manifest = tmp_path / "updated.txt"
     manifest.write_text(f"{accession}\n")
@@ -780,17 +750,15 @@ def test_archive_assemblies_partial_already_archived_overwritten(
 
     assert archived == 2  # noqa: PLR2004
     # file_a should now have the current content (overwritten)
-    obj_a = mock_s3_client_no_checksum.get_object(Bucket=str(TEST_BUCKET), Key=str(archive_base / file_a))
+    obj_a = mock_s3_client.get_object(Bucket=str(TEST_BUCKET), Key=str(archive_base / file_a))
     assert obj_a["Body"].read() == b"new-genomic", "Re-run should overwrite stale archive"
     # file_b should now be archived
-    obj_b = mock_s3_client_no_checksum.get_object(Bucket=str(TEST_BUCKET), Key=str(archive_base / file_b))
+    obj_b = mock_s3_client.get_object(Bucket=str(TEST_BUCKET), Key=str(archive_base / file_b))
     assert obj_b["Body"].read() == b"new-protein"
 
 
 @pytest.mark.s3
-def test_archive_assemblies_partial_delete_resumes(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
-) -> None:
+def test_archive_assemblies_partial_delete_resumes(mock_s3_client: botocore.client.BaseClient, tmp_path: Path) -> None:
     """Re-running replaced_or_suppressed archive after partial copy+delete is safe.
 
     Simulates: file_a was copied+deleted, file_b was copied but NOT deleted,
@@ -808,11 +776,11 @@ def test_archive_assemblies_partial_delete_resumes(
 
     # file_a already gone (deleted in first partial run)
     # file_b present at source (not yet deleted from first partial run)
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(base / file_b), Body=b"protein")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(base / file_b), Body=b"protein")
     # file_c present at source (not touched at all)
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(base / file_c), Body=b"report")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(base / file_c), Body=b"report")
     # file_a already at archive destination
-    mock_s3_client_no_checksum.put_object(
+    mock_s3_client.put_object(
         Bucket=str(TEST_BUCKET), Key=f"{archive_base / accession}_genomic.fna.gz", Body=b"genomic"
     )
 
@@ -832,25 +800,23 @@ def test_archive_assemblies_partial_delete_resumes(
     assert archived == 2  # noqa: PLR2004
     # Both now gone from source
     for fname in (file_b, file_c):
-        result = mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(base / fname))
+        result = mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(base / fname))
         assert result.get("KeyCount", 0) == 0, f"Expected {fname} deleted"
     # file_a archive still intact (not touched by re-run)
-    resp = mock_s3_client_no_checksum.head_object(
-        Bucket=str(TEST_BUCKET), Key=f"{archive_base / accession}_genomic.fna.gz"
-    )
+    resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=f"{archive_base / accession}_genomic.fna.gz")
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK
 
 
 @pytest.mark.s3
 def test_archive_assemblies_idempotent_updated_reruns_cleanly(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
+    mock_s3_client: botocore.client.BaseClient, tmp_path: Path
 ) -> None:
     """Running updated archive twice on the same data produces the same result."""
     accession = "GCF_000001215.4"
     base = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_215
     file_names = [f"{accession}_genomic.fna.gz", f"{accession}_protein.faa.gz"]
     for fname in file_names:
-        mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(base / fname), Body=b"content")
+        mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(base / fname), Body=b"content")
 
     manifest = tmp_path / "updated.txt"
     manifest.write_text(f"{accession}\n")
@@ -874,13 +840,13 @@ def test_archive_assemblies_idempotent_updated_reruns_cleanly(
     assert archived_2 == len(file_names)
     # Sources still present after both runs (delete_source=False)
     for fname in file_names:
-        resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(base / fname))
+        resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(base / fname))
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK
 
 
 @pytest.mark.s3
 def test_archive_assemblies_multi_accession_manifest(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
+    mock_s3_client: botocore.client.BaseClient, tmp_path: Path
 ) -> None:
     """Multiple accessions in a single manifest are all archived."""
     accessions = [
@@ -889,7 +855,7 @@ def test_archive_assemblies_multi_accession_manifest(
     ]
     for accession, asm_dir, path in accessions:
         key = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / path / asm_dir / f"{accession}_genomic.fna.gz"
-        mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"data")
+        mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"data")
 
     manifest = tmp_path / "updated.txt"
     manifest.write_text("\n".join(acc for acc, _, _ in accessions) + "\n")
@@ -914,20 +880,18 @@ def test_archive_assemblies_multi_accession_manifest(
             / asm_dir
             / f"{accession}_genomic.fna.gz"
         )
-        result = mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(archive_key))
+        result = mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(archive_key))
         assert result.get("KeyCount", 0) == 1, f"Archive missing for {accession}"
 
 
 @pytest.mark.s3
-def test_archive_assemblies_dry_run_multi_file(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
-) -> None:
+def test_archive_assemblies_dry_run_multi_file(mock_s3_client: botocore.client.BaseClient, tmp_path: Path) -> None:
     """dry_run with multiple files per accession makes no copies and no deletes."""
     accession = "GCF_000005845.2"
     base = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_845
     file_names = [f"{accession}_genomic.fna.gz", f"{accession}_protein.faa.gz", f"{accession}_rna.fna.gz"]
     for fname in file_names:
-        mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(base / fname), Body=b"data")
+        mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(base / fname), Body=b"data")
 
     manifest = tmp_path / "removed.txt"
     manifest.write_text(f"{accession}\n")
@@ -946,22 +910,22 @@ def test_archive_assemblies_dry_run_multi_file(
     assert archived == len(file_names)
     # No actual archive keys created
     archive_prefix = DEFAULT_LAKEHOUSE_KEY_PREFIX / "archive"
-    result = mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(archive_prefix))
+    result = mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(archive_prefix))
     assert result.get("KeyCount", 0) == 0
     # Sources untouched
     for fname in file_names:
-        resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(base / fname))
+        resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(base / fname))
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK
 
 
 @pytest.mark.s3
 def test_archive_assemblies_invalid_accession_skipped(
-    mock_s3_client_no_checksum: botocore.client.BaseClient, tmp_path: Path
+    mock_s3_client: botocore.client.BaseClient, tmp_path: Path
 ) -> None:
     """Malformed accession lines are skipped; valid ones still archived."""
     accession = "GCF_000001215.4"
     key = DEFAULT_LAKEHOUSE_KEY_PREFIX / "raw_data" / ACC_PATH_215 / f"{accession}_genomic.fna.gz"
-    mock_s3_client_no_checksum.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"data")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(key), Body=b"data")
 
     manifest = tmp_path / "mixed.txt"
     manifest.write_text("NOT_AN_ACCESSION\n\n   \n" + f"{accession}\n")
@@ -981,7 +945,7 @@ def test_archive_assemblies_invalid_accession_skipped(
 
 @pytest.mark.s3
 def test_promote_multi_file_all_land_at_final_path(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """All files for an assembly are promoted concurrently — none missed."""
     file_names = [
@@ -991,7 +955,7 @@ def test_promote_multi_file_all_land_at_final_path(
         f"{_ACC1}_assembly_report.txt",
         f"{_ACC1}_assembly_stats.txt",
     ]
-    _stage(mock_s3_client_no_checksum, _STG1, {PurePosixPath(f): f.encode() for f in file_names})
+    _stage(mock_s3_client, _STG1, {PurePosixPath(f): f.encode() for f in file_names})
 
     report = promote_from_s3(
         staging_key_prefix=_STAGE_PREFIX,
@@ -1003,13 +967,13 @@ def test_promote_multi_file_all_land_at_final_path(
     assert report["promoted"] == len(file_names)
     assert report["failed"] == 0
     for fname in file_names:
-        resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=f"{_LKH1 / fname}")
+        resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=f"{_LKH1 / fname}")
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK
 
 
 @pytest.mark.s3
 def test_promote_multi_file_content_preserved(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """Content at the final key is byte-identical to the staged content."""
     files = {
@@ -1017,7 +981,7 @@ def test_promote_multi_file_content_preserved(
         PurePosixPath(f"{_ACC1}_protein.faa.gz"): b"\x1f\x8bPROTEIN",
         PurePosixPath(f"{_ACC1}_rna.fna.gz"): b"\x1f\x8bRNA",
     }
-    _stage(mock_s3_client_no_checksum, _STG1, files)
+    _stage(mock_s3_client, _STG1, files)
 
     promote_from_s3(
         staging_key_prefix=_STAGE_PREFIX,
@@ -1027,18 +991,18 @@ def test_promote_multi_file_content_preserved(
     )
 
     for fname, expected in files.items():
-        obj = mock_s3_client_no_checksum.get_object(Bucket=str(TEST_BUCKET), Key=f"{_LKH1 / fname}")
+        obj = mock_s3_client.get_object(Bucket=str(TEST_BUCKET), Key=f"{_LKH1 / fname}")
         assert obj["Body"].read() == expected, f"Content mismatch for {fname}"
 
 
 @pytest.mark.s3
 def test_promote_md5_metadata_set_from_sidecar(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """MD5 metadata on the promoted object matches the .md5 sidecar value."""
     content = b"\x1f\x8bGENOMIC"
     fname = PurePosixPath(f"{_ACC1}_genomic.fna.gz")
-    _stage(mock_s3_client_no_checksum, _STG1, {fname: content}, with_md5=True)
+    _stage(mock_s3_client, _STG1, {fname: content}, with_md5=True)
     expected_md5 = hashlib.md5(content).hexdigest()  # noqa: S324
 
     promote_from_s3(
@@ -1048,17 +1012,17 @@ def test_promote_md5_metadata_set_from_sidecar(
         lakehouse_key_prefix=DEFAULT_LAKEHOUSE_KEY_PREFIX,
     )
 
-    resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(_LKH1 / fname))
+    resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(_LKH1 / fname))
     assert resp["Metadata"].get("md5") == expected_md5
 
 
 @pytest.mark.s3
 def test_promote_no_sidecar_no_md5_metadata(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """A file staged without a .md5 sidecar is promoted but carries no md5 metadata."""
     fname = PurePosixPath(f"{_ACC1}_genomic.fna.gz")
-    _stage(mock_s3_client_no_checksum, _STG1, {fname: b"data"}, with_md5=False)
+    _stage(mock_s3_client, _STG1, {fname: b"data"}, with_md5=False)
 
     promote_from_s3(
         staging_key_prefix=_STAGE_PREFIX,
@@ -1067,20 +1031,20 @@ def test_promote_no_sidecar_no_md5_metadata(
         lakehouse_key_prefix=DEFAULT_LAKEHOUSE_KEY_PREFIX,
     )
 
-    resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(_LKH1 / fname))
+    resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(_LKH1 / fname))
     assert resp["Metadata"].get("md5") is None
 
 
 @pytest.mark.s3
 def test_promote_staging_data_files_deleted_after_promote(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """Staged data files are deleted from staging after a fully successful assembly promote."""
     files = {
         PurePosixPath(f"{_ACC1}_genomic.fna.gz"): b"genomic",
         PurePosixPath(f"{_ACC1}_protein.faa.gz"): b"protein",
     }
-    staged_keys = _stage(mock_s3_client_no_checksum, _STG1, files)
+    staged_keys = _stage(mock_s3_client, _STG1, files)
 
     promote_from_s3(
         staging_key_prefix=_STAGE_PREFIX,
@@ -1090,20 +1054,20 @@ def test_promote_staging_data_files_deleted_after_promote(
     )
 
     for key in staged_keys:
-        result = mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(key))
+        result = mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(key))
         assert result.get("KeyCount", 0) == 0, f"Staged data file not deleted: {key}"
 
 
 @pytest.mark.s3
 def test_promote_md5_sidecars_deleted_after_promote(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """Staged .md5 sidecar files are deleted from staging after a successful promote."""
     files = {
         PurePosixPath(f"{_ACC1}_genomic.fna.gz"): b"genomic",
         PurePosixPath(f"{_ACC1}_protein.faa.gz"): b"protein",
     }
-    staged_keys = _stage(mock_s3_client_no_checksum, _STG1, files, with_md5=True)
+    staged_keys = _stage(mock_s3_client, _STG1, files, with_md5=True)
 
     promote_from_s3(
         staging_key_prefix=_STAGE_PREFIX,
@@ -1114,17 +1078,17 @@ def test_promote_md5_sidecars_deleted_after_promote(
 
     for key in staged_keys:
         for sidecar_key in (f"{key}.md5", f"{key}.crc64nvme"):
-            result = mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(sidecar_key))
+            result = mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(sidecar_key))
             assert result.get("KeyCount", 0) == 0, f"Sidecar not deleted: {sidecar_key}"
 
 
 @pytest.mark.s3
 def test_promote_crc64nvme_sidecars_deleted_after_promote(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """Staged .crc64nvme sidecar files are also batch-deleted after a successful promote."""
     fname = PurePosixPath(f"{_ACC1}_genomic.fna.gz")
-    _stage(mock_s3_client_no_checksum, _STG1, {fname: b"data"}, with_md5=True, with_crc64=True)
+    _stage(mock_s3_client, _STG1, {fname: b"data"}, with_md5=True, with_crc64=True)
 
     promote_from_s3(
         staging_key_prefix=_STAGE_PREFIX,
@@ -1135,13 +1099,13 @@ def test_promote_crc64nvme_sidecars_deleted_after_promote(
 
     staged_key = f"{_STG1}{fname}"
     for sidecar_key in (f"{staged_key}.md5", f"{staged_key}.crc64nvme"):
-        result = mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(sidecar_key))
+        result = mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(sidecar_key))
         assert result.get("KeyCount", 0) == 0, f"Sidecar not deleted: {sidecar_key}"
 
 
 @pytest.mark.s3
 def test_promote_partial_failure_staging_not_cleaned(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """When one file in an assembly fails, NO staged files for that assembly are deleted.
 
@@ -1150,12 +1114,12 @@ def test_promote_partial_failure_staging_not_cleaned(
     """
     file_ok = PurePosixPath(f"{_ACC1}_genomic.fna.gz")
     file_fail = PurePosixPath(f"{_ACC1}_protein.faa.gz")
-    _stage(mock_s3_client_no_checksum, _STG1, {file_ok: b"ok", file_fail: b"fail"})
+    _stage(mock_s3_client, _STG1, {file_ok: b"ok", file_fail: b"fail"})
     staged_ok = _STG1 / file_ok
     staged_fail = _STG1 / file_fail
 
     # Make download_file raise for exactly the failing key
-    dynamic_client = cast("DownloadFileClient", mock_s3_client_no_checksum)
+    dynamic_client = cast("DownloadFileClient", mock_s3_client)
     original_download = dynamic_client.download_file
 
     def _download_one_fail(Bucket: str, Key: str, Filename: str, **kw: object) -> None:  # noqa: N803
@@ -1176,7 +1140,7 @@ def test_promote_partial_failure_staging_not_cleaned(
     assert report["failed"] == 1
     # Staging files must still be present (cleanup skipped due to failure)
     for key in (staged_ok, staged_fail):
-        resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(key))
+        resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(key))
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK, (
             f"Expected staged file to survive partial failure: {key}"
         )
@@ -1184,7 +1148,7 @@ def test_promote_partial_failure_staging_not_cleaned(
 
 @pytest.mark.s3
 def test_promote_partial_failure_failed_count(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     r"""report[\"failed\"] reflects the number of files that could not be promoted."""
     file_names = [
@@ -1192,10 +1156,10 @@ def test_promote_partial_failure_failed_count(
         PurePosixPath(f"{_ACC1}_protein.faa.gz"),
         PurePosixPath(f"{_ACC1}_rna.fna.gz"),
     ]
-    _stage(mock_s3_client_no_checksum, _STG1, dict.fromkeys(file_names, b"data"))
+    _stage(mock_s3_client, _STG1, dict.fromkeys(file_names, b"data"))
 
     failing_key = f"{_STG1 / file_names[1]}"
-    dynamic_client = cast("DownloadFileClient", mock_s3_client_no_checksum)
+    dynamic_client = cast("DownloadFileClient", mock_s3_client)
     original_download = dynamic_client.download_file
 
     def _download_middle_fail(Bucket: str, Key: str, Filename: str, **kw: object) -> None:  # noqa: N803
@@ -1219,7 +1183,7 @@ def test_promote_partial_failure_failed_count(
 
 @pytest.mark.s3
 def test_promote_two_assemblies_independent_cleanup(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """A fully successful assembly cleans up its staging even when another assembly partially fails.
 
@@ -1228,18 +1192,18 @@ def test_promote_two_assemblies_independent_cleanup(
     """
     # Assembly 1: two files, both succeed
     _stage(
-        mock_s3_client_no_checksum,
+        mock_s3_client,
         _STG1,
         {PurePosixPath(f"{_ACC1}_genomic.fna.gz"): b"g1", PurePosixPath(f"{_ACC1}_protein.faa.gz"): b"p1"},
     )
     # Assembly 2: two files, one will fail
     _stage(
-        mock_s3_client_no_checksum,
+        mock_s3_client,
         _STG2,
         {PurePosixPath(f"{_ACC2}_genomic.fna.gz"): b"g2", PurePosixPath(f"{_ACC2}_protein.faa.gz"): b"p2"},
     )
     failing_key = f"{_STG2 / _ACC2}_protein.faa.gz"
-    dynamic_client = cast("DownloadFileClient", mock_s3_client_no_checksum)
+    dynamic_client = cast("DownloadFileClient", mock_s3_client)
     original_download = dynamic_client.download_file
 
     def _patched(Bucket: str, Key: str, Filename: str, **kw: object) -> None:  # noqa: N803
@@ -1261,12 +1225,12 @@ def test_promote_two_assemblies_independent_cleanup(
 
     # Assembly 1 staging must be gone
     for fname in (f"{_ACC1}_genomic.fna.gz", f"{_ACC1}_protein.faa.gz"):
-        result = mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(_STG1 / fname))
+        result = mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(_STG1 / fname))
         assert result.get("KeyCount", 0) == 0, f"Assembly 1 staging should be cleaned: {fname}"
 
     # Assembly 2 staging must remain (partial failure)
     for fname in (f"{_ACC2}_genomic.fna.gz", f"{_ACC2}_protein.faa.gz"):
-        resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(_STG2 / fname))
+        resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(_STG2 / fname))
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK, (
             f"Assembly 2 staging must survive partial failure: {fname}"
         )
@@ -1274,11 +1238,11 @@ def test_promote_two_assemblies_independent_cleanup(
 
 @pytest.mark.s3
 def test_promote_multi_assembly_all_succeed_all_cleaned(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """Two assemblies both fully succeed → all staged files removed for both."""
-    _stage(mock_s3_client_no_checksum, _STG1, {PurePosixPath(f"{_ACC1}_genomic.fna.gz"): b"g1"})
-    _stage(mock_s3_client_no_checksum, _STG2, {PurePosixPath(f"{_ACC2}_genomic.fna.gz"): b"g2"})
+    _stage(mock_s3_client, _STG1, {PurePosixPath(f"{_ACC1}_genomic.fna.gz"): b"g1"})
+    _stage(mock_s3_client, _STG2, {PurePosixPath(f"{_ACC2}_genomic.fna.gz"): b"g2"})
 
     report = promote_from_s3(
         staging_key_prefix=_STAGE_PREFIX,
@@ -1294,19 +1258,19 @@ def test_promote_multi_assembly_all_succeed_all_cleaned(
         (_STG1, f"{_ACC1}_genomic.fna.gz", _LKH1),
         (_STG2, f"{_ACC2}_genomic.fna.gz", _LKH2),
     ):
-        result = mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(stg / fname))
+        result = mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(stg / fname))
         assert result.get("KeyCount", 0) == 0, f"Staging not cleaned: {fname}"
-        resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(lkh / fname))
+        resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(lkh / fname))
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK
 
 
 @pytest.mark.s3
 def test_promote_dry_run_multi_file_no_writes_no_cleanup(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """dry_run with multiple files writes nothing to final path and does not delete staging."""
     file_names = [f"{_ACC1}_genomic.fna.gz", f"{_ACC1}_protein.faa.gz", f"{_ACC1}_rna.fna.gz"]
-    staged_keys = _stage(mock_s3_client_no_checksum, _STG1, {PurePosixPath(f): f.encode() for f in file_names})
+    staged_keys = _stage(mock_s3_client, _STG1, {PurePosixPath(f): f.encode() for f in file_names})
 
     report = promote_from_s3(
         staging_key_prefix=_STAGE_PREFIX,
@@ -1320,28 +1284,24 @@ def test_promote_dry_run_multi_file_no_writes_no_cleanup(
     assert report["dry_run"] is True
 
     # Final path must be empty
-    result = mock_s3_client_no_checksum.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(_LKH1))
+    result = mock_s3_client.list_objects_v2(Bucket=str(TEST_BUCKET), Prefix=str(_LKH1))
     assert result.get("KeyCount", 0) == 0
 
     # Staging keys must survive
     for key in staged_keys:
-        resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(key))
+        resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(key))
         assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK, f"Staging deleted during dry-run: {key}"
 
 
 @pytest.mark.s3
 def test_promote_skips_non_raw_data_paths(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """Files outside raw_data/ (e.g. download_report.json) are silently skipped."""
     # Stage a real data file alongside non-promotable files
-    _stage(mock_s3_client_no_checksum, _STG1, {PurePosixPath(f"{_ACC1}_genomic.fna.gz"): b"data"})
-    mock_s3_client_no_checksum.put_object(
-        Bucket=str(TEST_BUCKET), Key=str(_STAGE_PREFIX / "download_report.json"), Body=b"{}"
-    )
-    mock_s3_client_no_checksum.put_object(
-        Bucket=str(TEST_BUCKET), Key=str(_STAGE_PREFIX / "logs/run.log"), Body=b"logs"
-    )
+    _stage(mock_s3_client, _STG1, {PurePosixPath(f"{_ACC1}_genomic.fna.gz"): b"data"})
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(_STAGE_PREFIX / "download_report.json"), Body=b"{}")
+    mock_s3_client.put_object(Bucket=str(TEST_BUCKET), Key=str(_STAGE_PREFIX / "logs/run.log"), Body=b"logs")
 
     report = promote_from_s3(
         staging_key_prefix=_STAGE_PREFIX,
@@ -1356,10 +1316,10 @@ def test_promote_skips_non_raw_data_paths(
 
 @pytest.mark.s3
 def test_promote_idempotent_second_run_on_empty_staging(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """Second promote run after staging has been cleaned promotes 0 files without error."""
-    _stage(mock_s3_client_no_checksum, _STG1, {PurePosixPath(f"{_ACC1}_genomic.fna.gz"): b"data"})
+    _stage(mock_s3_client, _STG1, {PurePosixPath(f"{_ACC1}_genomic.fna.gz"): b"data"})
 
     report1 = promote_from_s3(
         staging_key_prefix=_STAGE_PREFIX,
@@ -1379,13 +1339,13 @@ def test_promote_idempotent_second_run_on_empty_staging(
     assert report2["failed"] == 0
 
     # Final key still present after second run
-    resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=f"{_LKH1 / _ACC1}_genomic.fna.gz")
+    resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=f"{_LKH1 / _ACC1}_genomic.fna.gz")
     assert resp["ResponseMetadata"]["HTTPStatusCode"] == HTTPStatus.OK
 
 
 @pytest.mark.s3
 def test_promote_multi_file_md5_per_file(
-    mock_s3_client_no_checksum: botocore.client.BaseClient,
+    mock_s3_client: botocore.client.BaseClient,
 ) -> None:
     """Each promoted file carries the MD5 matching its own content, not another file's."""
     files = {
@@ -1393,7 +1353,7 @@ def test_promote_multi_file_md5_per_file(
         PurePosixPath(f"{_ACC1}_protein.faa.gz"): b"PROTEIN_UNIQUE",
         PurePosixPath(f"{_ACC1}_rna.fna.gz"): b"RNA_UNIQUE",
     }
-    _stage(mock_s3_client_no_checksum, _STG1, files, with_md5=True)
+    _stage(mock_s3_client, _STG1, files, with_md5=True)
 
     promote_from_s3(
         staging_key_prefix=_STAGE_PREFIX,
@@ -1404,5 +1364,5 @@ def test_promote_multi_file_md5_per_file(
 
     for fname, content in files.items():
         expected_md5 = hashlib.md5(content).hexdigest()  # noqa: S324
-        resp = mock_s3_client_no_checksum.head_object(Bucket=str(TEST_BUCKET), Key=str(_LKH1 / fname))
+        resp = mock_s3_client.head_object(Bucket=str(TEST_BUCKET), Key=str(_LKH1 / fname))
         assert resp["Metadata"].get("md5") == expected_md5, f"Wrong MD5 on {fname}"

--- a/tests/utils/file_transfer/s3/conftest.py
+++ b/tests/utils/file_transfer/s3/conftest.py
@@ -1,18 +1,14 @@
 """Tests for s3 utils.py using moto to mock AWS S3."""
 
-from collections.abc import Generator
 from pathlib import Path
-from typing import Any, Final
-from unittest.mock import patch
+from typing import Final
 
-import boto3
 import pytest
-from moto import mock_aws
 from types_boto3_s3.client import S3Client
 
 import cdm_data_loaders.utils.file_transfer.s3.client as s3_client
 from cdm_data_loaders.utils.file_transfer.s3.client import reset_s3_client
-from tests.s3_helpers import strip_checksum_algorithm
+from tests.conftest import ALT_BUCKET, TEST_BUCKET
 
 HTTP_200: Final[int] = 200  # Status OK
 HTTP_204: Final[int] = 204  # Status no content
@@ -27,14 +23,10 @@ SAMPLE_FILES = [
     "dir_one/sub_dir/under_dir/file4.txt",
 ]
 
-TEST_BUCKET: Final[str] = "test_bucket"
-ALT_BUCKET: Final[str] = "alt_bucket"
-
 FILES_IN_BUCKETS = {
     TEST_BUCKET: SAMPLE_FILES,
     ALT_BUCKET: ["dir_one/file1.txt"],
 }
-BUCKETS = [TEST_BUCKET, ALT_BUCKET]
 
 
 # CLI helper function tests
@@ -66,51 +58,6 @@ TEST_MB_ARGS_ERROR = [
     pytest.param(["/bucket"], START_WITH_BUCKET_NAME, id="preceding slash"),
     pytest.param(["/"], START_WITH_BUCKET_NAME, id="root"),
 ]
-
-
-@pytest.fixture
-def mock_s3_client(monkeypatch: pytest.MonkeyPatch) -> Generator[S3Client, Any]:
-    """Yield a mocked S3 client with both valid buckets created.
-
-    The function get_s3_client() is patched to ensure that all module functions use this client.
-
-    Resets the cached client before and after to prevent state leaking between tests.
-    """
-    # Remove any real endpoint/credential env vars so moto intercepts all HTTP calls.
-    monkeypatch.setenv("AWS_ACCESS_KEY_ID", "testing")
-    monkeypatch.setenv("AWS_SECRET_ACCESS_KEY", "testing")
-    monkeypatch.setenv("AWS_DEFAULT_REGION", "us-east-1")
-    monkeypatch.delenv("AWS_ENDPOINT_URL", raising=False)
-    monkeypatch.delenv("AWS_ENDPOINT_URL_S3", raising=False)
-    boto3.DEFAULT_SESSION = None
-
-    with mock_aws():
-        reset_s3_client()
-        client: S3Client = boto3.client("s3")
-        for bucket in FILES_IN_BUCKETS:
-            client.create_bucket(Bucket=bucket)
-
-        # delete any existing client
-        reset_s3_client()
-        assert s3_client._s3_client is None  # noqa: SLF001
-
-        # patch in the client that we have just created
-        with patch.object(s3_client, "get_s3_client", return_value=client):
-            yield client
-
-        reset_s3_client()
-        assert s3_client._s3_client is None  # noqa: SLF001
-
-
-@pytest.fixture
-def mocked_s3_client_no_checksum(mock_s3_client: S3Client) -> S3Client:
-    """Yield the mocked S3 client with copy_object patched to strip ChecksumAlgorithm.
-
-    This works around the moto limitation of not supporting CRC64NVME checksums,
-    allowing copy_object calls that include ChecksumAlgorithm to succeed.
-    """
-    mock_s3_client.copy_object = strip_checksum_algorithm(mock_s3_client.copy_object)
-    return mock_s3_client
 
 
 @pytest.fixture

--- a/tests/utils/file_transfer/s3/test_object_utils.py
+++ b/tests/utils/file_transfer/s3/test_object_utils.py
@@ -28,9 +28,9 @@ from cdm_data_loaders.utils.file_transfer.s3.object_utils import (
     upload_file,
     upload_fileobj,
 )
+from tests.conftest import BUCKETS
 from tests.utils.file_transfer.s3.conftest import (
     ALT_BUCKET,
-    BUCKETS,
     FILES_IN_BUCKETS,
     HTTP_200,
     HTTP_204,
@@ -1042,9 +1042,9 @@ def test_download_file_pass_show_progress_false_disables_progress_bar(mock_s3_cl
 # copy_object
 @pytest.mark.s3
 @pytest.mark.parametrize("destination", BUCKETS)
-def test_copy_object(mocked_s3_client_no_checksum: S3Client, destination: str) -> None:
+def test_copy_object(mock_s3_client: S3Client, destination: str) -> None:
     """Verify that copy_object copies an object to a new key within the same bucket."""
-    mocked_s3_client_no_checksum.put_object(Bucket=TEST_BUCKET, Key="src/file.txt", Body=b"copy me")
+    mock_s3_client.put_object(Bucket=TEST_BUCKET, Key="src/file.txt", Body=b"copy me")
     assert object_exists(f"{TEST_BUCKET}/src/file.txt")
     response = copy_object(f"{TEST_BUCKET}/src/file.txt", f"{destination}/dst/path/to/file.txt")
 
@@ -1052,7 +1052,7 @@ def test_copy_object(mocked_s3_client_no_checksum: S3Client, destination: str) -
     assert object_exists(f"{TEST_BUCKET}/src/file.txt")
     assert object_exists(f"{destination}/dst/path/to/file.txt")
 
-    obj = mocked_s3_client_no_checksum.get_object(Bucket=destination, Key="dst/path/to/file.txt")
+    obj = mock_s3_client.get_object(Bucket=destination, Key="dst/path/to/file.txt")
     assert obj["Body"].read() == b"copy me"
     assert response["ResponseMetadata"]["HTTPStatusCode"] == HTTP_200
 
@@ -1107,13 +1107,12 @@ def list_keys(mock_s3_client: S3Client, bucket: str, prefix: str = "") -> set[st
 @pytest.mark.parametrize("source_suffix", ["", "/"])
 @pytest.mark.parametrize("dest_suffix", ["", "/"])
 def test_copy_directory_copies_all_objects_to_dest(
-    mocked_s3_client_no_checksum: S3Client, source_suffix: str, dest_suffix: str
+    mock_s3_client: S3Client, source_suffix: str, dest_suffix: str
 ) -> None:
     """Verify that all objects under the source prefix are present in the successes dict.
 
     Ensure that copy works correctly with or without a slash at the end of the directory name.
     """
-    mock_s3_client = mocked_s3_client_no_checksum
     populate_mock_s3(mock_s3_client, {TEST_BUCKET: FILES_IN_BUCKETS[TEST_BUCKET]})
     source_bucket_files = list_keys(mock_s3_client, TEST_BUCKET)
     assert set(source_bucket_files) == set(SAMPLE_FILES)
@@ -1284,11 +1283,9 @@ def test_upload_file_with_metadata_accepts_str_and_path(sample_file: Path, path_
 # copy_object
 @pytest.mark.s3
 @pytest.mark.parametrize("destination", BUCKETS)
-def test_copy_object_preserves_user_metadata(mocked_s3_client_no_checksum: S3Client, destination: str) -> None:
+def test_copy_object_preserves_user_metadata(mock_s3_client: S3Client, destination: str) -> None:
     """copy_object preserves source user metadata (MetadataDirective=COPY default)."""
-    mocked_s3_client_no_checksum.put_object(
-        Bucket=TEST_BUCKET, Key="src/file.txt", Body=b"archive me", Metadata={"md5": "abc123"}
-    )
+    mock_s3_client.put_object(Bucket=TEST_BUCKET, Key="src/file.txt", Body=b"archive me", Metadata={"md5": "abc123"})
     response = copy_object(
         f"{TEST_BUCKET}/src/file.txt",
         f"{destination}/archive/file.txt",
@@ -1296,7 +1293,7 @@ def test_copy_object_preserves_user_metadata(mocked_s3_client_no_checksum: S3Cli
     assert response["ResponseMetadata"]["HTTPStatusCode"] == HTTP_200
 
     # source user metadata is preserved (MetadataDirective=COPY)
-    resp = mocked_s3_client_no_checksum.head_object(Bucket=destination, Key="archive/file.txt")
+    resp = mock_s3_client.head_object(Bucket=destination, Key="archive/file.txt")
     assert resp["Metadata"].get("md5") == "abc123"
 
     # verify source still exists
@@ -1304,14 +1301,14 @@ def test_copy_object_preserves_user_metadata(mocked_s3_client_no_checksum: S3Cli
 
 
 @pytest.mark.s3
-def test_copy_object_preserves_content(mocked_s3_client_no_checksum: S3Client) -> None:
+def test_copy_object_preserves_content(mock_s3_client: S3Client) -> None:
     """Verify that the content of the copied object matches the original."""
-    mocked_s3_client_no_checksum.put_object(Bucket=TEST_BUCKET, Key="src/data.bin", Body=b"binary data")
+    mock_s3_client.put_object(Bucket=TEST_BUCKET, Key="src/data.bin", Body=b"binary data")
     copy_object(
         f"{TEST_BUCKET}/src/data.bin",
         f"{TEST_BUCKET}/dst/data.bin",
     )
-    obj = mocked_s3_client_no_checksum.get_object(Bucket=TEST_BUCKET, Key="dst/data.bin")
+    obj = mock_s3_client.get_object(Bucket=TEST_BUCKET, Key="dst/data.bin")
     assert obj["Body"].read() == b"binary data"
 
 

--- a/tests/utils/file_transfer/s3/test_object_utils.py
+++ b/tests/utils/file_transfer/s3/test_object_utils.py
@@ -21,7 +21,7 @@ from cdm_data_loaders.utils.file_transfer.s3.object_utils import (
     download_file,
     get_existing_object_info,
     head_object,
-    list_matching_objects,
+    list_objects,
     object_exists,
     split_s3_path,
     upload_dir,
@@ -296,32 +296,32 @@ def test_object_exists_returns_false_when_absent(
     assert object_exists(f"{protocol}{bucket}/{s3_path}") is False
 
 
-# list_matching_objects
+# list_objects
 @pytest.mark.s3
 @pytest.mark.parametrize("bucket", BUCKETS)
 @pytest.mark.parametrize("protocol", ["", "s3://", "s3a://"])
-def test_list_matching_objects_lists_objects(
+def test_list_objects_lists_objects(
     mock_s3_client: S3Client,
     bucket: str,
     protocol: str,
 ) -> None:
     """Verify that all objects under a given prefix are returned, regardless of whether the protocol is supplied."""
     populate_mock_s3(mock_s3_client, FILES_IN_BUCKETS)
-    contents = list_matching_objects(f"{protocol}{bucket}/dir_one")
+    contents = list_objects(f"{protocol}{bucket}/dir_one")
     keys = {obj["Key"] for obj in contents}
     assert keys == {f for f in FILES_IN_BUCKETS[bucket] if f.startswith("dir_one")}
 
 
 @pytest.mark.s3
 @pytest.mark.parametrize("dir_path", ["dir_one/sub_dir", "dir_one/sub_dir/", "dir_one/sub_dir/und"])
-def test_list_matching_objects_filters_by_prefix(
+def test_list_objects_filters_by_prefix(
     mock_s3_client: S3Client,
     dir_path: str,
 ) -> None:
     """Check that more specific queries, including those that have 'incomplete' dir/file names, return correct results."""
     bucket = TEST_BUCKET
     populate_mock_s3(mock_s3_client, {bucket: FILES_IN_BUCKETS[bucket]})
-    contents = list_matching_objects(f"{bucket}/{dir_path}")
+    contents = list_objects(f"{bucket}/{dir_path}")
     keys = {obj["Key"] for obj in contents}
     # make sure this is a subset of all the files in the bucket
     assert len(keys) < len(FILES_IN_BUCKETS[bucket])
@@ -330,14 +330,14 @@ def test_list_matching_objects_filters_by_prefix(
 
 @pytest.mark.s3
 @pytest.mark.parametrize("protocol", ["", "s3://", "s3a://"])
-def test_list_matching_objects_empty_for_missing_prefix(
+def test_list_objects_empty_for_missing_prefix(
     mock_s3_client: S3Client,
     protocol: str,
 ) -> None:
     """Verify that an empty list is returned when no objects match the given prefix."""
     populate_mock_s3(mock_s3_client, FILES_IN_BUCKETS)
     for bucket in FILES_IN_BUCKETS:
-        contents = list_matching_objects(f"{protocol}{bucket}/nonexistent/")
+        contents = list_objects(f"{protocol}{bucket}/nonexistent/")
         assert contents == []
 
 
@@ -363,7 +363,7 @@ EXPECTED_FILE_LIST = {
 # NOTE: These tests currently compose multiple fixtures explicitly for readability.
 @pytest.mark.s3
 @pytest.mark.parametrize("dir_path", EXPECTED_FILE_LIST.keys())
-def test_list_matching_objects_returns_more_than_1000_entries(
+def test_list_objects_returns_more_than_1000_entries(
     mock_s3_client: S3Client,
     dir_path: str,
 ) -> None:
@@ -372,16 +372,16 @@ def test_list_matching_objects_returns_more_than_1000_entries(
     # this adds two extra dirs to TEST_BUCKET with 1005 files in each
     populate_mock_s3(mock_s3_client, LOTS_OF_FILES)
 
-    contents = list_matching_objects(f"{TEST_BUCKET}/{dir_path}")
+    contents = list_objects(f"{TEST_BUCKET}/{dir_path}")
     keys = {obj["Key"] for obj in contents}
     assert keys == set(EXPECTED_FILE_LIST[dir_path])
 
 
 @pytest.mark.s3
-def test_list_matching_objects_pass_respects_custom_max_keys(mock_s3_client: S3Client) -> None:
+def test_list_objects_pass_respects_custom_max_keys(mock_s3_client: S3Client) -> None:
     """A small custom max_keys value still results in complete results via pagination."""
     populate_mock_s3(mock_s3_client, {TEST_BUCKET: FILES_IN_BUCKETS[TEST_BUCKET]})
-    contents = list_matching_objects(f"{TEST_BUCKET}/dir_one", max_keys=1)
+    contents = list_objects(f"{TEST_BUCKET}/dir_one", max_keys=1)
     keys = {obj["Key"] for obj in contents}
     assert keys == {f for f in FILES_IN_BUCKETS[TEST_BUCKET] if f.startswith("dir_one")}
 

--- a/tests/utils/file_transfer/test_clients.py
+++ b/tests/utils/file_transfer/test_clients.py
@@ -167,7 +167,7 @@ async def test_extra_headers(
     assert last_log_msg.message.startswith(f"{DOWNLOAD_URL}: resource has not been modified")
 
 
-@pytest.mark.parametrize("checksum_fn", [None, *hashlib.algorithms_available])
+@pytest.mark.parametrize("checksum_fn", [None, *hashlib.algorithms_available, "crc64nvme"])
 @pytest.mark.parametrize("content", [b"Hello, world!", b"a" * 256])
 @pytest.mark.asyncio
 async def test_checksum_success(
@@ -179,8 +179,8 @@ async def test_checksum_success(
 ) -> None:
     """Test that a correct checksum does not throw an error."""
     checksum_fn_used = checksum_fn or "sha256"
-    if checksum_fn_used.startswith("shake"):
-        pytest.skip("shake algorithms not supported")
+    if checksum_fn_used.startswith("shake") or checksum_fn_used == "crc64nvme":
+        pytest.skip("shake and crc64nvme algorithms not supported")
 
     def handler(_: httpx.Request) -> httpx.Response:
         return httpx.Response(200, content=content)
@@ -200,20 +200,20 @@ async def test_checksum_success(
     assert f"{DOWNLOAD_URL}: {checksum_fn_used} checksum matches" in [m.message for m in caplog.records]
 
 
-@pytest.mark.parametrize("checksum_fn", ["shake128", " shake256", "shake-n-vac"])
+@pytest.mark.parametrize("checksum_fn", ["shake128", " shake256", "shake-n-vac", "CRC64NVME", "crc64nvme"])
 def test_checksum_invalid_sync_downloader(checksum_fn: str, tmp_path: Path) -> None:
     """Ensure that invalid checksums throw an error."""
     downloader = FileDownloader()
-    with pytest.raises(ValueError, match=f"Hashing algorithm {checksum_fn} not supported"):
+    with pytest.raises(ValueError, match=f"Hashing algorithm {checksum_fn.lower()} not supported"):
         downloader.download(DOWNLOAD_URL, tmp_path, checksum_fn=checksum_fn)
 
 
-@pytest.mark.parametrize("checksum_fn", ["shake128", " shake256", "shake-n-vac"])
+@pytest.mark.parametrize("checksum_fn", ["shake128", " shake256", "shake-n-vac", "CRC64NVME", "crc64nvme"])
 @pytest.mark.asyncio
 async def test_checksum_invalid_async_downloader(checksum_fn: str, tmp_path: Path) -> None:
     """Ensure that invalid checksums throw an error."""
     downloader = AsyncFileDownloader()
-    with pytest.raises(ValueError, match=f"Hashing algorithm {checksum_fn} not supported"):
+    with pytest.raises(ValueError, match=f"Hashing algorithm {checksum_fn.lower()} not supported"):
         await downloader.download(DOWNLOAD_URL, tmp_path, checksum_fn=checksum_fn)
 
 
@@ -227,7 +227,7 @@ async def test_checksum_mismatch(tmp_path: Path, sample_content: bytes, download
     downloader = downloader_adapter.make_downloader(handler)
     destination = tmp_path / "file.txt"
 
-    with pytest.raises(ChecksumMismatchError):
+    with pytest.raises(ChecksumMismatchError, match="Checksum mismatch: expected=some_checksum_or_other, actual="):
         await downloader_adapter.download(
             downloader,
             DOWNLOAD_URL,


### PR DESCRIPTION
- function renaming
- use the same mock s3 client for tests where AWS is mocked
- centralise values in a DEFAULT config
